### PR TITLE
Implemented ACS Request Resend command (SIP2-12)

### DIFF
--- a/src/main/java/org/folio/edge/sip2/domain/PreviousMessage.java
+++ b/src/main/java/org/folio/edge/sip2/domain/PreviousMessage.java
@@ -1,0 +1,38 @@
+package org.folio.edge.sip2.domain;
+
+import org.folio.edge.sip2.parser.Message;
+
+/**
+ * Class that defines the data structure for the previous message's request + response pair.
+ */
+public class PreviousMessage {
+  private int previousRequestSequenceNo;
+  private String previousRequestChecksum;
+  private String previousMessageResponse;
+
+  /**
+   * Constructor that constructs the PreviousMessage instance.
+   *
+   * @param message - The parsed request object
+   * @param response - the SIP response that corresponds to the @message.
+   */
+  public PreviousMessage(Message<Object> message, String response) {
+    if (message.isErrorDetectionEnabled()) {
+      previousRequestSequenceNo = message.getSequenceNumber();
+      previousRequestChecksum = message.getChecksumsString();
+    }
+    previousMessageResponse = response;
+  }
+
+  public String getPreviousMessageResponse() {
+    return previousMessageResponse;
+  }
+
+  public String getPreviousRequestChecksum() {
+    return previousRequestChecksum;
+  }
+
+  public int getPreviousRequestSequenceNo() {
+    return previousRequestSequenceNo;
+  }
+}

--- a/src/main/java/org/folio/edge/sip2/handlers/ACSResendHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/ACSResendHandler.java
@@ -1,0 +1,26 @@
+package org.folio.edge.sip2.handlers;
+
+import io.vertx.core.Future;
+
+import org.folio.edge.sip2.domain.PreviousMessage;
+import org.folio.edge.sip2.parser.Message;
+import org.folio.edge.sip2.repositories.HistoricalMessageRepository;
+
+
+public class ACSResendHandler implements ISip2RequestHandler {
+
+  @Override
+  public Future<String> execute(Object message) {
+    PreviousMessage prevMessage = HistoricalMessageRepository.getPreviousMessage();
+
+    if (prevMessage == null) {
+      return Future.failedFuture("PreviousMessage is NULL");
+    }
+    return Future.succeededFuture(prevMessage.getPreviousMessageResponse());
+  }
+
+  @Override
+  public void writeHistory(Message<Object> request, String response) {
+    //Do nothing. No need to save a response for the 97 message.
+  }
+}

--- a/src/main/java/org/folio/edge/sip2/handlers/HandlersFactory.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/HandlersFactory.java
@@ -46,7 +46,7 @@ public class HandlersFactory {
 
   /**
    * Returns a Login Response command handler with the specified arguments.
-   * 
+   *
    * @param loginRepository a store of login data
    * @param resourceProvider a service for interacting with resources
    * @param commandTemplate the template for SIP2 command output
@@ -89,5 +89,9 @@ public class HandlersFactory {
     }
 
     return commandTemplate;
+  }
+
+  public static ISip2RequestHandler getACSResendHandler() {
+    return new ACSResendHandler();
   }
 }

--- a/src/main/java/org/folio/edge/sip2/handlers/ISip2RequestHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/ISip2RequestHandler.java
@@ -2,6 +2,25 @@ package org.folio.edge.sip2.handlers;
 
 import io.vertx.core.Future;
 
+import org.folio.edge.sip2.parser.Message;
+import org.folio.edge.sip2.repositories.HistoricalMessageRepository;
+
+
 public interface ISip2RequestHandler {
+
+  /**
+   * Handle the request and prepare a SIP response to send back.
+   * @param message  Request message that contains all the information needed to fill the response.
+   * @return  SIP response string
+   */
   Future<String> execute(Object message);
+
+  /**
+   * Save the current request/response as a history item (for the next request).
+   * @param request A parsed SIP request object
+   * @param response SIP response for the passed in request
+   */
+  default void writeHistory(Message<Object> request, String response) {
+    HistoricalMessageRepository.setPreviousMessage(request, response);
+  }
 }

