### PR TITLE
Fix a NPE in the login repository

### DIFF
--- a/src/main/java/org/folio/edge/sip2/repositories/LoginRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/LoginRepository.java
@@ -47,7 +47,7 @@ public class LoginRepository {
         .put("password", password);
     
     final Future<IResource> result = resourceProvider
-        .createResource(new LoginRequestData(credentials));
+        .createResource(new LoginRequestData(credentials, sessionData));
 
     return result
         .otherwiseEmpty()
@@ -68,9 +68,11 @@ public class LoginRepository {
 
   private class LoginRequestData implements IRequestData {
     private final JsonObject body;
+    private final SessionData sessionData;
 
-    private LoginRequestData(JsonObject body) {
+    private LoginRequestData(JsonObject body, SessionData sessionData) {
       this.body = body;
+      this.sessionData = sessionData;
     }
 
     @Override
@@ -88,6 +90,11 @@ public class LoginRepository {
     @Override
     public JsonObject getBody() {
       return body;
+    }
+
+    @Override
+    public SessionData getSessionData() {
+      return sessionData;
     }
   }
 }


### PR DESCRIPTION
The `sessionData` returned by `LoginRequestData.getSessionData()` is `null` as per the default implementation of `IRequestData`. Now we store the passed in session data in the request data and pass it to the provider.