### PR TITLE
SIP2-47: Add checkout support to edge-sip2

### DIFF
--- a/src/main/java/org/folio/edge/sip2/handlers/CheckoutHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/CheckoutHandler.java
@@ -1,19 +1,58 @@
 package org.folio.edge.sip2.handlers;
 
+import freemarker.template.Template;
 import io.vertx.core.Future;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.domain.messages.requests.Checkout;
+import org.folio.edge.sip2.domain.messages.responses.CheckoutResponse;
+import org.folio.edge.sip2.handlers.freemarker.FormatDateTimeMethodModel;
+import org.folio.edge.sip2.handlers.freemarker.FreemarkerUtils;
+import org.folio.edge.sip2.repositories.CirculationRepository;
 import org.folio.edge.sip2.session.SessionData;
 
 public class CheckoutHandler implements ISip2RequestHandler {
+  private static final Logger log = LogManager.getLogger();
+
+  private final CirculationRepository circulationRepository;
+  private final Template commandTemplate;
+
+  @Inject
+  CheckoutHandler(
+      CirculationRepository circulationRepository,
+      @Named("checkoutResponse") Template commandTemplate) {
+    this.circulationRepository = Objects.requireNonNull(circulationRepository,
+        "CirculationRepository cannot be null");
+    this.commandTemplate = Objects.requireNonNull(commandTemplate, "Template cannot be null");
+  }
 
   @Override
   public Future<String> execute(Object message, SessionData sessionData) {
     final Checkout checkout = (Checkout) message;
-    //call FOLIO
 
-    //format into SIP message
-    return Future.succeededFuture("Successfully checked out "
-        + checkout.toString());
+    log.debug("Checkout: {}", () -> checkout);
 
+    final Future<CheckoutResponse> circulationFuture =
+        circulationRepository.checkout(checkout, sessionData);
+
+    return circulationFuture.compose(checkoutResponse -> {
+      log.debug("CheckoutResponse: {}", () -> checkoutResponse);
+
+      final Map<String, Object> root = new HashMap<>();
+      root.put("formatDateTime", new FormatDateTimeMethodModel());
+      root.put("delimiter", sessionData.getFieldDelimiter());
+      root.put("checkoutResponse", checkoutResponse);
+
+      final String response = FreemarkerUtils.executeFreemarkerTemplate(root, commandTemplate);
+
+      log.debug("SIP checkout response: {}", response);
+
+      return Future.succeededFuture(response);
+    });
   }
 }

--- a/src/main/java/org/folio/edge/sip2/handlers/HandlersFactory.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/HandlersFactory.java
@@ -40,10 +40,6 @@ public class HandlersFactory {
     return new SCStatusHandler(configRepo, freeMarkerTemplate);
   }
 
-  public static ISip2RequestHandler getCheckoutHandlerIntance() {
-    return new CheckoutHandler();
-  }
-
   public static ISip2RequestHandler getInvalidMessageHandler() {
     return new InvalidMessageHandler();
   }

--- a/src/main/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerRepository.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerRepository.java
@@ -56,6 +56,7 @@ public class FreemarkerRepository {
     addTemplate(Command.ACS_STATUS, "acs-status.ftl", configuration);
     addTemplate(Command.LOGIN_RESPONSE, "LoginResponse.ftl", configuration);
     addTemplate(Command.CHECKIN_RESPONSE, "CheckinResponse.ftl", configuration);
+    addTemplate(Command.CHECKOUT_RESPONSE, "CheckoutResponse.ftl", configuration);
     addTemplate(Command.REQUEST_SC_RESEND, "RequestSCResend.ftl", configuration);
   }
 

--- a/src/main/java/org/folio/edge/sip2/modules/ApplicationModule.java
+++ b/src/main/java/org/folio/edge/sip2/modules/ApplicationModule.java
@@ -1,6 +1,7 @@
 package org.folio.edge.sip2.modules;
 
 import static org.folio.edge.sip2.parser.Command.CHECKIN_RESPONSE;
+import static org.folio.edge.sip2.parser.Command.CHECKOUT_RESPONSE;
 import static org.folio.edge.sip2.parser.Command.LOGIN_RESPONSE;
 
 import com.google.inject.AbstractModule;
