### PR TITLE
 Add support for the Checkin command: SIP2-32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,12 @@
       <version>2.27.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <version>4.2.2</version>
+      <classifier>no_aop</classifier>
+    </dependency>
   </dependencies>
 
   <distributionManagement>

--- a/src/main/java/org/folio/edge/sip2/MainVerticle.java
+++ b/src/main/java/org/folio/edge/sip2/MainVerticle.java
@@ -1,28 +1,36 @@
 package org.folio.edge.sip2;
 
+import static java.lang.Boolean.FALSE;
+import static org.folio.edge.sip2.parser.Command.CHECKIN;
 import static org.folio.edge.sip2.parser.Command.CHECKOUT;
 import static org.folio.edge.sip2.parser.Command.LOGIN;
 import static org.folio.edge.sip2.parser.Command.REQUEST_SC_RESEND;
 import static org.folio.edge.sip2.parser.Command.SC_STATUS;
 
+import com.google.inject.Guice;
+import com.google.inject.Injector;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetServerOptions;
 import io.vertx.core.parsetools.RecordParser;
 import java.lang.invoke.MethodHandles;
+import java.nio.charset.Charset;
 import java.util.EnumMap;
 import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.edge.sip2.handlers.CheckinHandler;
 import org.folio.edge.sip2.handlers.HandlersFactory;
 import org.folio.edge.sip2.handlers.ISip2RequestHandler;
+import org.folio.edge.sip2.handlers.LoginHandler;
+import org.folio.edge.sip2.modules.ApplicationModule;
+import org.folio.edge.sip2.modules.FolioResourceProviderModule;
 import org.folio.edge.sip2.parser.Command;
 import org.folio.edge.sip2.parser.Message;
 import org.folio.edge.sip2.parser.Parser;