--- a/src/main/java/org/folio/edge/sip2/handlers/LoginHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/LoginHandler.java
@@ -43,7 +43,7 @@ public class LoginHandler implements ISip2RequestHandler {
 
     return responseFuture.compose(loginResponse -> {
       log.debug("LoginResponse: {}", () -> loginResponse);
-  
+
       final Map<String, Object> root = new HashMap<>();
       root.put("formatDateTime", new FormatDateTimeMethodModel());
       root.put("delimiter", "|");

--- a/src/main/java/org/folio/edge/sip2/handlers/SCStatusHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/SCStatusHandler.java
@@ -46,15 +46,15 @@ public class SCStatusHandler implements ISip2RequestHandler {
           new PackagedSupportedMessages(acsStatus.getSupportedMessages()));
       root.put("ACSStatus",acsStatus);
       root.put("formatDateTime", new FormatDateTimeMethodModel());
-  
+
       if (template == null) {
         log.error("Unable to locate Freemarker template for the command: " + ACS_STATUS.name());
         return Future.failedFuture("");
       }
-  
+
       String acsSipStatusMessage = FreemarkerUtils.executeFreemarkerTemplate(root, template);
       log.debug("Sip2 ACSStatus message: " + acsSipStatusMessage);
-  
+
       return Future.succeededFuture(acsSipStatusMessage);
     });
   }

--- a/src/main/java/org/folio/edge/sip2/repositories/HistoricalMessageRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/HistoricalMessageRepository.java
@@ -1,0 +1,31 @@
+package org.folio.edge.sip2.repositories;
+
+import org.folio.edge.sip2.domain.PreviousMessage;
+import org.folio.edge.sip2.parser.Message;
+
+/**
+ * Class that manages the previous message's request + response pair.
+ */
+public class HistoricalMessageRepository {
+
+  private static PreviousMessage previousMessage;
+
+  /**
+   * A getter that returns the previous pair of request and response messages.
+   * @return Returns previous message stored.
+   */
+  public static PreviousMessage getPreviousMessage() {
+    return previousMessage;
+  }
+
+  /**
+   * Method to set the previous message.  The "previous" message is the current outgoing message.
+   *
+   * @param message The parsed request message
+   * @param response the entire response message that corresponds to the request message.
+   *
+   **/
+  public static void setPreviousMessage(Message<Object> message, String response) {
+    previousMessage = new PreviousMessage(message, response);
+  }
+}

--- a/src/test/java/org/folio/edge/sip2/api/support/BaseTest.java
+++ b/src/test/java/org/folio/edge/sip2/api/support/BaseTest.java
@@ -25,6 +25,7 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.folio.edge.sip2.MainVerticle;
+import org.folio.edge.sip2.handlers.ACSResendHandler;
 import org.folio.edge.sip2.handlers.ISip2RequestHandler;
 import org.folio.edge.sip2.handlers.LoginHandler;
 import org.folio.edge.sip2.handlers.freemarker.FreemarkerRepository;