@@ -36,6 +37,12 @@ public class ApplicationModule extends AbstractModule {
   @Named("checkinResponse")
   Template provideCheckinResponseTemplate() {
     return FreemarkerRepository.getInstance().getFreemarkerTemplate(CHECKIN_RESPONSE);
+  }
+
+  @Provides
+  @Named("checkoutResponse")
+  Template provideCheckoutResponseTemplate() {
+    return FreemarkerRepository.getInstance().getFreemarkerTemplate(CHECKOUT_RESPONSE);
   }
 
   @Provides

--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -28,7 +28,7 @@ import org.folio.edge.sip2.session.SessionData;
  */
 public class CirculationRepository {
   // Should consider letting the template take care of required fields with missing values
-  private static final String UNKNOWN = "Unknown";
+  private static final String UNKNOWN = "";
   private final IResourceProvider<IRequestData> resourceProvider;
   private final Clock clock;
 
@@ -69,7 +69,7 @@ public class CirculationRepository {
         .createResource(checkinRequestData);
 
     return result
-        .otherwiseEmpty()
+        .otherwise(() -> null)
         .compose(resource -> Future.succeededFuture(
             CheckinResponse.builder()
               .ok(resource.getResource() == null ? FALSE : TRUE)
@@ -115,7 +115,7 @@ public class CirculationRepository {
     final Future<IResource> result = resourceProvider.createResource(checkoutRequestData);
 
     return result
-        .otherwiseEmpty()
+        .otherwise(() -> null)
         .compose(resource -> {
           final ZonedDateTime dueDate;
           // This is a mess. Need to clean this up. The problem here is that the checkout has

--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -167,8 +167,6 @@ public class CirculationRepository {
       this.sessionData = sessionData;
     }
 
-    public abstract String getPath();
-
     @Override
     public Map<String, String> getHeaders() {
       return headers;

--- a/src/main/java/org/folio/edge/sip2/repositories/FolioResourceProvider.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/FolioResourceProvider.java
@@ -74,6 +74,10 @@ public class FolioResourceProvider implements IResourceProvider<IRequestData> {
 
   @Override
   public Future<IResource> createResource(IRequestData requestData) {
+    log.debug("Create resource {}, body: {}",
+        requestData::getPath,
+        () -> requestData.getBody().encodePrettily());
+
     final HttpRequest<Buffer> request =
         client.postAbs(okapiUrl + requestData.getPath());
 

--- a/src/main/java/org/folio/edge/sip2/repositories/LoginRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/LoginRepository.java
@@ -40,14 +40,14 @@ public class LoginRepository {
   public Future<LoginResponse> login(Login login, SessionData sessionData) {
     final String user = login.getLoginUserId();
     final String password = login.getLoginPassword();
-    // We'll need to figure out what to do with the location code
+    final String locationCode = login.getLocationCode();
 
     final JsonObject credentials = new JsonObject()
         .put("username", user)
         .put("password", password);
     
     final Future<IResource> result = resourceProvider
-        .createResource(new LoginRequestData(credentials));
+        .createResource(new LoginRequestData(credentials, sessionData));
 
     return result
         .otherwiseEmpty()
@@ -59,6 +59,7 @@ public class LoginRepository {
             return Future.succeededFuture(LoginResponse.builder().ok(FALSE).build());
           }
           sessionData.setAuthenticationToken(authenticationToken);
+          sessionData.setScLocation(locationCode);
           return Future.succeededFuture(
             LoginResponse.builder()
               .ok(resource.getResource() == null ? FALSE : TRUE)
@@ -68,9 +69,11 @@ public class LoginRepository {
 
   private class LoginRequestData implements IRequestData {
     private final JsonObject body;
+    private final SessionData sessionData;
 
-    private LoginRequestData(JsonObject body) {
+    private LoginRequestData(JsonObject body, SessionData sessionData) {
       this.body = body;
+      this.sessionData = sessionData;
     }
 
     @Override
@@ -88,6 +91,11 @@ public class LoginRepository {
     @Override
     public JsonObject getBody() {
       return body;
+    }
+
+    @Override
+    public SessionData getSessionData() {
+      return sessionData;
     }
   }
 }

--- a/src/main/java/org/folio/edge/sip2/repositories/LoginRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/LoginRepository.java
@@ -50,7 +50,7 @@ public class LoginRepository {
         .createResource(new LoginRequestData(credentials, sessionData));
 
     return result
-        .otherwiseEmpty()
+        .otherwise(() -> null)
         .compose(resource -> {
           final String authenticationToken = resource.getAuthenticationToken();
           if (authenticationToken == null) {

--- a/src/main/java/org/folio/edge/sip2/repositories/Utils.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/Utils.java
@@ -1,0 +1,24 @@
+package org.folio.edge.sip2.repositories;
+
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+
+/**
+ * Utils for the repository implementations.
+ *
+ * @author mreno-EBSCO
+ *
+ */
+final class Utils {
+  private Utils() {
+    super();
+  }
+
+  public static DateTimeFormatter getFolioDateTimeFormatter() {
+    return new DateTimeFormatterBuilder()
+        .parseCaseInsensitive()
+        .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        .appendPattern("[XXX][XX][X]")
+        .toFormatter();
+  }
+}

--- a/src/main/resources/templates/CheckoutResponse.ftl
+++ b/src/main/resources/templates/CheckoutResponse.ftl
@@ -21,7 +21,7 @@
 <#-- title identifier: variable-length required field -->
 <@lib.titleIdentifier value=checkoutResponse.titleIdentifier/>
 <#-- due date: variable-length required field -->
-<@lib.dueDate value=checkoutResponse.dueDate/>
+<@lib.dueDate value=checkoutResponse.dueDate!""/>
 <#--
     fee type: 2-char, fixed-length optional field (01 thru 99)
     The type of fee associated with checking out this item

--- a/src/main/resources/templates/RenewResponse.ftl
+++ b/src/main/resources/templates/RenewResponse.ftl
@@ -21,7 +21,7 @@
 <#-- title identifier: variable-length required field -->
 <@lib.titleIdentifier value=renewResponse.titleIdentifier/>
 <#-- due date: variable-length required field -->
-<@lib.dueDate value=renewResponse.dueDate/>
+<@lib.dueDate value=renewResponse.dueDate!""/>
 <#--
     fee type: 2-char, fixed-length optional field (01 thru 99)
     The type of fee associated with renewing this item

--- a/src/main/resources/templates/lib.ftl
+++ b/src/main/resources/templates/lib.ftl
@@ -39,7 +39,11 @@
 </#macro>
 
 <#macro variableLengthDateField id value>
-  ${id}${formatDateTime(value, "yyyyMMdd    HHmmss")}${delimiter}<#t>
+  ${id}<#t>
+  <#if value?has_content>
+    ${formatDateTime(value, "yyyyMMdd    HHmmss")}<#t>
+  </#if>
+  ${delimiter}<#t>
 </#macro>
 
 <#macro limitNumberToRange value min max length>
@@ -100,8 +104,10 @@
   <@booleanToYorNorU value=value/><#t>
 </#macro>
 
-<#macro dueDate value>
-  <@variableLengthDateField id="AH" value=value/>
+<#macro dueDate value required=true>
+  <#if required || value?has_content>
+    <@variableLengthDateField id="AH" value=value/>
+  </#if>
 </#macro>
 
 <#macro endSession value>

--- a/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
+++ b/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
@@ -1,15 +1,12 @@
 package org.folio.edge.sip2.api;
 
-import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxTestContext;
-
 import java.text.SimpleDateFormat;
-import java.time.ZonedDateTime;
 import java.util.Date;
 import org.folio.edge.sip2.api.support.BaseTest;
 import org.junit.jupiter.api.Tag;
@@ -37,7 +34,7 @@ public class MainVerticleTests extends BaseTest {
     String sipMessage = "97\r";
     callService(sipMessage,
         context, vertx, result -> {
-          final String expectedString = "PreviousMessage is NULL";
+          final String expectedString = "PreviousMessage is NULL\r";
           assertEquals(expectedString, result);
         });
   }
@@ -49,42 +46,6 @@ public class MainVerticleTests extends BaseTest {
           final String expectedString = "941\r";
           assertEquals(expectedString, result);
         });
-  }
-
-  @Test
-  public void canStartMainVericleInjectingSip2RequestHandlers(
-      Vertx vertex, VertxTestContext testContext) {
-
-    final ZonedDateTime now = ZonedDateTime.now();
-    final String transactionDateString = getFormattedLocalDateTime(now);
-    final String nbDueDateString = getFormattedLocalDateTime(now.plusDays(30));
-    String title = "Angry Planet";
-    String sipMessage =
-        "11YY" + transactionDateString + nbDueDateString
-        + "AOinstitution_id|AApatron_id|AB" + title + "|AC1234|\r";
-
-    callService(sipMessage, testContext, vertex, result -> {
-      final String expectedString = new StringBuilder()
-          .append("Successfully checked out ")
-          .append("Checkout [scRenewalPolicy=true")
-          .append(", noBlock=true")
-          // need a better way to do dates, this could fail in rare cases
-          // due to offset changes such as DST.
-          .append(", transactionDate=")
-          .append(now.truncatedTo(SECONDS).toOffsetDateTime())
-          .append(", nbDueDate=")
-          .append(now.plusDays(30).truncatedTo(SECONDS).toOffsetDateTime())
-          .append(", institutionId=institution_id")
-          .append(", patronIdentifier=patron_id")
-          .append(", itemIdentifier=").append(title)
-          .append(", terminalPassword=1234")
-          .append(", itemProperties=null")
-          .append(", patronPassword=null")
-          .append(", feeAcknowledged=null")
-          .append(", cancel=null")
-          .append("]\r").toString();
-      assertEquals(expectedString, result);
-    });
   }
 
   @Test

--- a/src/test/java/org/folio/edge/sip2/api/support/BaseTest.java
+++ b/src/test/java/org/folio/edge/sip2/api/support/BaseTest.java
@@ -103,19 +103,22 @@ public abstract class BaseTest {
     NetClient tcpClient = vertx.createNetClient(options);
 
     tcpClient.connect(port, "localhost", res -> {
-      log.debug("Shaking hands...");
-      NetSocket socket = res.result();
-      socket.write(ncipMessage);
-      log.debug("done writing");
-
-      socket.handler(buffer -> {
-        String message = buffer.getString(0, buffer.length());
-        testContext.verify(() -> testHandler.handle(message));
-        testContext.completeNow();
-      }).exceptionHandler(t -> {
-        log.error(t);
-        testContext.failNow(t);
-      });
+      if (res.succeeded()) {
+        log.debug("Shaking hands...");
+        NetSocket socket = res.result();
+  
+        socket.handler(buffer -> {
+          String message = buffer.getString(0, buffer.length());
+          testContext.verify(() -> testHandler.handle(message));
+          testContext.completeNow();
+        }).exceptionHandler(t -> {
+          log.error("Socket handler test expection", t);
+          testContext.failNow(t);
+        }).write(ncipMessage);
+        log.debug("done writing");
+      } else {
+        log.error("Failed to connect", res.cause());
+      }
     });
   }
 

--- a/src/test/java/org/folio/edge/sip2/handlers/CheckinHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/CheckinHandlerTests.java
@@ -112,7 +112,7 @@ public class CheckinHandlerTests {
             .transactionDate(ZonedDateTime.now(clock))
             .institutionId(institutionId)
             .itemIdentifier(itemIdentifier)
-            .permanentLocation("Main Library")
+            .permanentLocation("")
             .build()));
 
     final CheckinHandler handler = new CheckinHandler(mockCirculationRepository,
@@ -124,7 +124,7 @@ public class CheckinHandlerTests {
         testContext.succeeding(sipMessage -> testContext.verify(() -> {
           final String expectedString = "100YUN"
               + ZonedDateTime.now(clock).format(DateTimeFormatter.ofPattern("yyyyMMdd    HHmmss"))
-              + "AO" + institutionId + "|AB" + itemIdentifier + "|AQMain Library|";
+              + "AO" + institutionId + "|AB" + itemIdentifier + "|AQ|";
 
           assertEquals(expectedString, sipMessage);
 

--- a/src/test/java/org/folio/edge/sip2/handlers/CheckoutHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/CheckoutHandlerTests.java
@@ -124,8 +124,8 @@ public class CheckoutHandlerTests {
             .institutionId(institutionId)
             .patronIdentifier(patronIdentifier)
             .itemIdentifier(itemIdentifier)
-            .titleIdentifier("Some Book")
-            .dueDate(ZonedDateTime.now(clock).plusDays(30))
+            .titleIdentifier("")
+            .dueDate(null)
             .build()));
 
     final CheckoutHandler handler = new CheckoutHandler(mockCirculationRepository,
@@ -138,10 +138,7 @@ public class CheckoutHandlerTests {
           final String expectedString = "120NUN"
               + ZonedDateTime.now(clock).format(DateTimeFormatter.ofPattern("yyyyMMdd    HHmmss"))
               + "AO" + institutionId + "|AA" + patronIdentifier + "|AB" + itemIdentifier
-              + "|AJSome Book|AH"
-              + ZonedDateTime.now(clock).plusDays(30).format(
-                  DateTimeFormatter.ofPattern("yyyyMMdd    HHmmss"))
-              + '|';
+              + "|AJ|AH|";
 
           assertEquals(expectedString, sipMessage);
 

--- a/src/test/java/org/folio/edge/sip2/handlers/CheckoutHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/CheckoutHandlerTests.java
@@ -1,0 +1,168 @@
+package org.folio.edge.sip2.handlers;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static org.folio.edge.sip2.parser.Command.CHECKOUT_RESPONSE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import org.folio.edge.sip2.domain.messages.requests.Checkout;
+import org.folio.edge.sip2.domain.messages.responses.CheckoutResponse;
+import org.folio.edge.sip2.handlers.freemarker.FreemarkerRepository;
+import org.folio.edge.sip2.repositories.CirculationRepository;
+import org.folio.edge.sip2.session.SessionData;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith({VertxExtension.class, MockitoExtension.class})
+public class CheckoutHandlerTests {
+  @Test
+  public void canExecuteASampleCheckoutUsingHandler(
+      @Mock CirculationRepository mockCirculationRepository,
+      Vertx vertx,
+      VertxTestContext testContext) {
+    final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+    final ZonedDateTime nbDueDate = ZonedDateTime.now();
+    final String institutionId = "diku";
+    final String patronIdentifier = "0192837465";
+    final String itemIdentifier = "1234567890";
+    final Checkout checkout = Checkout.builder()
+        .scRenewalPolicy(FALSE)
+        .noBlock(FALSE)
+        .transactionDate(ZonedDateTime.now())
+        .nbDueDate(nbDueDate)
+        .institutionId(institutionId)
+        .patronIdentifier(patronIdentifier)
+        .itemIdentifier(itemIdentifier)
+        .terminalPassword("1234")
+        .itemProperties("Some property of this item")
+        .patronPassword("4321")
+        .feeAcknowledged(FALSE)
+        .cancel(FALSE)
+        .build();
+
+    when(mockCirculationRepository.checkout(any(), any()))
+        .thenReturn(Future.succeededFuture(CheckoutResponse.builder()
+            .ok(TRUE)
+            .renewalOk(FALSE)
+            .magneticMedia(null)
+            .desensitize(TRUE)
+            .transactionDate(ZonedDateTime.now(clock))
+            .institutionId(institutionId)
+            .patronIdentifier(patronIdentifier)
+            .itemIdentifier(itemIdentifier)
+            .titleIdentifier("Some Book")
+            .dueDate(ZonedDateTime.now(clock).plusDays(30))
+            .build()));
+
+    final CheckoutHandler handler = new CheckoutHandler(mockCirculationRepository,
+        FreemarkerRepository.getInstance().getFreemarkerTemplate(CHECKOUT_RESPONSE));
+
+    final SessionData sessionData = SessionData.createSession(institutionId, '|', false, "IBM850");
+
+    handler.execute(checkout, sessionData).setHandler(
+        testContext.succeeding(sipMessage -> testContext.verify(() -> {
+          final String expectedString = "121NUY"
+              + ZonedDateTime.now(clock).format(DateTimeFormatter.ofPattern("yyyyMMdd    HHmmss"))
+              + "AO" + institutionId + "|AA" + patronIdentifier + "|AB" + itemIdentifier
+              + "|AJSome Book|AH"
+              + ZonedDateTime.now(clock).plusDays(30).format(
+                  DateTimeFormatter.ofPattern("yyyyMMdd    HHmmss"))
+              + '|';
+
+          assertEquals(expectedString, sipMessage);
+
+          testContext.completeNow();
+        })));
+  }
+
+  @Test
+  public void canExecuteASampleFailedCheckoutUsingHandler(
+      @Mock CirculationRepository mockCirculationRepository,
+      Vertx vertx,
+      VertxTestContext testContext) {
+    final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+    final ZonedDateTime nbDueDate = ZonedDateTime.now();
+    final String institutionId = "diku";
+    final String patronIdentifier = "0192837465";
+    final String itemIdentifier = "1234567890";
+    final Checkout checkout = Checkout.builder()
+        .scRenewalPolicy(FALSE)
+        .noBlock(FALSE)
+        .transactionDate(ZonedDateTime.now())
+        .nbDueDate(nbDueDate)
+        .institutionId(institutionId)
+        .patronIdentifier(patronIdentifier)
+        .itemIdentifier(itemIdentifier)
+        .terminalPassword("1234")
+        .itemProperties("Some property of this item")
+        .patronPassword("4321")
+        .feeAcknowledged(FALSE)
+        .cancel(FALSE)
+        .build();
+
+    when(mockCirculationRepository.checkout(any(), any()))
+        .thenReturn(Future.succeededFuture(CheckoutResponse.builder()
+            .ok(FALSE)
+            .renewalOk(FALSE)
+            .magneticMedia(null)
+            .desensitize(FALSE)
+            .transactionDate(ZonedDateTime.now(clock))
+            .institutionId(institutionId)
+            .patronIdentifier(patronIdentifier)
+            .itemIdentifier(itemIdentifier)
+            .titleIdentifier("Some Book")
+            .dueDate(ZonedDateTime.now(clock).plusDays(30))
+            .build()));
+
+    final CheckoutHandler handler = new CheckoutHandler(mockCirculationRepository,
+        FreemarkerRepository.getInstance().getFreemarkerTemplate(CHECKOUT_RESPONSE));
+
+    final SessionData sessionData = SessionData.createSession(institutionId, '|', false, "IBM850");
+
+    handler.execute(checkout, sessionData).setHandler(
+        testContext.succeeding(sipMessage -> testContext.verify(() -> {
+          final String expectedString = "120NUN"
+              + ZonedDateTime.now(clock).format(DateTimeFormatter.ofPattern("yyyyMMdd    HHmmss"))
+              + "AO" + institutionId + "|AA" + patronIdentifier + "|AB" + itemIdentifier
+              + "|AJSome Book|AH"
+              + ZonedDateTime.now(clock).plusDays(30).format(
+                  DateTimeFormatter.ofPattern("yyyyMMdd    HHmmss"))
+              + '|';
+
+          assertEquals(expectedString, sipMessage);
+
+          testContext.completeNow();
+        })));
+  }
+
+  @Test
+  public void cannotCreateHandlerDueToMissingCirculationRepository() {
+    final NullPointerException thrown = assertThrows(
+        NullPointerException.class,
+        () -> new CheckinHandler(null, null));
+
+    assertEquals("CirculationRepository cannot be null", thrown.getMessage());
+  }
+
+  @Test
+  public void cannotCreateHandlerDueToMissingTemplate(@Mock CirculationRepository mock) {
+    final NullPointerException thrown = assertThrows(NullPointerException.class,
+        () -> new CheckinHandler(mock, null));
+
+    assertEquals("Template cannot be null", thrown.getMessage());
+  }
+}

--- a/src/test/java/org/folio/edge/sip2/handlers/HandlersFactoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/HandlersFactoryTests.java
@@ -35,13 +35,6 @@ public class HandlersFactoryTests {
   }
 
   @Test
-  public void canGetCheckoutHandler() {
-    ISip2RequestHandler checkoutHandler = HandlersFactory.getCheckoutHandlerIntance();
-    assertNotNull(checkoutHandler);
-    assertTrue(checkoutHandler instanceof CheckoutHandler);
-  }
-
-  @Test
   public void canGetAcsResendHandler() {
     ISip2RequestHandler acsResendHandler = HandlersFactory.getACSResendHandler();
     assertNotNull(acsResendHandler);

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -6,6 +6,7 @@
     </Console>
   </Appenders>
   <Loggers>
+    <Logger name="org.folio.edge.sip2" level="debug"/>
     <Root level="info">
       <AppenderRef ref="STDOUT"/>
     </Root>


### PR DESCRIPTION
Added support for the checkout SIP2 command that allows edge-sip2 to receive this command, extract relevant data and send a FOLIO checkout request. This implementation also translates the FOLIO checkout response back into a SIP2 checkout response and returns this message to the client.