-import org.folio.edge.sip2.repositories.FolioResourceProvider;
-import org.folio.edge.sip2.repositories.LoginRepository;
+import org.folio.edge.sip2.session.SessionData;
 
 public class MainVerticle extends AbstractVerticle {
 
@@ -44,19 +52,17 @@ public class MainVerticle extends AbstractVerticle {
 
   @Override
   public void start() {
+    // We need to reduce the complexity of this method...
     if (handlers == null) {
-      final FolioResourceProvider folioResourceProvider =
-          new FolioResourceProvider(config().getString("okapiUrl"),
-              config().getString("tenant"), vertx);
+      final Injector injector = Guice.createInjector(
+          new FolioResourceProviderModule(config().getString("okapiUrl"), vertx),
+          new ApplicationModule());
       handlers = new EnumMap<>(Command.class);
-      handlers.put(LOGIN, HandlersFactory.getLoginHandlerInstance(
-          new LoginRepository(folioResourceProvider),
-          folioResourceProvider, null));
+      handlers.put(LOGIN, injector.getInstance(LoginHandler.class));
+      handlers.put(CHECKIN, injector.getInstance(CheckinHandler.class));
       handlers.put(CHECKOUT, HandlersFactory.getCheckoutHandlerIntance());
-      handlers.put(SC_STATUS,
-          HandlersFactory.getScStatusHandlerInstance(null, null, null));
-      handlers.put(REQUEST_SC_RESEND,
-          HandlersFactory.getInvalidMessageHandler());
+      handlers.put(SC_STATUS, HandlersFactory.getScStatusHandlerInstance(null, null, null));
+      handlers.put(REQUEST_SC_RESEND, HandlersFactory.getInvalidMessageHandler());
     }
 
     //set Config object's defaults
@@ -67,9 +73,15 @@ public class MainVerticle extends AbstractVerticle {
     log.info("Deployed verticle at port " + port);
 
     server.connectHandler(socket -> {
+      final SessionData sessionData = SessionData.createSession(
+          config().getString("tenant"),
+          config().getString("fieldDelimiter", "|").charAt(0),
+          config().getBoolean("errorDetectionEnabled", FALSE),
+          config().getString("charset", "IBM850"));
+
       socket.handler(RecordParser.newDelimited("\r", buffer -> {
         final String messageString = buffer.getString(0, buffer.length());
-        log.info("Received message: {}", messageString);
+        log.debug("Received message: {}", messageString);
 
         try {
           // Create a parser with the default delimiter '|' and the default
@@ -77,7 +89,11 @@ public class MainVerticle extends AbstractVerticle {
           // tenant specific. This will be difficult considering that we need
           // to parse the login message before we know which tenant it is.
           // We may need another mechanism to obtain this configuration...
-          final Parser parser = Parser.builder().build();
+          final Parser parser = Parser.builder()
+              .delimiter(sessionData.getFieldDelimiter())
+              .charset(Charset.forName(sessionData.getCharset()))
+              .errorDetectionEnaled(sessionData.isErrorDetectionEnabled())
+              .build();
 
           //parsing
           final Message<Object> message = parser.parseMessage(messageString);
@@ -89,10 +105,10 @@ public class MainVerticle extends AbstractVerticle {
             if (message.getChecksumsString() != null) {
               //resends validation if checksum string does not match
               ISip2RequestHandler handler = handlers.get(Command.REQUEST_SC_RESEND);
-              handler.execute(message.getRequest())
+              handler.execute(message.getRequest(), sessionData)
                   .setHandler(ar -> {
                     if (ar.succeeded()) {
-                      socket.write(ar.result());
+                      socket.write(formatResponse(ar.result(), message, sessionData, true));
                     } else {
                       log.error("Failed to send SC resend", ar.cause());
                     }
@@ -110,10 +126,10 @@ public class MainVerticle extends AbstractVerticle {
           }
 
           handler
-              .execute(message.getRequest())
+              .execute(message.getRequest(), sessionData)
               .setHandler(ar -> {
                 if (ar.succeeded()) {
-                  socket.write(ar.result());  //call FOLIO
+                  socket.write(formatResponse(ar.result(), message, sessionData));  //call FOLIO
                 } else {
                   log.error("Failed to respond to request", ar.cause());
                 }
@@ -153,5 +169,40 @@ public class MainVerticle extends AbstractVerticle {
         stopFuture.fail(result.cause());
       }
     });
+  }
+
+  private String formatResponse(String response, Message<Object> message, SessionData sessionData) {
+    return formatResponse(response, message, sessionData, false);
+  }
+
+  private String formatResponse(String response, Message<Object> message, SessionData sessionData,
+      boolean isSCResend) {
+    final String result;
+
+    if (message.isErrorDetectionEnabled()) {
+      final StringBuilder sb = new StringBuilder(response.length() + (isSCResend ? 6 : 9))
+          .append(response);
+      // SC Resend messages never include a sequence number, but will include the checksum
+      if (!isSCResend) {
+        sb.append("AY").append(message.getSequenceNumber());
+      }
+
+      sb.append("AZ");
+
+      final byte [] bytes = sb.toString().getBytes(Charset.forName(sessionData.getCharset()));
+      int checksum = 0;
+      for (final byte b : bytes) {
+        checksum += b & 0xff;
+      }
+
+      checksum = -checksum & 0xffff;
+      sb.append(String.format("%04X", checksum)).append('\r');
+
+      result = sb.toString();
+    } else {
+      result = response + '\r';
+    }
+
+    return result;
   }
 }

--- a/src/main/java/org/folio/edge/sip2/MainVerticle.java
+++ b/src/main/java/org/folio/edge/sip2/MainVerticle.java
@@ -70,7 +70,7 @@ public class MainVerticle extends AbstractVerticle {
     NetServerOptions options = new NetServerOptions().setPort(port);
     server = vertx.createNetServer(options);
 
-    log.info("Deployed verticle at port " + port);
+    log.info("Deployed verticle at port {}", port);
 
     server.connectHandler(socket -> {
       final SessionData sessionData = SessionData.createSession(

--- a/src/main/java/org/folio/edge/sip2/handlers/CheckinHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/CheckinHandler.java
@@ -1,17 +1,59 @@
 package org.folio.edge.sip2.handlers;
 
+import freemarker.template.Template;
 import io.vertx.core.Future;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.domain.messages.requests.Checkin;
+import org.folio.edge.sip2.domain.messages.responses.CheckinResponse;
+import org.folio.edge.sip2.handlers.freemarker.FormatDateTimeMethodModel;
+import org.folio.edge.sip2.handlers.freemarker.FreemarkerUtils;
+import org.folio.edge.sip2.repositories.CirculationRepository;
+import org.folio.edge.sip2.session.SessionData;
 
 public class CheckinHandler implements ISip2RequestHandler {
+  private static final Logger log = LogManager.getLogger();
+
+  private final CirculationRepository circulationRepository;
+  private final Template commandTemplate;
+
+  @Inject
+  CheckinHandler(
+      CirculationRepository circulationRepository,
+      @Named("checkinResponse") Template commandTemplate) {
+    this.circulationRepository = Objects.requireNonNull(circulationRepository,
+        "CirculationRepository cannot be null");
+    this.commandTemplate = Objects.requireNonNull(commandTemplate, "Template cannot be null");
+  }
+
   @Override
-  public Future<String> execute(Object message) {
+  public Future<String> execute(Object message, SessionData sessionData) {
     final Checkin checkin = (Checkin) message;
-    //call FOLIO
 
-    //format into SIP message
-    return Future.succeededFuture("Successfully checked in "
-        + checkin.toString());
+    log.debug("Checkin: {}", () -> checkin);
 
+    final Future<CheckinResponse> circulationFuture =
+        circulationRepository.checkin(checkin, sessionData);
+
+    return circulationFuture.compose(checkinResponse -> {
+      log.debug("CheckinResponse: {}", () -> checkinResponse);
+
+      final Map<String, Object> root = new HashMap<>();
+      root.put("formatDateTime", new FormatDateTimeMethodModel());
+      root.put("delimiter", sessionData.getFieldDelimiter());
+      root.put("checkinResponse", checkinResponse);
+
+      final String response = FreemarkerUtils
+          .executeFreemarkerTemplate(root, commandTemplate);
+
+      log.debug("SIP checkin response: {}", response);
+
+      return Future.succeededFuture(response);
+    });
   }
 }

--- a/src/main/java/org/folio/edge/sip2/handlers/CheckoutHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/CheckoutHandler.java
@@ -2,11 +2,12 @@ package org.folio.edge.sip2.handlers;
 
 import io.vertx.core.Future;
 import org.folio.edge.sip2.domain.messages.requests.Checkout;
+import org.folio.edge.sip2.session.SessionData;
 
 public class CheckoutHandler implements ISip2RequestHandler {
 
   @Override
-  public Future<String> execute(Object message) {
+  public Future<String> execute(Object message, SessionData sessionData) {
     final Checkout checkout = (Checkout) message;
     //call FOLIO
 

--- a/src/main/java/org/folio/edge/sip2/handlers/HandlersFactory.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/HandlersFactory.java
@@ -1,16 +1,12 @@
 package org.folio.edge.sip2.handlers;
 
-import static org.folio.edge.sip2.parser.Command.LOGIN_RESPONSE;
-
 import freemarker.template.Template;
 
 import org.folio.edge.sip2.handlers.freemarker.FreemarkerRepository;
 import org.folio.edge.sip2.parser.Command;
 import org.folio.edge.sip2.repositories.ConfigurationRepository;
 import org.folio.edge.sip2.repositories.DefaultResourceProvider;
-import org.folio.edge.sip2.repositories.IRequestData;
 import org.folio.edge.sip2.repositories.IResourceProvider;
-import org.folio.edge.sip2.repositories.LoginRepository;
 
 /**
  * Factory class that holds instantiation logic for all ISip2RequestHandlers.
@@ -42,25 +38,6 @@ public class HandlersFactory {
         Command.ACS_STATUS);
 
     return new SCStatusHandler(configRepo, freeMarkerTemplate);
-  }
-
-  /**
-   * Returns a Login Response command handler with the specified arguments.
-   * 
-   * @param loginRepository a store of login data
-   * @param resourceProvider a service for interacting with resources
-   * @param commandTemplate the template for SIP2 command output
-   * @return
-   */
-  public static ISip2RequestHandler getLoginHandlerInstance(
-      LoginRepository loginRepository,
-      IResourceProvider<IRequestData> resourceProvider,
-      Template commandTemplate) {
-    return new LoginHandler(
-        loginRepository == null ? new LoginRepository(
-            getResourceProvider(resourceProvider))
-            : loginRepository,
-        getCommandTemplate(commandTemplate, LOGIN_RESPONSE));
   }
 
   public static ISip2RequestHandler getCheckoutHandlerIntance() {

--- a/src/main/java/org/folio/edge/sip2/handlers/ISip2RequestHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/ISip2RequestHandler.java
@@ -1,7 +1,8 @@
 package org.folio.edge.sip2.handlers;
 
 import io.vertx.core.Future;
+import org.folio.edge.sip2.session.SessionData;
 
 public interface ISip2RequestHandler {
-  Future<String> execute(Object message);
+  Future<String> execute(Object message, SessionData sessionData);
 }

--- a/src/main/java/org/folio/edge/sip2/handlers/InvalidMessageHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/InvalidMessageHandler.java
@@ -7,10 +7,11 @@ import io.vertx.core.Future;
 import java.util.Collections;
 import org.folio.edge.sip2.handlers.freemarker.FreemarkerRepository;
 import org.folio.edge.sip2.handlers.freemarker.FreemarkerUtils;
+import org.folio.edge.sip2.session.SessionData;
 
 public class InvalidMessageHandler implements ISip2RequestHandler {
   @Override
-  public Future<String> execute(Object message) {
+  public Future<String> execute(Object message, SessionData sessionData) {
     final Template commandTemplate = FreemarkerRepository
         .getInstance().getFreemarkerTemplate(REQUEST_SC_RESEND);
     final String response = FreemarkerUtils

--- a/src/main/java/org/folio/edge/sip2/handlers/LoginHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/LoginHandler.java
@@ -23,7 +23,7 @@ public class LoginHandler implements ISip2RequestHandler {
   private final Template commandTemplate;
 
   @Inject
-  LoginHandler(LoginRepository loginRepository,@Named("loginResponse") Template commandTemplate) {
+  LoginHandler(LoginRepository loginRepository, @Named("loginResponse") Template commandTemplate) {
     this.loginRepository = Objects.requireNonNull(loginRepository,
         "LoginRepository cannot be null");
     this.commandTemplate = Objects.requireNonNull(commandTemplate, "Template cannot be null");

--- a/src/main/java/org/folio/edge/sip2/handlers/LoginHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/LoginHandler.java
@@ -5,6 +5,8 @@ import io.vertx.core.Future;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import javax.inject.Inject;
+import javax.inject.Named;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.domain.messages.requests.Login;
@@ -12,6 +14,7 @@ import org.folio.edge.sip2.domain.messages.responses.LoginResponse;
 import org.folio.edge.sip2.handlers.freemarker.FormatDateTimeMethodModel;
 import org.folio.edge.sip2.handlers.freemarker.FreemarkerUtils;
 import org.folio.edge.sip2.repositories.LoginRepository;
+import org.folio.edge.sip2.session.SessionData;
 
 public class LoginHandler implements ISip2RequestHandler {
   private static final Logger log = LogManager.getLogger();
@@ -19,34 +22,27 @@ public class LoginHandler implements ISip2RequestHandler {
   private final LoginRepository loginRepository;
   private final Template commandTemplate;
 
-  /**
-   * Construct a Login handler with the specified parameters.
-   * @param loginRepository the login repository
-   * @param commandTemplate the command template
-   */
-  public LoginHandler(
-      LoginRepository loginRepository,
-      Template commandTemplate) {
+  @Inject
+  LoginHandler(LoginRepository loginRepository,@Named("loginResponse") Template commandTemplate) {
     this.loginRepository = Objects.requireNonNull(loginRepository,
         "LoginRepository cannot be null");
-    this.commandTemplate = Objects.requireNonNull(commandTemplate,
-        "Template cannot be null");
+    this.commandTemplate = Objects.requireNonNull(commandTemplate, "Template cannot be null");
   }
 
   @Override
-  public Future<String> execute(Object message) {
+  public Future<String> execute(Object message, SessionData sessionData) {
     final Login login = (Login) message;
 
     log.debug("Login: {}", () -> login);
 
-    final Future<LoginResponse> responseFuture = loginRepository.login(login);
+    final Future<LoginResponse> responseFuture = loginRepository.login(login, sessionData);
 
     return responseFuture.compose(loginResponse -> {
       log.debug("LoginResponse: {}", () -> loginResponse);
-  
+
       final Map<String, Object> root = new HashMap<>();
       root.put("formatDateTime", new FormatDateTimeMethodModel());
-      root.put("delimiter", "|");
+      root.put("delimiter", sessionData.getFieldDelimiter());
       root.put("loginResponse", loginResponse);
 
       final String response = FreemarkerUtils

--- a/src/main/java/org/folio/edge/sip2/handlers/SCStatusHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/SCStatusHandler.java
@@ -16,6 +16,7 @@ import org.folio.edge.sip2.domain.messages.responses.ACSStatus;
 import org.folio.edge.sip2.handlers.freemarker.FormatDateTimeMethodModel;
 import org.folio.edge.sip2.handlers.freemarker.FreemarkerUtils;
 import org.folio.edge.sip2.repositories.ConfigurationRepository;
+import org.folio.edge.sip2.session.SessionData;
 
 public class SCStatusHandler implements ISip2RequestHandler {
 
@@ -37,7 +38,7 @@ public class SCStatusHandler implements ISip2RequestHandler {
   }
 
   @Override
-  public Future<String> execute(Object message)  {
+  public Future<String> execute(Object message, SessionData sessionData)  {
     Future<ACSStatus> future = configurationRepository.getACSStatus();
 
     return future.compose(acsStatus -> {

--- a/src/main/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerRepository.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerRepository.java
@@ -55,6 +55,7 @@ public class FreemarkerRepository {
 
     addTemplate(Command.ACS_STATUS, "acs-status.ftl", configuration);
     addTemplate(Command.LOGIN_RESPONSE, "LoginResponse.ftl", configuration);
+    addTemplate(Command.CHECKIN_RESPONSE, "CheckinResponse.ftl", configuration);
     addTemplate(Command.REQUEST_SC_RESEND, "RequestSCResend.ftl", configuration);
   }
 

--- a/src/main/java/org/folio/edge/sip2/modules/ApplicationModule.java
+++ b/src/main/java/org/folio/edge/sip2/modules/ApplicationModule.java
@@ -1,0 +1,46 @@
+package org.folio.edge.sip2.modules;
+
+import static org.folio.edge.sip2.parser.Command.CHECKIN_RESPONSE;
+import static org.folio.edge.sip2.parser.Command.LOGIN_RESPONSE;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.TypeLiteral;
+import freemarker.template.Template;
+import java.time.Clock;
+import javax.inject.Named;
+import org.folio.edge.sip2.handlers.freemarker.FreemarkerRepository;
+import org.folio.edge.sip2.repositories.CirculationRepository;
+import org.folio.edge.sip2.repositories.FolioResourceProvider;
+import org.folio.edge.sip2.repositories.IRequestData;
+import org.folio.edge.sip2.repositories.IResourceProvider;
+import org.folio.edge.sip2.repositories.LoginRepository;
+
+/**
+ * Module to bind dependencies for {@code CirculationRespository}.
+ *
+ * @author mreno-EBSCO
+ *
+ */
+public class ApplicationModule extends AbstractModule {
+  @Override
+  protected void configure() {
+    bind(new TypeLiteral<IResourceProvider<IRequestData>>() {})
+        .to(FolioResourceProvider.class).asEagerSingleton();
+    bind(Clock.class).toInstance(Clock.systemUTC());
+    bind(CirculationRepository.class);
+    bind(LoginRepository.class);
+  }
+
+  @Provides
+  @Named("checkinResponse")
+  Template provideCheckinResponseTemplate() {
+    return FreemarkerRepository.getInstance().getFreemarkerTemplate(CHECKIN_RESPONSE);
+  }
+
+  @Provides
+  @Named("loginResponse")
+  Template provideLoginResponseTemplate() {
+    return FreemarkerRepository.getInstance().getFreemarkerTemplate(LOGIN_RESPONSE);
+  }
+}

--- a/src/main/java/org/folio/edge/sip2/modules/FolioResourceProviderModule.java
+++ b/src/main/java/org/folio/edge/sip2/modules/FolioResourceProviderModule.java
@@ -1,0 +1,32 @@
+package org.folio.edge.sip2.modules;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.name.Names;
+import io.vertx.core.Vertx;
+
+/**
+ * Module for creating a {@code FolioResourceProvider} via Dependency injection.
+ *
+ * @author mreno-EBSCO
+ *
+ */
+public class FolioResourceProviderModule extends AbstractModule {
+  private final String okapiUrl;
+  private final Vertx vertx;
+
+  /**
+   * Build a module for dependency injection.
+   * @param okapiUrl the okapi url
+   * @param vertx the instance of vertx
+   */
+  public FolioResourceProviderModule(String okapiUrl, Vertx vertx) {
+    this.okapiUrl = okapiUrl;
+    this.vertx = vertx;
+  }
+
+  @Override
+  protected void configure() {
+    bind(String.class).annotatedWith(Names.named("okapiUrl")).toInstance(okapiUrl);
+    bind(Vertx.class).annotatedWith(Names.named("vertx")).toInstance(vertx);
+  }
+}

--- a/src/main/java/org/folio/edge/sip2/parser/Parser.java
+++ b/src/main/java/org/folio/edge/sip2/parser/Parser.java
@@ -69,7 +69,7 @@ public final class Parser {
     if (ed.valid) {
       if (ed.sequenceNumber != null) {
         // Remove the error detection chars before parsing the message
-        message = message.substring(0, message.length() - 9);
+        message = message.substring(0, message.length() - (command == REQUEST_ACS_RESEND ? 6 : 9));
       }
 
       // Remove the command identifier before parsing

--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -1,0 +1,119 @@
+package org.folio.edge.sip2.repositories;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import java.time.Clock;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.inject.Inject;
+import org.folio.edge.sip2.domain.messages.requests.Checkin;
+import org.folio.edge.sip2.domain.messages.responses.CheckinResponse;
+import org.folio.edge.sip2.session.SessionData;
+
+/**
+ * Provides interaction with the login service.
+ *
+ * @author mreno-EBSCO
+ *
+ */
+public class CirculationRepository {
+  private final IResourceProvider<IRequestData> resourceProvider;
+  private final Clock clock;
+
+  @Inject
+  CirculationRepository(IResourceProvider<IRequestData> resourceProvider, Clock clock) {
+    this.resourceProvider = Objects.requireNonNull(resourceProvider,
+        "Resource provider cannot be null");
+    this.clock = Objects.requireNonNull(clock, "Clock cannot be null");
+  }
+
+  /**
+   * Perform a checkin.
+   *
+   * @param checkin the login domain object
+   * @return the checkin response domain object
+   */
+  public Future<CheckinResponse> checkin(Checkin checkin, SessionData sessionData) {
+    final ZonedDateTime returnDate = checkin.getReturnDate();
+    final String currentLocation = checkin.getCurrentLocation();
+    final String institutionId = checkin.getInstitutionId();
+    final String itemIdentifier = checkin.getItemIdentifier();
+
+    final JsonObject body = new JsonObject()
+        .put("itemBarcode", itemIdentifier)
+        .put("servicePointId", currentLocation)
+        .put("checkInDate", DateTimeFormatter.ISO_DATE_TIME
+            .withZone(ZoneOffset.UTC)
+            .format(returnDate));
+    Map<String, String> headers = new HashMap<>();
+    headers.put("accept", "application/json");
+
+    final CheckinRequestData checkinRequestData =
+        new CheckinRequestData(body, headers, sessionData);
+    final Future<IResource> result = resourceProvider
+        .createResource(checkinRequestData);
+
+    return result
+        .otherwiseEmpty()
+        .compose(resource -> Future.succeededFuture(
+            CheckinResponse.builder()
+              .ok(resource.getResource() == null ? FALSE : TRUE)
+              .resensitize(resource.getResource() == null ? FALSE : TRUE)
+              .magneticMedia(null)
+              .alert(FALSE)
+              // Need to get the "local" time zone from somewhere
+              // Using UTC for now
+              .transactionDate(ZonedDateTime.now(clock))
+              .institutionId(institutionId)
+              .itemIdentifier(itemIdentifier)
+              // this is probably not the permanent location
+              // this might require a call to inventory
+              .permanentLocation(
+                  resource.getResource() == null ? "Unknown"
+                      : resource.getResource().getJsonObject("item",
+                          new JsonObject()).getJsonObject("location",
+                              new JsonObject()).getString("name", "Unknown"))
+              .build()));
+  }
+
+  private class CheckinRequestData implements IRequestData {
+    private final JsonObject body;
+    private final Map<String, String> headers;
+    private final SessionData sessionData;
+
+    private CheckinRequestData(JsonObject body, Map<String, String> headers,
+        SessionData sessionData) {
+      this.body = body;
+      this.headers = Collections.unmodifiableMap(new HashMap<>(headers));
+      this.sessionData = sessionData;
+    }
+
+    @Override
+    public String getPath() {
+      return "/circulation/check-in-by-barcode";
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+      return headers;
+    }
+
+    @Override
+    public JsonObject getBody() {
+      return body;
+    }
+
+    @Override
+    public SessionData getSessionData() {
+      return sessionData;
+    }
+  }
+}

--- a/src/main/java/org/folio/edge/sip2/repositories/ConfigurationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/ConfigurationRepository.java
@@ -83,9 +83,10 @@ public class ConfigurationRepository {
    */
   public Future<JsonObject> retrieveTenantConfiguration(String configKey) {
 
-    Future<JsonObject> future = resourceProvider.retrieveResource(null);
+    Future<IResource> future = resourceProvider.retrieveResource(null);
 
-    return future.compose(jsonFile -> {
+    return future.compose(resource -> {
+      final JsonObject jsonFile = resource.getResource();
       JsonObject configJson = null;
 
       JsonArray tenantConfigurations = jsonFile.getJsonArray("tenantConfigurations");
@@ -104,8 +105,9 @@ public class ConfigurationRepository {
 
   private Future<JsonObject> retrieveAcsConfiguration() {
 
-    Future<JsonObject> future = resourceProvider.retrieveResource(null);
-    return future.compose(fullConfiguration -> {
+    Future<IResource> future = resourceProvider.retrieveResource(null);
+    return future.compose(resource -> {
+      final JsonObject fullConfiguration = resource.getResource();
       JsonObject acsConfiguration = null;
       if (fullConfiguration != null) {
         acsConfiguration = fullConfiguration.getJsonObject("acsConfiguration");

--- a/src/main/java/org/folio/edge/sip2/repositories/DefaultResourceProvider.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/DefaultResourceProvider.java
@@ -37,7 +37,7 @@ public class DefaultResourceProvider implements IResourceProvider<Object> {
          InputStreamReader isr = new InputStreamReader(inputStream);
          BufferedReader br = new BufferedReader(isr)) {
 
-      log.debug("Config file location:" + configurationResource.toString());
+      log.debug("Config file location: {}", configurationResource);
       String fileContent = br.lines().collect(Collectors.joining("\n"));
       br.lines().close();
 

--- a/src/main/java/org/folio/edge/sip2/repositories/DefaultResourceProvider.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/DefaultResourceProvider.java
@@ -22,12 +22,12 @@ public class DefaultResourceProvider implements IResourceProvider<Object> {
   }
 
   @Override
-  public Future<JsonObject> createResource(Object fromData) {
+  public Future<IResource> createResource(Object fromData) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public Future<JsonObject> retrieveResource(Object key) {
+  public Future<IResource> retrieveResource(Object key) {
 
     JsonObject jsonFile = null;
 
@@ -47,16 +47,17 @@ public class DefaultResourceProvider implements IResourceProvider<Object> {
     } catch (Exception ex) {
       log.error("General exception encountered reading configuration file: " + ex.getMessage());
     }
-    return Future.succeededFuture(jsonFile);
+    final JsonObject result = jsonFile;
+    return Future.succeededFuture(() -> result);
   }
 
   @Override
-  public Future<JsonObject> editResource(Object fromData) {
+  public Future<IResource> editResource(Object fromData) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public Future<JsonObject> deleteResource(Object resource) {
+  public Future<IResource> deleteResource(Object resource) {
     throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/org/folio/edge/sip2/repositories/FolioResource.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/FolioResource.java
@@ -1,0 +1,35 @@
+package org.folio.edge.sip2.repositories;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Represents the response from the {@code FolioResourceProvider}. Contains the response JSON,
+ * if any, as well as the headers stored as metadata. The data is not immutable.
+ * @author mreno-EBSCO
+ *
+ */
+public class FolioResource implements IResource {
+  private final JsonObject resource;
+  private final MultiMap metadata;
+
+  public FolioResource(JsonObject resource, MultiMap metadata) {
+    this.resource = resource;
+    this.metadata = metadata;
+  }
+
+  @Override
+  public JsonObject getResource() {
+    return resource;
+  }
+
+  @Override
+  public MultiMap getMetadata() {
+    return metadata;
+  }
+
+  @Override
+  public String getAuthenticationToken() {
+    return metadata.get("x-okapi-token");
+  }
+}

--- a/src/main/java/org/folio/edge/sip2/repositories/FolioResourceProvider.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/FolioResourceProvider.java
@@ -4,17 +4,23 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.NoStackTraceThrowable;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.predicate.ErrorConverter;
 import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import io.vertx.ext.web.codec.BodyCodec;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Named;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.edge.sip2.session.SessionData;
 
 /**
  * Resource provider for communicating with FOLIO.
@@ -28,32 +34,36 @@ public class FolioResourceProvider implements IResourceProvider<IRequestData> {
 
   private final String okapiUrl;
   private final WebClient client;
-  private final String tenant;
-  private String okapiToken = null;
 
   /**
    * Construct a FOLIO resource provider with the specified parameters.
    * @param okapiUrl the URL for okapi
-   * @param tenant the tenant for the request
    * @param vertx the vertx instance
    */
-  public FolioResourceProvider(String okapiUrl, String tenant, Vertx vertx) {
+  @Inject
+  public FolioResourceProvider(
+      @Named("okapiUrl") String okapiUrl,
+      @Named("vertx") Vertx vertx) {
     this.okapiUrl = okapiUrl;
-    this.tenant = tenant;
     this.client = WebClient.create(vertx);
   }
 
   @Override
-  public Future<JsonObject> retrieveResource(IRequestData requestData) {
+  public Future<IResource> retrieveResource(IRequestData requestData) {
     final HttpRequest<Buffer> request =
         client.getAbs(okapiUrl + requestData.getPath());
 
-    setHeaders(requestData.getHeaders(), request);
+    setHeaders(requestData.getHeaders(), request, requestData.getSessionData());
 
-    final Future<JsonObject> future = Future.future();
+    final Future<IResource> future = Future.future();
     request
-        .expect(ResponsePredicate.SC_OK)
-        .expect(ResponsePredicate.JSON)
+        .expect(ResponsePredicate.create(ResponsePredicate.SC_OK, getErrorConverter()))
+        // Some APIs return application/json, some return with the charset
+        // parameter (e.g. circulation). So we can't use the built-in JSON
+        // predicate here.
+        .expect(ResponsePredicate.contentType(Arrays.asList(
+            "application/json",
+            "application/json; charset=utf-8")))
         .as(BodyCodec.jsonObject())
         .send(ar -> handleResponse(future, ar));
 
@@ -61,16 +71,21 @@ public class FolioResourceProvider implements IResourceProvider<IRequestData> {
   }
 
   @Override
-  public Future<JsonObject> createResource(IRequestData requestData) {
+  public Future<IResource> createResource(IRequestData requestData) {
     final HttpRequest<Buffer> request =
         client.postAbs(okapiUrl + requestData.getPath());
 
-    setHeaders(requestData.getHeaders(), request);
+    setHeaders(requestData.getHeaders(), request, requestData.getSessionData());
 
-    final Future<JsonObject> future = Future.future();
+    final Future<IResource> future = Future.future();
     request
-        .expect(ResponsePredicate.SC_CREATED)
-        .expect(ResponsePredicate.JSON)
+        .expect(ResponsePredicate.create(ResponsePredicate.SC_SUCCESS, getErrorConverter()))
+        // Some APIs return application/json, some return with the charset
+        // parameter (e.g. circulation). So we can't use the built-in JSON
+        // predicate here.
+        .expect(ResponsePredicate.contentType(Arrays.asList(
+            "application/json",
+            "application/json; charset=utf-8")))
         .as(BodyCodec.jsonObject())
         .sendJsonObject(requestData.getBody(),
             ar -> handleResponse(future, ar));
@@ -79,44 +94,51 @@ public class FolioResourceProvider implements IResourceProvider<IRequestData> {
   }
 
   @Override
-  public Future<JsonObject> editResource(IRequestData fromData) {
+  public Future<IResource> editResource(IRequestData fromData) {
     return null;
   }
 
   @Override
-  public Future<JsonObject> deleteResource(IRequestData resource) {
+  public Future<IResource> deleteResource(IRequestData resource) {
     return null;
   }
 
   private void setHeaders(
       Map<String, String> headers,
-      HttpRequest<Buffer> request) {
+      HttpRequest<Buffer> request,
+      SessionData sessionData) {
     for (Map.Entry<String,String> entry : Optional.ofNullable(headers)
         .orElse(Collections.emptyMap()).entrySet()) {
       request.putHeader(entry.getKey(), entry.getValue());
     }
 
-    if (okapiToken != null) {
-      request.putHeader(HEADER_X_OKAPI_TOKEN, okapiToken);
+    if (sessionData != null) {
+      final String authenticationToken = sessionData.getAuthenticationToken();
+      if (authenticationToken != null) {
+        request.putHeader(HEADER_X_OKAPI_TOKEN, authenticationToken);
+      }
+      request.putHeader("x-okapi-tenant", sessionData.getTenant());
     }
-
-    request.putHeader("x-okapi-tenant", tenant);
   }
 
   private void handleResponse(
-      Future<JsonObject> future,
+      Future<IResource> future,
       AsyncResult<HttpResponse<JsonObject>> ar) {
     if (ar.succeeded()) {
-      // Save the okapi token. There is probably a better way to do this.
-      final String serverToken = ar.result()
-          .getHeader(HEADER_X_OKAPI_TOKEN);
-      if (!serverToken.equals(okapiToken)) {
-        okapiToken = serverToken;
-      }
-      future.complete(ar.result().body());
+      log.debug("FOLIO response body: {}",
+          () -> ar.result().body().encodePrettily());
+
+      future.complete(new FolioResource(ar.result().body(), ar.result().headers()));
     } else {
       log.error("Creation failed", ar.cause());
       future.fail(ar.cause());
     }
+  }
+
+  private ErrorConverter getErrorConverter() {
+    return ErrorConverter.createFullBody(result -> {
+      log.error("Error communicating with FOLIO: {}", result.response().bodyAsString());
+      return new NoStackTraceThrowable(result.message());
+    });
   }
 }

--- a/src/main/java/org/folio/edge/sip2/repositories/FolioResourceProvider.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/FolioResourceProvider.java
@@ -15,6 +15,7 @@ import io.vertx.ext.web.codec.BodyCodec;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -53,7 +54,8 @@ public class FolioResourceProvider implements IResourceProvider<IRequestData> {
     final HttpRequest<Buffer> request =
         client.getAbs(okapiUrl + requestData.getPath());
 
-    setHeaders(requestData.getHeaders(), request, requestData.getSessionData());
+    setHeaders(requestData.getHeaders(), request,
+        Objects.requireNonNull(requestData.getSessionData(), "SessionData cannot be null"));
 
     final Future<IResource> future = Future.future();
     request
@@ -112,13 +114,11 @@ public class FolioResourceProvider implements IResourceProvider<IRequestData> {
       request.putHeader(entry.getKey(), entry.getValue());
     }
 
-    if (sessionData != null) {
-      final String authenticationToken = sessionData.getAuthenticationToken();
-      if (authenticationToken != null) {
-        request.putHeader(HEADER_X_OKAPI_TOKEN, authenticationToken);
-      }
-      request.putHeader("x-okapi-tenant", sessionData.getTenant());
+    final String authenticationToken = sessionData.getAuthenticationToken();
+    if (authenticationToken != null) {
+      request.putHeader(HEADER_X_OKAPI_TOKEN, authenticationToken);
     }
+    request.putHeader("x-okapi-tenant", sessionData.getTenant());
   }
 
   private void handleResponse(

--- a/src/main/java/org/folio/edge/sip2/repositories/IRequestData.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/IRequestData.java
@@ -3,6 +3,7 @@ package org.folio.edge.sip2.repositories;
 import io.vertx.core.json.JsonObject;
 import java.util.Collections;
 import java.util.Map;
+import org.folio.edge.sip2.session.SessionData;
 
 /**
  * Data used for making the resource request.
@@ -19,5 +20,9 @@ public interface IRequestData {
 
   default Map<String, String> getHeaders() {
     return Collections.emptyMap();
+  }
+
+  default SessionData getSessionData() {
+    return null;
   }
 }

--- a/src/main/java/org/folio/edge/sip2/repositories/IResource.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/IResource.java
@@ -1,0 +1,36 @@
+package org.folio.edge.sip2.repositories;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Represents resource data retrieved by an {@code IResourceProvider}.
+ *
+ * @author mreno-EBSCO
+ *
+ */
+public interface IResource {
+  /**
+   * Returns the resource data as a JsonObject.
+   * @return the resource data
+   */
+  JsonObject getResource();
+
+  /**
+   * Returns resource metadata in whatever format the provider specifies.
+   * @return the resource metadata
+   */
+  default MultiMap getMetadata() {
+    return null;
+  }
+
+  /**
+   * Returns the authentication token used to access the resource. The resource provider may not
+   * require a token, in this case this method may return {@code ""}. A return of {@code null}
+   * means something went wrong.
+   * @return the authentication token
+   */
+  default String getAuthenticationToken() {
+    return "";
+  }
+}

--- a/src/main/java/org/folio/edge/sip2/repositories/IResourceProvider.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/IResourceProvider.java
@@ -1,18 +1,17 @@
 package org.folio.edge.sip2.repositories;
 
 import io.vertx.core.Future;
-import io.vertx.core.json.JsonObject;
 
 /**
  * Interface that specifies CRUD implementations to provide a resource.
  */
 public interface IResourceProvider<T> {
 
-  Future<JsonObject> retrieveResource(T key);
+  Future<IResource> retrieveResource(T key);
 
-  Future<JsonObject> createResource(T fromData);
+  Future<IResource> createResource(T fromData);
 
-  Future<JsonObject> editResource(T fromData);
+  Future<IResource> editResource(T fromData);
 
-  Future<JsonObject> deleteResource(T resource);
+  Future<IResource> deleteResource(T resource);
 }

--- a/src/main/java/org/folio/edge/sip2/session/SessionData.java
+++ b/src/main/java/org/folio/edge/sip2/session/SessionData.java
@@ -1,0 +1,84 @@
+package org.folio.edge.sip2.session;
+
+public class SessionData {
+  private final char fieldDelimiter;
+  private final String tenant;
+  private final boolean errorDetectionEnabled;
+  private final String charset;
+
+  private String scLocation;
+  private String authenticationToken;
+  private int maxWidth;
+  private String username;
+  private String password; // should we really save this?
+
+  private SessionData(String tenant, char fieldDelimiter,
+      boolean errorDetectionEnabled, String charset) {
+    this.tenant = tenant;
+    this.fieldDelimiter = fieldDelimiter;
+    this.errorDetectionEnabled = errorDetectionEnabled;
+    this.charset = charset;
+  }
+
+  public String getScLocation() {
+    return scLocation;
+  }
+
+  public void setScLocation(String scLocation) {
+    this.scLocation = scLocation;
+  }
+
+  public String getAuthenticationToken() {
+    return authenticationToken;
+  }
+
+  public void setAuthenticationToken(String authenticationToken) {
+    this.authenticationToken = authenticationToken;
+  }
+
+  public int getMaxWidth() {
+    return maxWidth;
+  }
+
+  public void setMaxWidth(int maxWidth) {
+    this.maxWidth = maxWidth;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  public char getFieldDelimiter() {
+    return fieldDelimiter;
+  }
+
+  public String getTenant() {
+    return tenant;
+  }
+
+  public boolean isErrorDetectionEnabled() {
+    return errorDetectionEnabled;
+  }
+
+  public String getCharset() {
+    return charset;
+  }
+
+  public static SessionData createSession(String tenant, char fieldDelimiter,
+      boolean errorDetectionEnabled, String charset) {
+    return new SessionData(tenant, fieldDelimiter, errorDetectionEnabled,
+        charset);
+  }
+}

--- a/src/main/java/org/folio/edge/sip2/session/SessionData.java
+++ b/src/main/java/org/folio/edge/sip2/session/SessionData.java
@@ -8,7 +8,7 @@ public class SessionData {
 
   private String scLocation;
   private String authenticationToken;
-  private int maxWidth;
+  private int maxPrintWidth = -1; // since 0 is valid 
   private String username;
   private String password; // should we really save this?
 
@@ -36,12 +36,12 @@ public class SessionData {
     this.authenticationToken = authenticationToken;
   }
 
-  public int getMaxWidth() {
-    return maxWidth;
+  public int getMaxPrintWidth() {
+    return maxPrintWidth;
   }
 
-  public void setMaxWidth(int maxWidth) {
-    this.maxWidth = maxWidth;
+  public void setMaxPrintWidth(int maxPrintWidth) {
+    this.maxPrintWidth = maxPrintWidth;
   }
 
   public String getUsername() {

--- a/src/main/resources/templates/lib.ftl
+++ b/src/main/resources/templates/lib.ftl
@@ -71,7 +71,7 @@
 <#-- Command macros that are mapped directly to a field name -->
 
 <#macro alert value>
-  <@booleanTo1or0 value=value/><#t>
+  <@booleanToYorN value=value/><#t>
 </#macro>
 
 <#macro chargedItems value>

--- a/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
+++ b/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
@@ -11,8 +11,8 @@ import io.vertx.junit5.VertxTestContext;
 import java.text.SimpleDateFormat;
 import java.time.ZonedDateTime;
 import java.util.Date;
-
 import org.folio.edge.sip2.api.support.BaseTest;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +27,6 @@ public class MainVerticleTests extends BaseTest {
 
   @Test
   public void canStartMainVerticle() {
-    System.out.print("canStartMainVerticle");
     assertNotNull(myVerticle.deploymentID());
   }
 

--- a/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
+++ b/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
@@ -12,6 +12,7 @@ import java.text.SimpleDateFormat;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import org.folio.edge.sip2.api.support.BaseTest;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 public class MainVerticleTests extends BaseTest {
@@ -25,7 +26,7 @@ public class MainVerticleTests extends BaseTest {
   public void canMakeARequest(Vertx vertex, VertxTestContext testContext) {
     callService("9300CNMartin|COpassword|\r",
         testContext, vertex, result -> {
-          final String expectedString = "941";
+          final String expectedString = "941\r";
           assertEquals(expectedString, result);
         });
   }
@@ -61,7 +62,7 @@ public class MainVerticleTests extends BaseTest {
           .append(", patronPassword=null")
           .append(", feeAcknowledged=null")
           .append(", cancel=null")
-          .append(']').toString();
+          .append("]\r").toString();
       assertEquals(expectedString, result);
     });
   }
@@ -90,11 +91,12 @@ public class MainVerticleTests extends BaseTest {
   }
 
   @Test
+  @Tag("ErrorDetectionEnabled")
   public void canGetCsResendMessageWhenSendingInvalidMessage(
       Vertx vertx, VertxTestContext testContext) {
     String scStatusMessage = "9900401.00AY1AZAAAA\r";
     callService(scStatusMessage, testContext, vertx, result -> {
-      assertEquals("96", result);
+      assertEquals("96AZFEF6\r", result);
     });
   }
 
@@ -116,7 +118,7 @@ public class MainVerticleTests extends BaseTest {
   private void validateExpectedACSStatus(String acsResponse) {
     String expectedPreLocalTime = "98YYNYNN53" + getFormattedDateString();
     String expectedPostLocalTime =
-        "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|AFscreenMessages|AGline|";
+        "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|AFscreenMessages|AGline|\r";
     String expectedBlankSpaces = "    ";
 
     assertEquals(expectedPreLocalTime, acsResponse.substring(0, 18));

--- a/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
+++ b/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
@@ -12,7 +12,6 @@ import java.text.SimpleDateFormat;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import org.folio.edge.sip2.api.support.BaseTest;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/org/folio/edge/sip2/api/support/BaseTest.java
+++ b/src/test/java/org/folio/edge/sip2/api/support/BaseTest.java
@@ -22,12 +22,14 @@ import java.time.format.DateTimeFormatter;
 import java.util.EnumMap;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.MainVerticle;
 import org.folio.edge.sip2.handlers.ACSResendHandler;
 import org.folio.edge.sip2.handlers.ISip2RequestHandler;
 import org.folio.edge.sip2.handlers.LoginHandler;
 import org.folio.edge.sip2.parser.Command;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.TestInfo;
@@ -37,6 +39,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith({VertxExtension.class, MockitoExtension.class})
 public abstract class BaseTest {
+  private static Logger log = LogManager.getLogger();
+
   @Mock
   private LoginHandler mockLoginHandler;
   protected MainVerticle myVerticle;
@@ -56,6 +60,7 @@ public abstract class BaseTest {
   @BeforeEach
   @DisplayName("Deploy the verticle")
   public void deployVerticle(Vertx vertx, VertxTestContext testContext, TestInfo testInfo) {
+    log.info("Starting: {}", testInfo.getDisplayName());
 
     JsonObject sipConfig = new JsonObject();
     sipConfig.put("port", port);
@@ -71,7 +76,13 @@ public abstract class BaseTest {
     setMainVerticleInstance(testInfo.getDisplayName());
     vertx.deployVerticle(myVerticle, opt, testContext.completing());
 
-    System.out.println("done deploying in base class");
+    log.info("done deploying in base class");
+  }
+
+  @AfterEach
+  @DisplayName("Shutdown")
+  void shutdown(Vertx vertx, TestInfo testInfo) {
+    log.info("Finished: {}", testInfo.getDisplayName());
   }
 
   /**
@@ -92,15 +103,18 @@ public abstract class BaseTest {
     NetClient tcpClient = vertx.createNetClient(options);
 
     tcpClient.connect(port, "localhost", res -> {
-      System.out.println("Shaking hands...");
+      log.debug("Shaking hands...");
       NetSocket socket = res.result();
       socket.write(ncipMessage);
-      System.out.println("done writing");
+      log.debug("done writing");
 
       socket.handler(buffer -> {
         String message = buffer.getString(0, buffer.length());
         testContext.verify(() -> testHandler.handle(message));
         testContext.completeNow();
+      }).exceptionHandler(t -> {
+        log.error(t);
+        testContext.failNow(t);
       });
     });
   }

--- a/src/test/java/org/folio/edge/sip2/handlers/CheckinHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/CheckinHandlerTests.java
@@ -1,0 +1,151 @@
+package org.folio.edge.sip2.handlers;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static org.folio.edge.sip2.parser.Command.CHECKIN_RESPONSE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+import org.folio.edge.sip2.domain.messages.requests.Checkin;
+import org.folio.edge.sip2.domain.messages.responses.CheckinResponse;
+import org.folio.edge.sip2.handlers.freemarker.FreemarkerRepository;
+import org.folio.edge.sip2.repositories.CirculationRepository;
+import org.folio.edge.sip2.session.SessionData;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith({VertxExtension.class, MockitoExtension.class})
+public class CheckinHandlerTests {
+  @Test
+  public void canExecuteASampleCheckinUsingHandler(
+      @Mock CirculationRepository mockCirculationRepository,
+      Vertx vertx,
+      VertxTestContext testContext) {
+    final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+    final ZonedDateTime returnDate = ZonedDateTime.now();
+    final String institutionId = "diku";
+    final String itemIdentifier = "1234567890";
+    final String currentLocation = UUID.randomUUID().toString();
+    final Checkin checkin = Checkin.builder()
+        .noBlock(FALSE)
+        .transactionDate(ZonedDateTime.now())
+        .returnDate(returnDate)
+        .currentLocation(currentLocation)
+        .institutionId(institutionId)
+        .itemIdentifier(itemIdentifier)
+        .terminalPassword("1234")
+        .itemProperties("Some property of this item")
+        .cancel(FALSE)
+        .build();
+
+    when(mockCirculationRepository.checkin(any(), any()))
+        .thenReturn(Future.succeededFuture(CheckinResponse.builder()
+            .ok(TRUE)
+            .resensitize(TRUE)
+            .magneticMedia(null)
+            .alert(FALSE)
+            .transactionDate(ZonedDateTime.now(clock))
+            .institutionId(institutionId)
+            .itemIdentifier(itemIdentifier)
+            .permanentLocation("Main Library")
+            .build()));
+
+    final CheckinHandler handler = new CheckinHandler(mockCirculationRepository,
+        FreemarkerRepository.getInstance().getFreemarkerTemplate(CHECKIN_RESPONSE));
+
+    final SessionData sessionData = SessionData.createSession(institutionId, '|', false, "IBM850");
+
+    handler.execute(checkin, sessionData).setHandler(
+        testContext.succeeding(sipMessage -> testContext.verify(() -> {
+          final String expectedString = "101YUN"
+              + ZonedDateTime.now(clock).format(DateTimeFormatter.ofPattern("yyyyMMdd    HHmmss"))
+              + "AO" + institutionId + "|AB" + itemIdentifier + "|AQMain Library|";
+
+          assertEquals(expectedString, sipMessage);
+
+          testContext.completeNow();
+        })));
+  }
+
+  @Test
+  public void canExecuteASampleFailedCheckinUsingHandler(
+      @Mock CirculationRepository mockCirculationRepository,
+      Vertx vertx,
+      VertxTestContext testContext) {
+    final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+    final ZonedDateTime returnDate = ZonedDateTime.now();
+    final String institutionId = "diku";
+    final String itemIdentifier = "1234567890";
+    final String currentLocation = UUID.randomUUID().toString();
+    final Checkin checkin = Checkin.builder()
+        .noBlock(FALSE)
+        .transactionDate(ZonedDateTime.now())
+        .returnDate(returnDate)
+        .currentLocation(currentLocation)
+        .institutionId(institutionId)
+        .itemIdentifier(itemIdentifier)
+        .terminalPassword("1234")
+        .itemProperties("Some property of this item")
+        .cancel(FALSE)
+        .build();
+
+    when(mockCirculationRepository.checkin(any(), any()))
+        .thenReturn(Future.succeededFuture(CheckinResponse.builder()
+            .ok(FALSE)
+            .resensitize(TRUE)
+            .magneticMedia(null)
+            .alert(FALSE)
+            .transactionDate(ZonedDateTime.now(clock))
+            .institutionId(institutionId)
+            .itemIdentifier(itemIdentifier)
+            .permanentLocation("Main Library")
+            .build()));
+
+    final CheckinHandler handler = new CheckinHandler(mockCirculationRepository,
+        FreemarkerRepository.getInstance().getFreemarkerTemplate(CHECKIN_RESPONSE));
+
+    final SessionData sessionData = SessionData.createSession(institutionId, '|', false, "IBM850");
+
+    handler.execute(checkin, sessionData).setHandler(
+        testContext.succeeding(sipMessage -> testContext.verify(() -> {
+          final String expectedString = "100YUN"
+              + ZonedDateTime.now(clock).format(DateTimeFormatter.ofPattern("yyyyMMdd    HHmmss"))
+              + "AO" + institutionId + "|AB" + itemIdentifier + "|AQMain Library|";
+
+          assertEquals(expectedString, sipMessage);
+
+          testContext.completeNow();
+        })));
+  }
+
+  @Test
+  public void cannotCreateHandlerDueToMissingCirculationRepository() {
+    final NullPointerException thrown = assertThrows(
+        NullPointerException.class,
+        () -> new CheckinHandler(null, null));
+
+    assertEquals("CirculationRepository cannot be null", thrown.getMessage());
+  }
+
+  @Test
+  public void cannotCreateHandlerDueToMissingTemplate(@Mock CirculationRepository mock) {
+    final NullPointerException thrown = assertThrows(NullPointerException.class,
+        () -> new CheckinHandler(mock, null));
+
+    assertEquals("Template cannot be null", thrown.getMessage());
+  }
+}

--- a/src/test/java/org/folio/edge/sip2/handlers/HandlersFactoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/HandlersFactoryTests.java
@@ -35,13 +35,6 @@ public class HandlersFactoryTests {
   }
 
   @Test
-  public void canGetLoginHandler() {
-    ISip2RequestHandler loginHandler = HandlersFactory.getLoginHandlerInstance(null, null, null);
-    assertNotNull(loginHandler);
-    assertTrue(loginHandler instanceof LoginHandler);
-  }
-
-  @Test
   public void canGetCheckoutHandler() {
     ISip2RequestHandler checkoutHandler = HandlersFactory.getCheckoutHandlerIntance();
     assertNotNull(checkoutHandler);

--- a/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
@@ -39,7 +39,7 @@ public class SCStatusHandlerTests {
     SCStatusHandler handler = ((SCStatusHandler) HandlersFactory
         .getScStatusHandlerInstance(null, defaultConfigurationProvider, null));
 
-    handler.execute(status).setHandler(
+    handler.execute(status, null).setHandler(
         testContext.succeeding(sipMessage -> testContext.verify(() -> {
           // Because the sipMessage has a dateTime component that's supposed
           // to be current, we can't assert on the entirety of the string,
@@ -74,7 +74,7 @@ public class SCStatusHandlerTests {
 
     SCStatusHandler handler = new SCStatusHandler(configurationRepository, null);
 
-    handler.execute(status).setHandler(
+    handler.execute(status, null).setHandler(
         testContext.failing(throwable -> testContext.verify(() -> {
           assertEquals("", throwable.getMessage());
           testContext.completeNow();

--- a/src/test/java/org/folio/edge/sip2/parser/ParserTests.java
+++ b/src/test/java/org/folio/edge/sip2/parser/ParserTests.java
@@ -97,7 +97,7 @@ class ParserTests {
 
   @Test
   void testLoginParsingWithErrorDetection() {
-    final Parser parser = Parser.builder().build();
+    final Parser parser = Parser.builder().errorDetectionEnaled(TRUE).build();
     final Message<?> message = parser.parseMessage(
         "9300CNuser_id|COpassw0rd|AY1AZF594");
 
@@ -115,7 +115,7 @@ class ParserTests {
 
   @Test
   void testLoginParsingWithErrorDetectionAndBadChecksum() {
-    final Parser parser = Parser.builder().build();
+    final Parser parser = Parser.builder().errorDetectionEnaled(TRUE).build();
     final Message<?> message = parser.parseMessage(
         "9300CNuser_id|COpassw0rd|AY1AZF595");
 
@@ -564,7 +564,7 @@ class ParserTests {
 
   @Test
   void testRenewAllParsingWithErrorDetection() {
-    final Parser parser = Parser.builder().build();
+    final Parser parser = Parser.builder().errorDetectionEnaled(TRUE).build();
 
     final ZonedDateTime transactionDate =
         ZonedDateTime.now().truncatedTo(SECONDS);
@@ -593,7 +593,7 @@ class ParserTests {
 
   @Test
   void testRenewAllParsingWithErrorDetectionAndKnownSequenceNumber() {
-    final Parser parser = Parser.builder().build();
+    final Parser parser = Parser.builder().errorDetectionEnaled(TRUE).build();
 
     final int sequenceNumber = 1;
     final ZonedDateTime transactionDate =

--- a/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
@@ -1,0 +1,106 @@
+package org.folio.edge.sip2.repositories;
+
+import static java.lang.Boolean.FALSE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+
+import io.vertx.core.Future;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+import org.folio.edge.sip2.domain.messages.requests.Checkin;
+import org.folio.edge.sip2.session.SessionData;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith({VertxExtension.class, MockitoExtension.class})
+public class CirculationRepositoryTests {
+
+  @Test
+  public void canCreateCirculationRepository(
+      @Mock IResourceProvider<IRequestData> mockFolioResource, @Mock Clock clock) {
+    final CirculationRepository circulationRepository =
+        new CirculationRepository(mockFolioResource, clock);
+
+    assertNotNull(circulationRepository);
+  }
+
+  @Test
+  public void cannotCreateCircilationRepositoryWhenResourceProviderIsNull() {
+    final NullPointerException thrown = assertThrows(
+        NullPointerException.class,
+        () -> new CirculationRepository(null, null));
+
+    assertEquals("Resource provider cannot be null", thrown.getMessage());
+  }
+
+  @Test
+  public void canCheckin(Vertx vertx,
+      VertxTestContext testContext,
+      @Mock IResourceProvider<IRequestData> mockFolioProvider) {
+    final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+    final ZonedDateTime returnDate = ZonedDateTime.now();
+    final String currentLocation = UUID.randomUUID().toString();
+    final String itemIdentifier = "1234567890";
+    final Checkin checkin = Checkin.builder()
+        .noBlock(FALSE)
+        .transactionDate(ZonedDateTime.now())
+        .returnDate(returnDate)
+        .currentLocation(currentLocation)
+        .institutionId("diku")
+        .itemIdentifier(itemIdentifier)
+        .terminalPassword("1234")
+        .itemProperties("Some property of this item")
+        .cancel(FALSE)
+        .build();
+
+    final JsonObject response = new JsonObject()
+        .put("item", new JsonObject()
+            .put("location", new JsonObject()
+                .put("name", "Main Library")));
+    when(mockFolioProvider.createResource(any()))
+        .thenReturn(Future.succeededFuture(new FolioResource(response,
+            MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
+
+    final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
+
+    final CirculationRepository circulationRepository =
+        new CirculationRepository(mockFolioProvider, clock);
+    circulationRepository.checkin(checkin, sessionData).setHandler(
+        testContext.succeeding(checkinResponse -> testContext.verify(() -> {
+          assertNotNull(checkinResponse);
+          assertTrue(checkinResponse.getOk());
+          assertTrue(checkinResponse.getResensitize());
+          assertNull(checkinResponse.getMagneticMedia());
+          assertFalse(checkinResponse.getAlert());
+          assertEquals(ZonedDateTime.now(clock), checkinResponse.getTransactionDate());
+          assertEquals("diku", checkinResponse.getInstitutionId());
+          assertEquals(itemIdentifier, checkinResponse.getItemIdentifier());
+          assertEquals("Main Library", checkinResponse.getPermanentLocation());
+          assertNull(checkinResponse.getTitleIdentifier());
+          assertNull(checkinResponse.getSortBin());
+          assertNull(checkinResponse.getPatronIdentifier());
+          assertNull(checkinResponse.getMediaType());
+          assertNull(checkinResponse.getItemProperties());
+          assertNull(checkinResponse.getScreenMessage());
+          assertNull(checkinResponse.getPrintLine());
+
+          testContext.completeNow();
+        })));
+  }
+}

--- a/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
@@ -41,7 +41,7 @@ public class CirculationRepositoryTests {
   }
 
   @Test
-  public void cannotCreateCircilationRepositoryWhenResourceProviderIsNull() {
+  public void cannotCreateCirculationRepositoryWhenResourceProviderIsNull() {
     final NullPointerException thrown = assertThrows(
         NullPointerException.class,
         () -> new CirculationRepository(null, null));

--- a/src/test/java/org/folio/edge/sip2/repositories/ConfigurationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/ConfigurationRepositoryTests.java
@@ -73,7 +73,7 @@ public class ConfigurationRepositoryTests {
     @SuppressWarnings("unchecked")
     IResourceProvider<Object> mockConfigProvider = mock(IResourceProvider.class);
     when(mockConfigProvider.retrieveResource(null))
-      .thenReturn(Future.succeededFuture(defaultConfigurations));
+      .thenReturn(Future.succeededFuture(() -> defaultConfigurations));
 
     ConfigurationRepository configurationRepository =
         new ConfigurationRepository(mockConfigProvider);

--- a/src/test/java/org/folio/edge/sip2/repositories/DefaultResourceProviderTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/DefaultResourceProviderTests.java
@@ -26,12 +26,12 @@ public class DefaultResourceProviderTests {
       VertxTestContext testContext) {
     DefaultResourceProvider defaultConfigurationProvider = new DefaultResourceProvider();
     defaultConfigurationProvider.retrieveResource(null).setHandler(
-        testContext.succeeding(jsonConfig -> testContext.verify(() -> {
-
+        testContext.succeeding(resource -> testContext.verify(() -> {
+          final JsonObject jsonConfig = resource.getResource();
           assertNotNull(jsonConfig);
-      
+
           JsonObject acsConfig = jsonConfig.getJsonObject("acsConfiguration");
-      
+
           assertEquals("fs00000010test", acsConfig.getString("institutionId"));
           assertEquals("1.23", acsConfig.getString("protocolVersion"));
 
@@ -46,13 +46,13 @@ public class DefaultResourceProviderTests {
 
     DefaultResourceProvider defaultConfigurationProvider = new DefaultResourceProvider();
     defaultConfigurationProvider.retrieveResource(null).setHandler(
-        testContext.succeeding(jsonConfig -> testContext.verify(() -> {
-
+        testContext.succeeding(resource -> testContext.verify(() -> {
+          final JsonObject jsonConfig = resource.getResource();
           assertNotNull(jsonConfig);
-      
+
           JsonArray tenantConfigs = jsonConfig.getJsonArray("tenantConfigurations");
           JsonObject firstTenantConfig = tenantConfigs.getJsonObject(0);
-      
+
           assertEquals("fs00000010test", firstTenantConfig.getString("tenantId"));
           assertEquals("ASCII", firstTenantConfig.getString("encoding"));
 

--- a/src/test/java/org/folio/edge/sip2/repositories/FolioResourceProviderTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/FolioResourceProviderTests.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+import org.folio.edge.sip2.session.SessionData;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -75,7 +76,7 @@ public class FolioResourceProviderTests {
       VertxTestContext testContext) {
     final FolioResourceProvider folioResourceProvider =
         new FolioResourceProvider("http://localhost:" + port, vertx);
-    folioResourceProvider.retrieveResource(() -> "/test_retrieve").setHandler(
+    folioResourceProvider.retrieveResource((FolioRequestData)() -> "/test_retrieve").setHandler(
         testContext.succeeding(resource -> testContext.verify(() -> {
           final JsonObject jo = resource.getResource();
 
@@ -93,7 +94,7 @@ public class FolioResourceProviderTests {
       VertxTestContext testContext) {
     final FolioResourceProvider folioResourceProvider =
         new FolioResourceProvider("http://localhost:" + port, vertx);
-    folioResourceProvider.retrieveResource(() -> "/test_retrieve_bad")
+    folioResourceProvider.retrieveResource((FolioRequestData)() -> "/test_retrieve_bad")
         .setHandler(testContext.failing(throwable -> testContext.verify(() -> {
           assertNotNull(throwable);
           assertEquals("Response status code 500 is not equal to 200",
@@ -109,7 +110,7 @@ public class FolioResourceProviderTests {
       VertxTestContext testContext) {
     final FolioResourceProvider folioResourceProvider =
         new FolioResourceProvider("http://localhost:" + port, vertx);
-    folioResourceProvider.createResource(() -> "/test_create").setHandler(
+    folioResourceProvider.createResource((FolioRequestData)() -> "/test_create").setHandler(
         testContext.succeeding(resource -> testContext.verify(() -> {
           final JsonObject jo = resource.getResource();
 
@@ -127,7 +128,7 @@ public class FolioResourceProviderTests {
       VertxTestContext testContext) {
     final FolioResourceProvider folioResourceProvider =
         new FolioResourceProvider("http://localhost:" + port, vertx);
-    folioResourceProvider.createResource(() -> "/test_create_bad")
+    folioResourceProvider.createResource((FolioRequestData)() -> "/test_create_bad")
         .setHandler(testContext.failing(throwable -> testContext.verify(() -> {
           assertNotNull(throwable);
           assertEquals("Response status code 500 is not between 200 and 300",
@@ -152,5 +153,12 @@ public class FolioResourceProviderTests {
     } while (true);
 
     return port;
+  }
+
+  private interface FolioRequestData extends IRequestData {
+    @Override
+    default SessionData getSessionData() {
+      return SessionData.createSession("diku", '|', true, "IBM850");
+    }
   }
 }

--- a/src/test/java/org/folio/edge/sip2/repositories/FolioResourceProviderTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/FolioResourceProviderTests.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.io.IOException;
@@ -61,7 +62,7 @@ public class FolioResourceProviderTests {
       Vertx vertx,
       VertxTestContext testContext) {
     final FolioResourceProvider folioResourceProvider =
-        new FolioResourceProvider("http://example.com", "diku", vertx);
+        new FolioResourceProvider("http://example.com", vertx);
 
     assertNotNull(folioResourceProvider);
 
@@ -73,9 +74,11 @@ public class FolioResourceProviderTests {
       Vertx vertx,
       VertxTestContext testContext) {
     final FolioResourceProvider folioResourceProvider =
-        new FolioResourceProvider("http://localhost:" + port, "diku", vertx);
+        new FolioResourceProvider("http://localhost:" + port, vertx);
     folioResourceProvider.retrieveResource(() -> "/test_retrieve").setHandler(
-        testContext.succeeding(jo -> testContext.verify(() -> {
+        testContext.succeeding(resource -> testContext.verify(() -> {
+          final JsonObject jo = resource.getResource();
+
           assertNotNull(jo);
           assertTrue(jo.containsKey("test"));
           assertEquals("value", jo.getString("test"));
@@ -89,7 +92,7 @@ public class FolioResourceProviderTests {
       Vertx vertx,
       VertxTestContext testContext) {
     final FolioResourceProvider folioResourceProvider =
-        new FolioResourceProvider("http://localhost:" + port, "diku", vertx);
+        new FolioResourceProvider("http://localhost:" + port, vertx);
     folioResourceProvider.retrieveResource(() -> "/test_retrieve_bad")
         .setHandler(testContext.failing(throwable -> testContext.verify(() -> {
           assertNotNull(throwable);
@@ -105,9 +108,11 @@ public class FolioResourceProviderTests {
       Vertx vertx,
       VertxTestContext testContext) {
     final FolioResourceProvider folioResourceProvider =
-        new FolioResourceProvider("http://localhost:" + port, "diku", vertx);
+        new FolioResourceProvider("http://localhost:" + port, vertx);
     folioResourceProvider.createResource(() -> "/test_create").setHandler(
-        testContext.succeeding(jo -> testContext.verify(() -> {
+        testContext.succeeding(resource -> testContext.verify(() -> {
+          final JsonObject jo = resource.getResource();
+
           assertNotNull(jo);
           assertTrue(jo.containsKey("test"));
           assertEquals("value", jo.getString("test"));
@@ -121,11 +126,11 @@ public class FolioResourceProviderTests {
       Vertx vertx,
       VertxTestContext testContext) {
     final FolioResourceProvider folioResourceProvider =
-        new FolioResourceProvider("http://localhost:" + port, "diku", vertx);
+        new FolioResourceProvider("http://localhost:" + port, vertx);
     folioResourceProvider.createResource(() -> "/test_create_bad")
         .setHandler(testContext.failing(throwable -> testContext.verify(() -> {
           assertNotNull(throwable);
-          assertEquals("Response status code 500 is not equal to 201",
+          assertEquals("Response status code 500 is not between 200 and 300",
               throwable.getMessage());
 
           testContext.completeNow();

--- a/src/test/java/org/folio/edge/sip2/session/SessionDataTests.java
+++ b/src/test/java/org/folio/edge/sip2/session/SessionDataTests.java
@@ -1,0 +1,120 @@
+package org.folio.edge.sip2.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SessionDataTests {
+  final String tenant = "diku";
+  final char fieldDelimiter = '|';
+  final boolean errorDetectionEnabled = true;
+  final String charset = "IBM850";
+  final String authenticationToken = "abc123";
+  final int maxWidth = 25;
+  final String password = "xyzzy";
+  final String scLocation = "pluto";
+  final String username = "jsmith";
+  SessionData sessionData;
+
+  @BeforeEach
+  void setup() {
+    sessionData = SessionData.createSession(tenant, fieldDelimiter, errorDetectionEnabled, charset);
+    sessionData.setAuthenticationToken(authenticationToken);
+    sessionData.setMaxPrintWidth(maxWidth);
+    sessionData.setPassword(password);
+    sessionData.setScLocation(scLocation);
+    sessionData.setUsername(username);
+  }
+
+  @Test
+  void testGetScLocation() {
+    assertEquals(scLocation, sessionData.getScLocation());
+  }
+
+  @Test
+  void testSetScLocation() {
+    sessionData.setScLocation("jupiter");
+    assertEquals("jupiter", sessionData.getScLocation());
+  }
+
+  @Test
+  void testGetAuthenticationToken() {
+    assertEquals(authenticationToken, sessionData.getAuthenticationToken());
+  }
+
+  @Test
+  void testSetAuthenticationToken() {
+    sessionData.setAuthenticationToken("890xyz");
+    assertEquals("890xyz", sessionData.getAuthenticationToken());
+  }
+
+  @Test
+  void testGetMaxPrintWidth() {
+    assertEquals(maxWidth, sessionData.getMaxPrintWidth());
+  }
+
+  @Test
+  void testSetMaxPrintWidth() {
+    sessionData.setMaxPrintWidth(100);
+    assertEquals(100, sessionData.getMaxPrintWidth());
+  }
+
+  @Test
+  void testGetUsername() {
+    assertEquals(username, sessionData.getUsername());
+  }
+
+  @Test
+  void testSetUsername() {
+    sessionData.setUsername("jdoe");
+    assertEquals("jdoe", sessionData.getUsername());
+  }
+
+  @Test
+  void testGetPassword() {
+    assertEquals(password, sessionData.getPassword());
+  }
+
+  @Test
+  void testSetPassword() {
+    sessionData.setPassword("plugh");
+    assertEquals("plugh", sessionData.getPassword());
+  }
+
+  @Test
+  void testGetFieldDelimiter() {
+    assertEquals(fieldDelimiter, sessionData.getFieldDelimiter());
+  }
+
+  @Test
+  void testGetTenant() {
+    assertEquals(tenant, sessionData.getTenant());
+  }
+
+  @Test
+  void testIsErrorDetectionEnabled() {
+    assertEquals(errorDetectionEnabled, sessionData.isErrorDetectionEnabled());
+  }
+
+  @Test
+  void testGetCharset() {
+    assertEquals(charset, sessionData.getCharset());
+  }
+
+  @Test
+  void testCreateSession() {
+    final SessionData newSessionData = SessionData.createSession("xxx", '^', false, "UTF-8");
+    assertEquals("xxx", newSessionData.getTenant());
+    assertEquals('^', newSessionData.getFieldDelimiter());
+    assertFalse(newSessionData.isErrorDetectionEnabled());
+    assertEquals("UTF-8", newSessionData.getCharset());
+    assertNull(newSessionData.getAuthenticationToken());
+    assertEquals(-1, newSessionData.getMaxPrintWidth());
+    assertNull(newSessionData.getPassword());
+    assertNull(newSessionData.getScLocation());
+    assertNull(newSessionData.getUsername());
+  }
+}


### PR DESCRIPTION
The module now can respond to the `Checkin` command. There is still work to determine the values of certain response fields, such as:
- resensitize (assuming Y on checkin success)
- magnetic media (assuming U)
- alert (assuming N)
- permanent location (using the effective location of the item now, to get the permanent location we will need to call inventory)
- title identifier (not setting)
- sort bin (not setting)
- patron identifier (not setting, will need to call mod-users to ge the barcode when a checkin is done on an item with an existing loan)
- media type (not setting)
- item properties (not setting)
- screen message (not setting, though may put error messages in here at some point)
- print line (not setting, no idea what to put in here)

Most of these fields are not required and we'll discover what institutions use the fields for as we go.

As part of getting checkin coded, some refactoring was done. Notably:
- Introduced dependency injection via Google guice. Dependencies were getting complicated and passing them around was leading to boiler plate code. Eliminated some of that via dependency injection. Started with trying to figure out clock management without writing a time machine.
- Added error detection on the outbound messages as well as the message terminator. Error detection is now a config property that should be set per tenant (when we get there).
- Refactored code to use a "session" object created when the client connects. This object stores the auth token for subsequent calls as well as many other properties that would be relevant to the session. This object might be a candidate for injection...