@@ -57,7 +58,6 @@ public abstract class BaseTest {
   @BeforeEach
   @DisplayName("Deploy the verticle")
   public void deployVerticle(Vertx vertx, VertxTestContext testContext, TestInfo testInfo) {
-
     DeploymentOptions opt = new DeploymentOptions();
 
     JsonObject sipConfig = new JsonObject();
@@ -130,6 +130,7 @@ public abstract class BaseTest {
       EnumMap<Command, ISip2RequestHandler> requestHandlerMap =
           new EnumMap<>(Command.class);
       requestHandlerMap.put(Command.LOGIN, loginHandler);
+      requestHandlerMap.put(Command.REQUEST_ACS_RESEND, new ACSResendHandler());
 
       myVerticle = new MainVerticle(requestHandlerMap);
 
@@ -139,7 +140,7 @@ public abstract class BaseTest {
   }
 
   private static int getRandomPort() {
-    int port = -1;
+    int port;
     do {
       // Use a random ephemeral port
       port = new Random().nextInt(16_384) + 49_152;

--- a/src/test/java/org/folio/edge/sip2/handlers/HandlersFactoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/HandlersFactoryTests.java
@@ -47,4 +47,11 @@ public class HandlersFactoryTests {
     assertNotNull(checkoutHandler);
     assertTrue(checkoutHandler instanceof CheckoutHandler);
   }
+
+  @Test
+  public void canGetAcsResendHandler() {
+    ISip2RequestHandler acsResendHandler = HandlersFactory.getACSResendHandler();
+    assertNotNull(acsResendHandler);
+    assertTrue(acsResendHandler instanceof ACSResendHandler);
+  }
 }

--- a/src/test/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerRepositoryTests.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import freemarker.template.Template;
-import org.folio.edge.sip2.handlers.freemarker.FreemarkerRepository;
+
 import org.folio.edge.sip2.parser.Command;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerUtilsTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerUtilsTests.java
@@ -3,18 +3,19 @@ package org.folio.edge.sip2.handlers.freemarker;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import freemarker.template.Template;
+
 import java.util.Date;
 
-import org.folio.edge.sip2.handlers.freemarker.FreemarkerRepository;
-import org.folio.edge.sip2.handlers.freemarker.FreemarkerUtils;
 import org.folio.edge.sip2.parser.Command;
+
 import org.junit.jupiter.api.Test;
+
 
 public class FreemarkerUtilsTests {
   @Test
   public void cannotExecuteFreemarkerTemplateGivenNullData() {
     Template acsStatusTemplate = FreemarkerRepository.getInstance()
-        .getFreemarkerTemplate(Command.ACS_STATUS);
+                                    .getFreemarkerTemplate(Command.ACS_STATUS);
     String result = FreemarkerUtils.executeFreemarkerTemplate(null, acsStatusTemplate);
     assertEquals("", result);
   }
@@ -23,7 +24,7 @@ public class FreemarkerUtilsTests {
   public void cannotExecuteFreemarkerTemplateGivenInvalidData() {
     Object data = new Date(); //give it some bogus class
     Template acsStatusTemplate = FreemarkerRepository.getInstance()
-        .getFreemarkerTemplate(Command.ACS_STATUS);
+                                    .getFreemarkerTemplate(Command.ACS_STATUS);
     String result = FreemarkerUtils.executeFreemarkerTemplate(data, acsStatusTemplate);
     assertEquals("", result);
   }

--- a/src/test/java/org/folio/edge/sip2/repositories/DefaultResourceProviderTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/DefaultResourceProviderTests.java
@@ -29,9 +29,9 @@ public class DefaultResourceProviderTests {
         testContext.succeeding(jsonConfig -> testContext.verify(() -> {
 
           assertNotNull(jsonConfig);
-      
+
           JsonObject acsConfig = jsonConfig.getJsonObject("acsConfiguration");
-      
+
           assertEquals("fs00000010test", acsConfig.getString("institutionId"));
           assertEquals("1.23", acsConfig.getString("protocolVersion"));
 
@@ -49,10 +49,10 @@ public class DefaultResourceProviderTests {
         testContext.succeeding(jsonConfig -> testContext.verify(() -> {
 
           assertNotNull(jsonConfig);
-      
+
           JsonArray tenantConfigs = jsonConfig.getJsonArray("tenantConfigurations");
           JsonObject firstTenantConfig = tenantConfigs.getJsonObject(0);
-      
+
           assertEquals("fs00000010test", firstTenantConfig.getString("tenantId"));
           assertEquals("ASCII", firstTenantConfig.getString("encoding"));
 

--- a/src/test/java/org/folio/edge/sip2/repositories/HistoricalMessageRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/HistoricalMessageRepositoryTests.java
@@ -1,0 +1,34 @@
+package org.folio.edge.sip2.repositories;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.folio.edge.sip2.domain.PreviousMessage;
+import org.folio.edge.sip2.parser.Message;
+import org.junit.jupiter.api.Test;
+
+public class HistoricalMessageRepositoryTests {
+
+  @Test
+  public void canSetAndGetPreviousMessage() {
+    final int expectedSeqNo = 9;
+    final String expectedChecksum = "AABBCC";
+    final String expectedResponse = "this is a SIP response";
+
+    Message.MessageBuilder builder = Message.builder();
+    builder.sequenceNumber(expectedSeqNo);
+    builder.checksumString(expectedChecksum);
+    builder.valid(true);
+    builder.build();
+
+    Message<Object> sampleMessage = new Message<>(builder);
+
+    HistoricalMessageRepository.setPreviousMessage(sampleMessage, expectedResponse);
+    PreviousMessage prevMsg = HistoricalMessageRepository.getPreviousMessage();
+
+    assertNotNull(prevMsg);
+    assertEquals(expectedSeqNo, prevMsg.getPreviousRequestSequenceNo());
+    assertEquals(expectedChecksum, prevMsg.getPreviousRequestChecksum());
+    assertEquals(expectedResponse, prevMsg.getPreviousMessageResponse());
+  }
+}


### PR DESCRIPTION
Added a default method to ISip2RequestHandler to save the message to "session" so that it can be referenced in the next request.  This method is called by MainVerticle.  Ideally it should be silently invoked by each of the handler itself.  Only ACSResendHandler does not need to write its response to the session. 

"Session" is implemented as a static variable for now, which is available to all sessions :D. Will change it once the formal session implementation is merged in. 

