### PR TITLE
implemented Resend SC request

### DIFF
--- a/src/main/java/org/folio/edge/sip2/MainVerticle.java
+++ b/src/main/java/org/folio/edge/sip2/MainVerticle.java
@@ -73,7 +73,8 @@ public class MainVerticle extends AbstractVerticle {
           //process validation results
           if (!message.isValid()) {
             log.error("Message is invalid: {}", messageString);
-            if (message.getChecksumsString() != null) {  //The presence of the checksum string or sequence number indicates that error detection was enabled.
+            //The presence of the checksum string indicates that error detection was enabled.
+            if (message.getChecksumsString() != null) {
               //resends validation if checksum string does not match
               ISip2RequestHandler handler = handlers.get(Command.REQUEST_SC_RESEND);
               socket.write(handler.execute(message.getRequest()));

--- a/src/main/java/org/folio/edge/sip2/MainVerticle.java
+++ b/src/main/java/org/folio/edge/sip2/MainVerticle.java
@@ -8,6 +8,7 @@ import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetServerOptions;
+import io.vertx.core.parsetools.RecordParser;
 
 import java.lang.invoke.MethodHandles;
 import java.util.EnumMap;
@@ -20,7 +21,6 @@ import org.folio.edge.sip2.handlers.ISip2RequestHandler;
 import org.folio.edge.sip2.parser.Command;
 import org.folio.edge.sip2.parser.Message;
 import org.folio.edge.sip2.parser.Parser;
-
 
 public class MainVerticle extends AbstractVerticle {
 
@@ -36,7 +36,7 @@ public class MainVerticle extends AbstractVerticle {
     handlers.put(LOGIN, HandlersFactory.getLoginHandlerIntance());
     handlers.put(CHECKOUT, HandlersFactory.getCheckoutHandlerIntance());
     handlers.put(SC_STATUS, HandlersFactory.getScStatusHandlerInstance(null, null, null));
-
+    handlers.put(Command.REQUEST_SC_RESEND, HandlersFactory.getInvalidMessageHandler());
     log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   }
 
@@ -55,10 +55,9 @@ public class MainVerticle extends AbstractVerticle {
     log.info("Deployed verticle at port " + port);
 
     server.connectHandler(socket -> {
-
-      socket.handler(buffer -> {
+      socket.handler(RecordParser.newDelimited("\r", buffer -> {
         final String messageString = buffer.getString(0, buffer.length());
-        log.info("Received message: {}",  messageString);
+        log.info("Received message: {}", messageString);
 
         try {
           // Create a parser with the default delimiter '|' and the default
@@ -74,7 +73,14 @@ public class MainVerticle extends AbstractVerticle {
           //process validation results
           if (!message.isValid()) {
             log.error("Message is invalid: {}", messageString);
-            //resends validation
+            if (message.getChecksumsString() != null) {  //The presence of the checksum string or sequence number indicates that error detection was enabled.
+              //resends validation if checksum string does not match
+              ISip2RequestHandler handler = handlers.get(Command.REQUEST_SC_RESEND);
+              socket.write(handler.execute(message.getRequest()));
+            } else {
+              socket.write("Problems handling the request");
+            }
+            return;
           }
 
           ISip2RequestHandler handler = handlers.get(message.getCommand());
@@ -90,7 +96,7 @@ public class MainVerticle extends AbstractVerticle {
           // Will find a better way to handle negative test cases.
           socket.write(message);
         }
-      });
+      }));
 
       socket.exceptionHandler(handler -> {
         log.info("Socket exceptionHandler caught an issue, see error logs for more details");

--- a/src/main/java/org/folio/edge/sip2/handlers/HandlersFactory.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/HandlersFactory.java
@@ -49,4 +49,8 @@ public class HandlersFactory {
   public static ISip2RequestHandler getCheckoutHandlerIntance() {
     return new CheckoutHandler();
   }
+
+  public static ISip2RequestHandler getInvalidMessageHandler(){
+    return new InvalidMessageHandler();
+  }
 }

--- a/src/main/java/org/folio/edge/sip2/handlers/HandlersFactory.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/HandlersFactory.java
@@ -50,7 +50,7 @@ public class HandlersFactory {
     return new CheckoutHandler();
   }
 
-  public static ISip2RequestHandler getInvalidMessageHandler(){
+  public static ISip2RequestHandler getInvalidMessageHandler() {
     return new InvalidMessageHandler();
   }
 }

--- a/src/main/java/org/folio/edge/sip2/handlers/InvalidMessageHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/InvalidMessageHandler.java
@@ -1,0 +1,8 @@
+package org.folio.edge.sip2.handlers;
+
+public class InvalidMessageHandler implements ISip2RequestHandler {
+  @Override
+  public String execute(Object message) {
+    return "96\r";
+  }
+}

--- a/src/main/java/org/folio/edge/sip2/parser/Parser.java
+++ b/src/main/java/org/folio/edge/sip2/parser/Parser.java
@@ -163,7 +163,11 @@ public final class Parser {
 
       return builder.build();
     } else {
-      return Message.builder().valid(false).build();
+      return Message.builder()
+        .valid(false)
+        .checksumString(ed.checksum)
+        .sequenceNumber(ed.sequenceNumber)
+        .build();
     }
   }
 

--- a/src/main/resources/templates/acs-status.ftl
+++ b/src/main/resources/templates/acs-status.ftl
@@ -1,36 +1,1 @@
-98<#rt>
-${ACSStatus.onLineStatus}<#rt>
-${ACSStatus.checkinOk}<#rt>
-${ACSStatus.checkoutOk}<#rt>
-${ACSStatus.acsRenewalPolicy}<#rt>
-${ACSStatus.statusUpdateOk}<#rt>
-${ACSStatus.offLineOk}<#rt>
-${ACSStatus.timeoutPeriod}<#rt>
-${ACSStatus.retriesAllowed}<#rt>
-${formatDateTime(ACSStatus.dateTimeSync, "yyyyMMdd    HHmmss")}<#t>
-${ACSStatus.protocolVersion}|<#rt>
-AO${ACSStatus.institutionId}|<#rt>
-AM${ACSStatus.libraryName}|<#rt>
-BX<@supportedMessages />|<#rt>
-AN${ACSStatus.terminalLocation}|<#rt>
-AF${ACSStatus.screenMessage}|<#rt>
-AG${ACSStatus.printLine}|<#rt>
-
-<#macro supportedMessages>
- ${PackagedSupportedMessages.patronStatusRequest}<#t>
- ${PackagedSupportedMessages.checkOut}<#t>
- ${PackagedSupportedMessages.checkIn}<#t>
- ${PackagedSupportedMessages.blockPatron}<#t>
- ${PackagedSupportedMessages.scAcsStatus}<#t>
- ${PackagedSupportedMessages.requestScAcsResend}<#t>
- ${PackagedSupportedMessages.login}<#t>
- ${PackagedSupportedMessages.patronInformation}<#t>
- ${PackagedSupportedMessages.endPatronSession}<#t>
- ${PackagedSupportedMessages.feePaid}<#t>
- ${PackagedSupportedMessages.itemInformation}<#t>
- ${PackagedSupportedMessages.itemStatusUpdate}<#t>
- ${PackagedSupportedMessages.patronEnable}<#t>
- ${PackagedSupportedMessages.hold}<#t>
- ${PackagedSupportedMessages.renew}<#t>
- ${PackagedSupportedMessages.renewAll}<#t>
-</#macro>
+98<#rt>${ACSStatus.onLineStatus}<#rt>${ACSStatus.checkinOk}<#rt>${ACSStatus.checkoutOk}<#rt>${ACSStatus.acsRenewalPolicy}<#rt>${ACSStatus.statusUpdateOk}<#rt>${ACSStatus.offLineOk}<#rt>${ACSStatus.timeoutPeriod}<#rt>${ACSStatus.retriesAllowed}<#rt>${formatDateTime(ACSStatus.dateTimeSync, "yyyyMMdd    HHmmss")}<#t>${ACSStatus.protocolVersion}|<#rt>AO${ACSStatus.institutionId}|<#rt>AM${ACSStatus.libraryName}|<#rt>BX<@supportedMessages />|<#rt>AN${ACSStatus.terminalLocation}|<#rt>AF${ACSStatus.screenMessage}|<#rt>AG${ACSStatus.printLine}|<#rt><#macro supportedMessages> ${PackagedSupportedMessages.patronStatusRequest}<#t> ${PackagedSupportedMessages.checkOut}<#t> ${PackagedSupportedMessages.checkIn}<#t> ${PackagedSupportedMessages.blockPatron}<#t> ${PackagedSupportedMessages.scAcsStatus}<#t> ${PackagedSupportedMessages.requestScAcsResend}<#t> ${PackagedSupportedMessages.login}<#t> ${PackagedSupportedMessages.patronInformation}<#t> ${PackagedSupportedMessages.endPatronSession}<#t> ${PackagedSupportedMessages.feePaid}<#t> ${PackagedSupportedMessages.itemInformation}<#t> ${PackagedSupportedMessages.itemStatusUpdate}<#t> ${PackagedSupportedMessages.patronEnable}<#t> ${PackagedSupportedMessages.hold}<#t> ${PackagedSupportedMessages.renew}<#t> ${PackagedSupportedMessages.renewAll}<#t></#macro>

--- a/src/main/resources/templates/acs-status.ftl
+++ b/src/main/resources/templates/acs-status.ftl
@@ -1,1 +1,35 @@
-98<#rt>${ACSStatus.onLineStatus}<#rt>${ACSStatus.checkinOk}<#rt>${ACSStatus.checkoutOk}<#rt>${ACSStatus.acsRenewalPolicy}<#rt>${ACSStatus.statusUpdateOk}<#rt>${ACSStatus.offLineOk}<#rt>${ACSStatus.timeoutPeriod}<#rt>${ACSStatus.retriesAllowed}<#rt>${formatDateTime(ACSStatus.dateTimeSync, "yyyyMMdd    HHmmss")}<#t>${ACSStatus.protocolVersion}|<#rt>AO${ACSStatus.institutionId}|<#rt>AM${ACSStatus.libraryName}|<#rt>BX<@supportedMessages />|<#rt>AN${ACSStatus.terminalLocation}|<#rt>AF${ACSStatus.screenMessage}|<#rt>AG${ACSStatus.printLine}|<#rt><#macro supportedMessages> ${PackagedSupportedMessages.patronStatusRequest}<#t> ${PackagedSupportedMessages.checkOut}<#t> ${PackagedSupportedMessages.checkIn}<#t> ${PackagedSupportedMessages.blockPatron}<#t> ${PackagedSupportedMessages.scAcsStatus}<#t> ${PackagedSupportedMessages.requestScAcsResend}<#t> ${PackagedSupportedMessages.login}<#t> ${PackagedSupportedMessages.patronInformation}<#t> ${PackagedSupportedMessages.endPatronSession}<#t> ${PackagedSupportedMessages.feePaid}<#t> ${PackagedSupportedMessages.itemInformation}<#t> ${PackagedSupportedMessages.itemStatusUpdate}<#t> ${PackagedSupportedMessages.patronEnable}<#t> ${PackagedSupportedMessages.hold}<#t> ${PackagedSupportedMessages.renew}<#t> ${PackagedSupportedMessages.renewAll}<#t></#macro>
+98<#rt>
+${ACSStatus.onLineStatus}<#rt>
+${ACSStatus.checkinOk}<#rt>
+${ACSStatus.checkoutOk}<#rt>
+${ACSStatus.acsRenewalPolicy}<#rt>
+${ACSStatus.statusUpdateOk}<#rt>
+${ACSStatus.offLineOk}<#rt>
+${ACSStatus.timeoutPeriod}<#rt>
+${ACSStatus.retriesAllowed}<#rt>
+${formatDateTime(ACSStatus.dateTimeSync, "yyyyMMdd    HHmmss")}<#t>
+${ACSStatus.protocolVersion}|<#rt>
+AO${ACSStatus.institutionId}|<#rt>
+AM${ACSStatus.libraryName}|<#rt>
+BX<@supportedMessages />|<#rt>
+AN${ACSStatus.terminalLocation}|<#rt>
+AF${ACSStatus.screenMessage}|<#rt>
+AG${ACSStatus.printLine}|<#rt>
+<#macro supportedMessages>
+ ${PackagedSupportedMessages.patronStatusRequest}<#t>
+ ${PackagedSupportedMessages.checkOut}<#t>
+ ${PackagedSupportedMessages.checkIn}<#t>
+ ${PackagedSupportedMessages.blockPatron}<#t>
+ ${PackagedSupportedMessages.scAcsStatus}<#t>
+ ${PackagedSupportedMessages.requestScAcsResend}<#t>
+ ${PackagedSupportedMessages.login}<#t>
+ ${PackagedSupportedMessages.patronInformation}<#t>
+ ${PackagedSupportedMessages.endPatronSession}<#t>
+ ${PackagedSupportedMessages.feePaid}<#t>
+ ${PackagedSupportedMessages.itemInformation}<#t>
+ ${PackagedSupportedMessages.itemStatusUpdate}<#t>
+ ${PackagedSupportedMessages.patronEnable}<#t>
+ ${PackagedSupportedMessages.hold}<#t>
+ ${PackagedSupportedMessages.renew}<#t>
+ ${PackagedSupportedMessages.renewAll}<#t>
+</#macro>

--- a/src/main/resources/templates/acs-status.ftl
+++ b/src/main/resources/templates/acs-status.ftl
@@ -15,6 +15,7 @@ BX<@supportedMessages />|<#rt>
 AN${ACSStatus.terminalLocation}|<#rt>
 AF${ACSStatus.screenMessage}|<#rt>
 AG${ACSStatus.printLine}|<#rt>
+
 <#macro supportedMessages>
  ${PackagedSupportedMessages.patronStatusRequest}<#t>
  ${PackagedSupportedMessages.checkOut}<#t>

--- a/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
+++ b/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
@@ -127,7 +127,7 @@ public class MainVerticleTests extends BaseTest {
   private void validateExpectedACSStatus(String acsResponse) {
     String expectedPreLocalTime = "98YYNYNN53" + getFormattedDateString();
     String expectedPostLocalTime =
-        "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|AFscreenMessages|AGline|";
+        "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|AFscreenMessages|AGline|\n";
     String expectedBlankSpaces = "    ";
 
     assertEquals(expectedPreLocalTime, acsResponse.substring(0, 18));

--- a/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
+++ b/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
@@ -5,8 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.folio.edge.sip2.api.support.BaseTest;
-
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxTestContext;
 
@@ -14,6 +12,7 @@ import java.text.SimpleDateFormat;
 import java.time.ZonedDateTime;
 import java.util.Date;
 
+import org.folio.edge.sip2.api.support.BaseTest;
 import org.folio.edge.sip2.domain.messages.enumerations.PWDAlgorithm;
 import org.folio.edge.sip2.domain.messages.enumerations.UIDAlgorithm;
 import org.junit.jupiter.api.Test;
@@ -27,7 +26,7 @@ public class MainVerticleTests extends BaseTest {
 
   @Test
   public void canMakeARequest(Vertx vertex, VertxTestContext testContext) {
-    callService("9300CNMartin|COpassword|",
+    callService("9300CNMartin|COpassword|\r",
         testContext, vertex, result -> {
           final String expectedString = new StringBuilder()
               .append("Logged ")
@@ -43,7 +42,8 @@ public class MainVerticleTests extends BaseTest {
   }
 
   @Test
-  public void canStartMainVericleInjectingSip2RequestHandlers(Vertx vertex, VertxTestContext testContext) {
+  public void canStartMainVericleInjectingSip2RequestHandlers(
+      Vertx vertex, VertxTestContext testContext) {
 
     final ZonedDateTime now = ZonedDateTime.now();
     final String transactionDateString = getFormattedLocalDateTime(now);
@@ -51,7 +51,7 @@ public class MainVerticleTests extends BaseTest {
     String title = "Angry Planet";
     String sipMessage =
         "11YY" + transactionDateString + nbDueDateString
-        + "AOinstitution_id|AApatron_id|AB" + title + "|AC1234|";
+        + "AOinstitution_id|AApatron_id|AB" + title + "|AC1234|\r";
 
     callService(sipMessage, testContext, vertex, result -> {
       final String expectedString = new StringBuilder()
@@ -79,35 +79,59 @@ public class MainVerticleTests extends BaseTest {
 
   @Test
   public void cannotCheckoutWithInvalidCommandCode(Vertx vertex, VertxTestContext testContext) {
-    callService("blablabalb", testContext, vertex, result -> {
+    callService("blablabalb\r", testContext, vertex, result -> {
       assertTrue(result.contains("Problems handling the request"));
     });
   }
 
   @Test
   public void canMakeValidSCStatusRequest(Vertx vertex, VertxTestContext testContext) {
-    callService("9900401.00AY1AZFCA5",
-      testContext, vertex, result -> {
-        String expectedPreLocalTime = "98YYNYNN53" + getFormattedDateString();
-        String expectedPostLocalTime = "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|AFscreenMessages|AGline|\n";
-        String expectedBlankSpaces = "    ";
-
-        assertEquals(result.substring(0, 18), expectedPreLocalTime);
-        assertEquals(result.substring(18, 22), expectedBlankSpaces);
-        assertEquals(result.substring(28), expectedPostLocalTime);
-    });
+    callService("9900401.00AY1AZFCA5\r",
+        testContext, vertex, result -> {
+          validateExpectedACSStatus(result);
+      });
   }
 
   @Test
-  public void canMakeInvalidStatusRequestAndGetExpectedErrorMessage(Vertx vertex, VertxTestContext testContext) {
-    callService("990231.23", testContext, vertex, result -> {
+  public void canMakeInvalidStatusRequestAndGetExpectedErrorMessage(
+      Vertx vertex, VertxTestContext testContext) {
+    callService("990231.23\r", testContext, vertex, result -> {
       assertTrue(result.contains("Problems handling the request"));
     });
   }
 
-  private String getFormattedDateString(){
+  @Test
+  public void canGetCsResendMessageWhenSendingInvalidMessage(
+      Vertx vertx, VertxTestContext testContext) {
+    String scStatusMessage = "9900401.00AY1AZAAAA\r";
+    callService(scStatusMessage, testContext, vertx, result -> {
+      assertEquals("96\r", result);
+    });
+  }
+
+  @Test
+  public void canGetACSStatusMessageWhenSendingValidMessage(
+      Vertx vertx, VertxTestContext testContext) {
+    String scStatusMessage = "9900401.00AY1AZFCA5\r";
+    callService(scStatusMessage, testContext, vertx, result -> {
+      validateExpectedACSStatus(result);
+    });
+  }
+
+  private String getFormattedDateString() {
     String pattern = "YYYYMMdd";
     SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern);
     return simpleDateFormat.format(new Date());
+  }
+
+  private void validateExpectedACSStatus(String acsResponse) {
+    String expectedPreLocalTime = "98YYNYNN53" + getFormattedDateString();
+    String expectedPostLocalTime =
+        "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|AFscreenMessages|AGline|\r";
+    String expectedBlankSpaces = "    ";
+
+    assertEquals(acsResponse.substring(0, 18), expectedPreLocalTime);
+    assertEquals(acsResponse.substring(18, 22), expectedBlankSpaces);
+    assertEquals(acsResponse.substring(28), expectedPostLocalTime);
   }
 }

--- a/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
+++ b/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
@@ -127,11 +127,11 @@ public class MainVerticleTests extends BaseTest {
   private void validateExpectedACSStatus(String acsResponse) {
     String expectedPreLocalTime = "98YYNYNN53" + getFormattedDateString();
     String expectedPostLocalTime =
-        "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|AFscreenMessages|AGline|\r";
+        "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|AFscreenMessages|AGline|";
     String expectedBlankSpaces = "    ";
 
-    assertEquals(acsResponse.substring(0, 18), expectedPreLocalTime);
-    assertEquals(acsResponse.substring(18, 22), expectedBlankSpaces);
-    assertEquals(acsResponse.substring(28), expectedPostLocalTime);
+    assertEquals(expectedPreLocalTime, acsResponse.substring(0, 18));
+    assertEquals(expectedBlankSpaces, acsResponse.substring(18, 22));
+    assertEquals(expectedPostLocalTime, acsResponse.substring(28));
   }
 }

--- a/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
@@ -19,11 +19,12 @@ import org.junit.jupiter.api.Test;
 public class SCStatusHandlerTests {
 
   @Test
-  public void canExecuteASampleScStatusRequestUsingHandlersFactory(){
+  public void canExecuteASampleScStatusRequestUsingHandlersFactory() {
 
     DefaultResourceProvider defaultConfigurationProvider = new DefaultResourceProvider();
 
-    SCStatusHandler handler = ((SCStatusHandler) HandlersFactory.getScStatusHandlerInstance(null, defaultConfigurationProvider, null));
+    SCStatusHandler handler = ((SCStatusHandler) HandlersFactory.getScStatusHandlerInstance(
+        null, defaultConfigurationProvider, null));
 
     SCStatus.SCStatusBuilder statusBuilder = SCStatus.builder();
     statusBuilder.maxPrintWidth(20);
@@ -32,9 +33,11 @@ public class SCStatusHandlerTests {
     SCStatus status =  statusBuilder.build();
 
     String sipMessage = handler.execute(status);
-    //Because the sipMessage has a dateTime component that's supposed to be current, we can't assert on the entirety of the string, have to break it up into pieces.
+    //Because the sipMessage has a dateTime component that's supposed to be current,
+    //we can't assert on the entirety of the string, have to break it up into pieces.
     String expectedPreLocalTime = "98YYNYNN53" + getFormattedDateString();
-    String expectedPostLocalTime = "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|AFscreenMessages|AGline|\n";
+    String expectedPostLocalTime =
+        "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|AFscreenMessages|AGline|\r";
     String expectedBlankSpaces = "    ";
 
     assertEquals(sipMessage.substring(0, 18), expectedPreLocalTime);
@@ -43,9 +46,10 @@ public class SCStatusHandlerTests {
   }
 
   @Test
-  public void cannotGetAValidResponseDueToMissingTemplate(){
+  public void cannotGetAValidResponseDueToMissingTemplate() {
     DefaultResourceProvider defaultConfigurationProvider = new DefaultResourceProvider();
-    ConfigurationRepository configurationRepository = new ConfigurationRepository(defaultConfigurationProvider);
+    ConfigurationRepository configurationRepository =
+        new ConfigurationRepository(defaultConfigurationProvider);
 
     SCStatusHandler handler = new SCStatusHandler(configurationRepository, null);
 
@@ -60,8 +64,7 @@ public class SCStatusHandlerTests {
   }
 
   @Test
-  public void canGetValidPackagedSupportedMessages(){
-
+  public void canGetValidPackagedSupportedMessages() {
     Set<Messages> supportedMessages = new HashSet<>();
     supportedMessages.add(Messages.CHECKIN);
     supportedMessages.add(Messages.CHECKOUT);
@@ -69,7 +72,8 @@ public class SCStatusHandlerTests {
     supportedMessages.add(Messages.RENEW);
 
 
-    SCStatusHandler.PackagedSupportedMessages psm = new SCStatusHandler.PackagedSupportedMessages(supportedMessages);
+    SCStatusHandler.PackagedSupportedMessages psm =
+        new SCStatusHandler.PackagedSupportedMessages(supportedMessages);
     assertTrue(psm.getCheckIn());
     assertTrue(psm.getCheckOut());
     assertTrue(psm.getHold());
@@ -88,7 +92,7 @@ public class SCStatusHandlerTests {
     assertFalse(psm.getPatronInformation());
   }
 
-  private String getFormattedDateString(){
+  private String getFormattedDateString() {
     String pattern = "YYYYMMdd";
     SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern);
     return simpleDateFormat.format(new Date());

--- a/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
@@ -37,12 +37,12 @@ public class SCStatusHandlerTests {
     //we can't assert on the entirety of the string, have to break it up into pieces.
     String expectedPreLocalTime = "98YYNYNN53" + getFormattedDateString();
     String expectedPostLocalTime =
-        "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|AFscreenMessages|AGline|\r";
+        "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|AFscreenMessages|AGline|";
     String expectedBlankSpaces = "    ";
 
-    assertEquals(sipMessage.substring(0, 18), expectedPreLocalTime);
-    assertEquals(sipMessage.substring(18, 22), expectedBlankSpaces);
-    assertEquals(sipMessage.substring(28), expectedPostLocalTime);
+    assertEquals(expectedPreLocalTime, sipMessage.substring(0, 18));
+    assertEquals(expectedBlankSpaces, sipMessage.substring(18, 22));
+    assertEquals(expectedPostLocalTime, sipMessage.substring(28));
   }
 
   @Test

--- a/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
@@ -37,7 +37,7 @@ public class SCStatusHandlerTests {
     //we can't assert on the entirety of the string, have to break it up into pieces.
     String expectedPreLocalTime = "98YYNYNN53" + getFormattedDateString();
     String expectedPostLocalTime =
-        "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|AFscreenMessages|AGline|";
+        "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|AFscreenMessages|AGline|\n";
     String expectedBlankSpaces = "    ";
 
     assertEquals(expectedPreLocalTime, sipMessage.substring(0, 18));

--- a/src/test/java/org/folio/edge/sip2/parser/ParserTests.java
+++ b/src/test/java/org/folio/edge/sip2/parser/ParserTests.java
@@ -120,6 +120,8 @@ class ParserTests {
         "9300CNuser_id|COpassw0rd|AY1AZF595");
 
     assertFalse(message.isValid());
+    assertNotNull(message.getChecksumsString());
+    assertEquals(1, message.getSequenceNumber());
   }
 
   @Test
@@ -333,7 +335,7 @@ class ParserTests {
         .ofPattern("yyyyMMdd    HHmmss")
         .format(transactionDate);
     final Message<?> message = parser.parseMessage(
-        "35" + transactionDateString 
+        "35" + transactionDateString
         + "AApatron_id|AD1234|AC|AOuniversity_id|");
 
     assertEquals(END_PATRON_SESSION, message.getCommand());

--- a/src/test/java/org/folio/edge/sip2/repositories/ConfigurationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/ConfigurationRepositoryTests.java
@@ -34,8 +34,7 @@ public class ConfigurationRepositoryTests {
   }
 
   @Test
-  public void canGetValidAcsStatus(){
-
+  public void canGetValidAcsStatus() {
     JsonArray supportedMsgs = new JsonArray();
     supportedMsgs.add(new JsonObject().put("messageName", "PATRON_INFORMATION")
                             .put("isSupported","Y"));


### PR DESCRIPTION
- Check that the Message output from the parser contains a checksum string, which indicates that Error Detection was enabled. If it was enabled, then check the validity of the checksum (performed by the parser).  If it's invalid, send message 96. 
- Wrapped the socket handler with a RecordParser so that it can take care of waiting for the ending delimiter.  This results in requiring all sip messages in tests to end in "\r".
- Able to set the IDE to use \r for carriage return. This effectively jumbled up the acs-status.ftl, as seen in the diff.
- Fixed checkstyle issues as encountered in files touched. 