### PR TITLE
ACS Status default values

### DIFF
--- a/src/main/java/org/folio/edge/sip2/MainVerticle.java
+++ b/src/main/java/org/folio/edge/sip2/MainVerticle.java
@@ -67,7 +67,7 @@ public class MainVerticle extends AbstractVerticle {
       handlers.put(LOGIN, injector.getInstance(LoginHandler.class));
       handlers.put(CHECKIN, injector.getInstance(CheckinHandler.class));
       handlers.put(CHECKOUT, injector.getInstance(CheckoutHandler.class));
-      handlers.put(SC_STATUS, HandlersFactory.getScStatusHandlerInstance(null, null, null));
+      handlers.put(SC_STATUS, HandlersFactory.getScStatusHandlerInstance(null, null, null, null));
       handlers.put(REQUEST_SC_RESEND, HandlersFactory.getInvalidMessageHandler());
       handlers.put(REQUEST_ACS_RESEND, HandlersFactory.getACSResendHandler());
       handlers.put(END_PATRON_SESSION, injector.getInstance(EndPatronSessionHandler.class));

--- a/src/main/java/org/folio/edge/sip2/handlers/HandlersFactory.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/HandlersFactory.java
@@ -2,6 +2,10 @@ package org.folio.edge.sip2.handlers;
 
 import freemarker.template.Template;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
 import org.folio.edge.sip2.handlers.freemarker.FreemarkerRepository;
 import org.folio.edge.sip2.parser.Command;
 import org.folio.edge.sip2.repositories.ConfigurationRepository;
@@ -27,11 +31,15 @@ public class HandlersFactory {
   public static ISip2RequestHandler getScStatusHandlerInstance(
       ConfigurationRepository configRepo,
       IResourceProvider<Object> resProvider,
-      Template freeMarkerTemplate) {
+      Template freeMarkerTemplate,
+      Clock clock) {
     resProvider = getResourceProvider(resProvider);
 
-    if (configRepo == null) {
-      configRepo = new ConfigurationRepository(resProvider);
+    if (configRepo == null && clock == null) {
+      configRepo = new ConfigurationRepository(resProvider,
+          Clock.fixed(Instant.now(), ZoneOffset.UTC));
+    } else if (configRepo == null && clock != null) {
+      configRepo = new ConfigurationRepository(resProvider, clock);
     }
 
     freeMarkerTemplate = getCommandTemplate(freeMarkerTemplate,

--- a/src/main/java/org/folio/edge/sip2/repositories/ConfigurationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/ConfigurationRepository.java
@@ -63,7 +63,7 @@ public class ConfigurationRepository {
         builder.terminalLocation(acsConfiguration.getString("terminalLocation"));
         builder.timeoutPeriod(acsConfiguration.getInteger("timeoutPeriod"));
         builder.supportedMessages(getSupportedMessagesFromJson(
-          acsConfiguration.getJsonArray("supportedMessages")));
+                acsConfiguration.getJsonArray("supportedMessages")));
 
         acsStatus = builder.build();
 
@@ -92,9 +92,9 @@ public class ConfigurationRepository {
 
       JsonArray tenantConfigurations = jsonFile.getJsonArray("tenantConfigurations");
       Optional<Object> tenantConfigObject = tenantConfigurations
-        .stream()
-        .filter(config -> ((JsonObject)config).getString("tenantId").equalsIgnoreCase(configKey))
-        .findFirst();
+          .stream()
+          .filter(config -> ((JsonObject)config).getString("tenantId").equalsIgnoreCase(configKey))
+          .findFirst();
 
       if (tenantConfigObject.isPresent()) {
         configJson = (JsonObject) tenantConfigObject.get();
@@ -120,9 +120,9 @@ public class ConfigurationRepository {
 
   private Set<Messages> getSupportedMessagesFromJson(JsonArray supportedMessages) {
     return supportedMessages
-      .stream()
-      .filter(el -> ((JsonObject) el).getString("isSupported").equalsIgnoreCase("Y"))
-      .map(el -> Messages.valueOf(((JsonObject) el).getString("messageName")))
-      .collect(Collectors.toSet());
+        .stream()
+        .filter(el -> ((JsonObject) el).getString("isSupported").equalsIgnoreCase("Y"))
+        .map(el -> Messages.valueOf(((JsonObject) el).getString("messageName")))
+        .collect(Collectors.toSet());
   }
 }

--- a/src/main/java/org/folio/edge/sip2/repositories/ConfigurationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/ConfigurationRepository.java
@@ -7,6 +7,7 @@ import io.vertx.core.json.JsonObject;
 import java.lang.invoke.MethodHandles;
 import java.time.Clock;
 import java.time.ZonedDateTime;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -20,17 +21,18 @@ public class ConfigurationRepository {
 
   private IResourceProvider<Object> resourceProvider;
   private final Logger log;
-
+  private Clock clock;
   /**
    * Constructor that takes an IResourceProvider.
    *
    * @param resourceProvider This can be DefaultResourceProvider or any provider in the future.
    */
-  public ConfigurationRepository(IResourceProvider<Object> resourceProvider) {
-    if (resourceProvider == null) {
-      throw new IllegalArgumentException("configGateway is null");
-    }
-    this.resourceProvider = resourceProvider;
+
+  public ConfigurationRepository(IResourceProvider<Object> resourceProvider,
+                                 Clock clock) {
+    this.resourceProvider = Objects.requireNonNull(resourceProvider,
+        "ConfigGateway cannot be null");
+    this.clock = Objects.requireNonNull(clock, "Clock cannot be null");
     log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
   }
 
@@ -49,7 +51,7 @@ public class ConfigurationRepository {
         builder.checkinOk(acsConfiguration.getBoolean("onlineStatus"));
         builder.acsRenewalPolicy(acsConfiguration.getBoolean("acsRenewalPolicy"));
         builder.checkoutOk(acsConfiguration.getBoolean("checkoutOk"));
-        builder.dateTimeSync(ZonedDateTime.now(Clock.systemUTC()));
+        builder.dateTimeSync(ZonedDateTime.now(clock));
         builder.institutionId(acsConfiguration.getString("institutionId"));
         builder.libraryName(acsConfiguration.getString("libraryName"));
         builder.offLineOk(acsConfiguration.getBoolean("checkoutOk"));

--- a/src/main/java/org/folio/edge/sip2/repositories/ConfigurationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/ConfigurationRepository.java
@@ -46,7 +46,6 @@ public class ConfigurationRepository {
       ACSStatus acsStatus = null;
       if (acsConfiguration != null) {
         ACSStatus.ACSStatusBuilder builder = ACSStatus.builder();
-
         builder.checkinOk(acsConfiguration.getBoolean("onlineStatus"));
         builder.acsRenewalPolicy(acsConfiguration.getBoolean("acsRenewalPolicy"));
         builder.checkoutOk(acsConfiguration.getBoolean("checkoutOk"));
@@ -64,13 +63,10 @@ public class ConfigurationRepository {
         builder.timeoutPeriod(acsConfiguration.getInteger("timeoutPeriod"));
         builder.supportedMessages(getSupportedMessagesFromJson(
                 acsConfiguration.getJsonArray("supportedMessages")));
-
         acsStatus = builder.build();
-
       } else {
         log.error("The JsonConfig object is null");
       }
-
       return Future.succeededFuture(acsStatus);
     });
   }
@@ -99,7 +95,6 @@ public class ConfigurationRepository {
       if (tenantConfigObject.isPresent()) {
         configJson = (JsonObject) tenantConfigObject.get();
       }
-
       return Future.succeededFuture(configJson);
     });
   }

--- a/src/main/java/org/folio/edge/sip2/repositories/ConfigurationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/ConfigurationRepository.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.lang.invoke.MethodHandles;
+import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.Set;
@@ -45,11 +46,11 @@ public class ConfigurationRepository {
       ACSStatus acsStatus = null;
       if (acsConfiguration != null) {
         ACSStatus.ACSStatusBuilder builder = ACSStatus.builder();
-  
+
         builder.checkinOk(acsConfiguration.getBoolean("onlineStatus"));
         builder.acsRenewalPolicy(acsConfiguration.getBoolean("acsRenewalPolicy"));
         builder.checkoutOk(acsConfiguration.getBoolean("checkoutOk"));
-        builder.dateTimeSync(ZonedDateTime.now());
+        builder.dateTimeSync(ZonedDateTime.now(Clock.systemUTC()));
         builder.institutionId(acsConfiguration.getString("institutionId"));
         builder.libraryName(acsConfiguration.getString("libraryName"));
         builder.offLineOk(acsConfiguration.getBoolean("checkoutOk"));
@@ -62,14 +63,14 @@ public class ConfigurationRepository {
         builder.terminalLocation(acsConfiguration.getString("terminalLocation"));
         builder.timeoutPeriod(acsConfiguration.getInteger("timeoutPeriod"));
         builder.supportedMessages(getSupportedMessagesFromJson(
-                acsConfiguration.getJsonArray("supportedMessages")));
-  
+          acsConfiguration.getJsonArray("supportedMessages")));
+
         acsStatus = builder.build();
-  
+
       } else {
         log.error("The JsonConfig object is null");
       }
-  
+
       return Future.succeededFuture(acsStatus);
     });
   }
@@ -91,10 +92,10 @@ public class ConfigurationRepository {
 
       JsonArray tenantConfigurations = jsonFile.getJsonArray("tenantConfigurations");
       Optional<Object> tenantConfigObject = tenantConfigurations
-          .stream()
-          .filter(config -> ((JsonObject)config).getString("tenantId").equalsIgnoreCase(configKey))
-          .findFirst();
-  
+        .stream()
+        .filter(config -> ((JsonObject)config).getString("tenantId").equalsIgnoreCase(configKey))
+        .findFirst();
+
       if (tenantConfigObject.isPresent()) {
         configJson = (JsonObject) tenantConfigObject.get();
       }
@@ -112,16 +113,16 @@ public class ConfigurationRepository {
       if (fullConfiguration != null) {
         acsConfiguration = fullConfiguration.getJsonObject("acsConfiguration");
       }
-  
+
       return Future.succeededFuture(acsConfiguration);
     });
   }
 
   private Set<Messages> getSupportedMessagesFromJson(JsonArray supportedMessages) {
     return supportedMessages
-        .stream()
-        .filter(el -> ((JsonObject) el).getString("isSupported").equalsIgnoreCase("Y"))
-        .map(el -> Messages.valueOf(((JsonObject) el).getString("messageName")))
-        .collect(Collectors.toSet());
+      .stream()
+      .filter(el -> ((JsonObject) el).getString("isSupported").equalsIgnoreCase("Y"))
+      .map(el -> Messages.valueOf(((JsonObject) el).getString("messageName")))
+      .collect(Collectors.toSet());
   }
 }

--- a/src/main/resources/DefaultACSConfiguration.json
+++ b/src/main/resources/DefaultACSConfiguration.json
@@ -3,19 +3,18 @@
     "onlineStatus": true,
     "checkinOk": true,
     "checkoutOk": true,
-    "acsRenewalPolicy": true,
-    "statusUpdateOk": true,
-    "offlineOk": true,
+    "acsRenewalPolicy": false,
+    "statusUpdateOk": false,
+    "offlineOk": false,
     "timeoutPeriod": 5,
     "retriesAllowed": 3,
-    "dateTimeSync": "2019-04-05 13:26:13",
-    "protocolVersion": "1.23",
+    "protocolVersion": "2.00",
     "institutionId": "fs00000010",
     "libraryName": "Chalmers",
     "supportedMessages": [
       {
         "messageName": "PATRON_STATUS_REQUEST",
-        "isSupported": "Y"
+        "isSupported": "N"
       },
       {
         "messageName": "CHECKOUT",
@@ -51,23 +50,23 @@
       },
       {
         "messageName": "ITEM_INFORMATION",
-        "isSupported": "Y"
+        "isSupported": "N"
       },
       {
         "messageName": "ITEM_STATUS_UPDATE",
-        "isSupported": "Y"
+        "isSupported": "N"
       },
       {
         "messageName": "PATRON_ENABLE",
-        "isSupported": "Y"
+        "isSupported": "N"
       },
       {
         "messageName": "HOLD",
-        "isSupported": "Y"
+        "isSupported": "N"
       },
       {
         "messageName": "RENEW",
-        "isSupported": "Y"
+        "isSupported": "N"
       },
       {
         "messageName": "RENEW_ALL",

--- a/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
+++ b/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
@@ -8,14 +8,13 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxTestContext;
 import java.text.SimpleDateFormat;
 import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.TimeZone;
 
 import org.folio.edge.sip2.api.support.BaseTest;
+import org.folio.edge.sip2.api.support.TestUtils;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -151,12 +150,12 @@ public class MainVerticleTests extends BaseTest {
     final String patronIdentifier = "patronId1234";
     final String patronPassword = "patronPassword";
     final String terminalPassword = "terminalPassword";
-    final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+    final Clock clock = TestUtils.getUtcFixedClock();
     final String delimeter = "|";
 
     StringBuffer sipMessageBf = new StringBuffer();
     sipMessageBf.append("35");
-    sipMessageBf.append(getFormattedLocalDateTime(ZonedDateTime.now(clock)));
+    sipMessageBf.append(TestUtils.getFormattedLocalDateTime(ZonedDateTime.now(clock)));
     sipMessageBf.append("AO" + institutionId + delimeter);
     sipMessageBf.append("AA" + patronIdentifier + delimeter);
     sipMessageBf.append("AC" + terminalPassword + delimeter);

--- a/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
+++ b/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
@@ -38,19 +38,19 @@ public class MainVerticleTests extends BaseTest {
   public void cannotSuccessfullyResendPreviousRequest(Vertx vertx, VertxTestContext context) {
     String sipMessage = "97\r";
     callService(sipMessage,
-      context, vertx, result -> {
-        final String expectedString = "PreviousMessage is NULL\r";
-        assertEquals(expectedString, result);
-      });
+        context, vertx, result -> {
+          final String expectedString = "PreviousMessage is NULL\r";
+          assertEquals(expectedString, result);
+        });
   }
 
   @Test
   public void canMakeARequest(Vertx vertex, VertxTestContext testContext) {
     callService("9300CNMartin|COpassword|\r",
-      testContext, vertex, result -> {
-        final String expectedString = "941\r";
-        assertEquals(expectedString, result);
-      });
+        testContext, vertex, result -> {
+          final String expectedString = "941\r";
+          assertEquals(expectedString, result);
+        });
   }
 
   @Test
@@ -63,14 +63,14 @@ public class MainVerticleTests extends BaseTest {
   @Test
   public void canMakeValidSCStatusRequest(Vertx vertex, VertxTestContext testContext) {
     callService("9900401.00AY1AZFCA5\r",
-      testContext, vertex, result -> {
-        validateExpectedACSStatus(result);
+        testContext, vertex, result -> {
+          validateExpectedACSStatus(result);
       });
   }
 
   @Test
   public void canMakeInvalidStatusRequestAndGetExpectedErrorMessage(
-    Vertx vertex, VertxTestContext testContext) {
+      Vertx vertex, VertxTestContext testContext) {
     callService("990231.23\r", testContext, vertex, result -> {
       assertTrue(result.contains("Problems handling the request"));
     });
@@ -79,7 +79,7 @@ public class MainVerticleTests extends BaseTest {
   @Test
   @Tag("ErrorDetectionEnabled")
   public void canGetCsResendMessageWhenSendingInvalidMessage(
-    Vertx vertx, VertxTestContext testContext) {
+      Vertx vertx, VertxTestContext testContext) {
     String scStatusMessage = "9900401.00AY1AZAAAA\r";
     callService(scStatusMessage, testContext, vertx, result -> {
       assertEquals("96AZFEF6\r", result);
@@ -88,7 +88,7 @@ public class MainVerticleTests extends BaseTest {
 
   @Test
   public void canGetACSStatusMessageWhenSendingValidMessage(
-    Vertx vertx, VertxTestContext testContext) {
+      Vertx vertx, VertxTestContext testContext) {
     String scStatusMessage = "9900401.00AY1AZFCA5\r";
     callService(scStatusMessage, testContext, vertx, result -> {
       validateExpectedACSStatus(result);
@@ -97,7 +97,7 @@ public class MainVerticleTests extends BaseTest {
 
   @Test
   public void canTriggerAcsToResendMessage(
-    Vertx vertx, VertxTestContext testContext) {
+      Vertx vertx, VertxTestContext testContext) {
     // Note that this test is highly dependent on the previous test
     // to set the previous message to be "9900401.00AY1AZFCA5\r";
 
@@ -106,71 +106,41 @@ public class MainVerticleTests extends BaseTest {
     sipMessaces[1] = "97\r";
 
     callServiceMultiple(sipMessaces,
-      testContext, vertx, result -> {
-        validateExpectedACSStatus(result);
-      });
+        testContext, vertx, result -> {
+          validateExpectedACSStatus(result);
+        });
 
   }
 
   @Test
   public void canTriggerAcsToResendMessageBySendingSameRequestMessage(
-    Vertx vertx, VertxTestContext testContext) {
+      Vertx vertx, VertxTestContext testContext) {
 
     String[] sipMessaces = new String[2];
     sipMessaces[0] = "9900401.00AY1AZFCA5\r";
     sipMessaces[1] = "9900401.00AY1AZFCA5\r";
 
     callServiceMultiple(sipMessaces,
-      testContext, vertx, result -> {
-        validateExpectedACSStatus(result);
-      });
+        testContext, vertx, result -> {
+          validateExpectedACSStatus(result);
+        });
   }
 
   @Test
   public void cannotTriggerAcsToResendMessageBySendingSameMessageWithoutED(
-    Vertx vertx, VertxTestContext testContext) {
+      Vertx vertx, VertxTestContext testContext) {
 
     String[] sipMessaces = new String[2];
     sipMessaces[0] = "9900401.00AY1AZFCA5\r";
     sipMessaces[1] = "9900401.00\r";
 
     callServiceMultiple(sipMessaces,
-      testContext, vertx, result -> {
-        // there is no way to verify the intended behavior
-        // because it also results in a fresh lookup by the ACS.
-        // Can only verify the lookup's result.
-        validateExpectedACSStatus(result);
-      });
-  }
-
-  @Test
-  public void canExecuteEndSessionCommand(
-    Vertx vertx, VertxTestContext testContext) {
-
-    final String institutionId = "fs00000001";
-    final String patronIdentifier = "patronId1234";
-    final String patronPassword = "patronPassword";
-    final String terminalPassword = "terminalPassword";
-    final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
-    final String delimeter = "|";
-
-    StringBuffer sipMessageBf = new StringBuffer();
-    sipMessageBf.append("35");
-    sipMessageBf.append(getFormattedLocalDateTime(ZonedDateTime.now(clock)));
-    sipMessageBf.append("AO" + institutionId + delimeter);
-    sipMessageBf.append("AA" + patronIdentifier + delimeter);
-    sipMessageBf.append("AC" + terminalPassword + delimeter);
-    sipMessageBf.append("AD" + patronPassword + delimeter);
-    sipMessageBf.append("\r");
-
-    final String expectedString = "36Y"
-      + ZonedDateTime.now(clock).format(DateTimeFormatter.ofPattern("yyyyMMdd    HHmmss"))
-      + "AO" + institutionId + "|AA" + patronIdentifier + '|' + '\r';
-
-    callService(sipMessageBf.toString(),
-      testContext, vertx, result -> {
-        assertEquals(expectedString, result);
-      });
+        testContext, vertx, result -> {
+          // there is no way to verify the intended behavior
+          // because it also results in a fresh lookup by the ACS.
+          // Can only verify the lookup's result.
+          validateExpectedACSStatus(result);
+        });
   }
 
   @Test
@@ -216,14 +186,14 @@ public class MainVerticleTests extends BaseTest {
 
     String expectedPreLocalTime = "98YYNYNN53" + getFormattedDateString();
     String expectedPostLocalTime =
-      "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|AFscreenMessages|AGline|\r";
+        "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|AFscreenMessages|AGline|\r";
     String expectedBlankSpaces = "    ";
 
     assertEquals(expectedPreLocalTime, acsResponse.substring(0, 18),
-      "preLocalTime substring is not as expected");
+        "preLocalTime substring is not as expected");
     assertEquals(expectedBlankSpaces, acsResponse.substring(18, 22),
-      "blank spaces substring is not as expected");
+        "blank spaces substring is not as expected");
     assertEquals(expectedPostLocalTime, acsResponse.substring(28),
-      "postLocalTime substring is not as expected");
+        "postLocalTime substring is not as expected");
   }
 }

--- a/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
+++ b/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
@@ -7,7 +7,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxTestContext;
 import java.text.SimpleDateFormat;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
+import java.util.TimeZone;
+
 import org.folio.edge.sip2.api.support.BaseTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -16,8 +23,6 @@ import org.junit.jupiter.api.Test;
  * Integration tests for SIP service.
  * 1. Not all cases need to be tested.
  * 2. Only test cases that cannot be unit tested
- * 3. The order of the tests need to be kept as is.
- *    New tests should be added on the bottom.
  */
 public class MainVerticleTests extends BaseTest {
 
@@ -33,19 +38,19 @@ public class MainVerticleTests extends BaseTest {
   public void cannotSuccessfullyResendPreviousRequest(Vertx vertx, VertxTestContext context) {
     String sipMessage = "97\r";
     callService(sipMessage,
-        context, vertx, result -> {
-          final String expectedString = "PreviousMessage is NULL\r";
-          assertEquals(expectedString, result);
-        });
+      context, vertx, result -> {
+        final String expectedString = "PreviousMessage is NULL\r";
+        assertEquals(expectedString, result);
+      });
   }
 
   @Test
   public void canMakeARequest(Vertx vertex, VertxTestContext testContext) {
     callService("9300CNMartin|COpassword|\r",
-        testContext, vertex, result -> {
-          final String expectedString = "941\r";
-          assertEquals(expectedString, result);
-        });
+      testContext, vertex, result -> {
+        final String expectedString = "941\r";
+        assertEquals(expectedString, result);
+      });
   }
 
   @Test
@@ -58,14 +63,14 @@ public class MainVerticleTests extends BaseTest {
   @Test
   public void canMakeValidSCStatusRequest(Vertx vertex, VertxTestContext testContext) {
     callService("9900401.00AY1AZFCA5\r",
-        testContext, vertex, result -> {
-          validateExpectedACSStatus(result);
+      testContext, vertex, result -> {
+        validateExpectedACSStatus(result);
       });
   }
 
   @Test
   public void canMakeInvalidStatusRequestAndGetExpectedErrorMessage(
-      Vertx vertex, VertxTestContext testContext) {
+    Vertx vertex, VertxTestContext testContext) {
     callService("990231.23\r", testContext, vertex, result -> {
       assertTrue(result.contains("Problems handling the request"));
     });
@@ -74,7 +79,7 @@ public class MainVerticleTests extends BaseTest {
   @Test
   @Tag("ErrorDetectionEnabled")
   public void canGetCsResendMessageWhenSendingInvalidMessage(
-      Vertx vertx, VertxTestContext testContext) {
+    Vertx vertx, VertxTestContext testContext) {
     String scStatusMessage = "9900401.00AY1AZAAAA\r";
     callService(scStatusMessage, testContext, vertx, result -> {
       assertEquals("96AZFEF6\r", result);
@@ -83,7 +88,7 @@ public class MainVerticleTests extends BaseTest {
 
   @Test
   public void canGetACSStatusMessageWhenSendingValidMessage(
-      Vertx vertx, VertxTestContext testContext) {
+    Vertx vertx, VertxTestContext testContext) {
     String scStatusMessage = "9900401.00AY1AZFCA5\r";
     callService(scStatusMessage, testContext, vertx, result -> {
       validateExpectedACSStatus(result);
@@ -92,7 +97,7 @@ public class MainVerticleTests extends BaseTest {
 
   @Test
   public void canTriggerAcsToResendMessage(
-      Vertx vertx, VertxTestContext testContext) {
+    Vertx vertx, VertxTestContext testContext) {
     // Note that this test is highly dependent on the previous test
     // to set the previous message to be "9900401.00AY1AZFCA5\r";
 
@@ -101,46 +106,77 @@ public class MainVerticleTests extends BaseTest {
     sipMessaces[1] = "97\r";
 
     callServiceMultiple(sipMessaces,
-        testContext, vertx, result -> {
-          validateExpectedACSStatus(result);
-        });
+      testContext, vertx, result -> {
+        validateExpectedACSStatus(result);
+      });
 
   }
 
   @Test
   public void canTriggerAcsToResendMessageBySendingSameRequestMessage(
-      Vertx vertx, VertxTestContext testContext) {
+    Vertx vertx, VertxTestContext testContext) {
 
     String[] sipMessaces = new String[2];
     sipMessaces[0] = "9900401.00AY1AZFCA5\r";
     sipMessaces[1] = "9900401.00AY1AZFCA5\r";
 
     callServiceMultiple(sipMessaces,
-        testContext, vertx, result -> {
-          validateExpectedACSStatus(result);
-        });
+      testContext, vertx, result -> {
+        validateExpectedACSStatus(result);
+      });
   }
 
   @Test
   public void cannotTriggerAcsToResendMessageBySendingSameMessageWithoutED(
-      Vertx vertx, VertxTestContext testContext) {
+    Vertx vertx, VertxTestContext testContext) {
 
     String[] sipMessaces = new String[2];
     sipMessaces[0] = "9900401.00AY1AZFCA5\r";
     sipMessaces[1] = "9900401.00\r";
 
     callServiceMultiple(sipMessaces,
-        testContext, vertx, result -> {
-          // there is no way to verify the intended behavior
-          // because it also results in a fresh lookup by the ACS.
-          // Can only verify the lookup's result.
-          validateExpectedACSStatus(result);
-        });
+      testContext, vertx, result -> {
+        // there is no way to verify the intended behavior
+        // because it also results in a fresh lookup by the ACS.
+        // Can only verify the lookup's result.
+        validateExpectedACSStatus(result);
+      });
+  }
+
+  @Test
+  public void canExecuteEndSessionCommand(
+    Vertx vertx, VertxTestContext testContext) {
+
+    final String institutionId = "fs00000001";
+    final String patronIdentifier = "patronId1234";
+    final String patronPassword = "patronPassword";
+    final String terminalPassword = "terminalPassword";
+    final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+    final String delimeter = "|";
+
+    StringBuffer sipMessageBf = new StringBuffer();
+    sipMessageBf.append("35");
+    sipMessageBf.append(getFormattedLocalDateTime(ZonedDateTime.now(clock)));
+    sipMessageBf.append("AO" + institutionId + delimeter);
+    sipMessageBf.append("AA" + patronIdentifier + delimeter);
+    sipMessageBf.append("AC" + terminalPassword + delimeter);
+    sipMessageBf.append("AD" + patronPassword + delimeter);
+    sipMessageBf.append("\r");
+
+    final String expectedString = "36Y"
+      + ZonedDateTime.now(clock).format(DateTimeFormatter.ofPattern("yyyyMMdd    HHmmss"))
+      + "AO" + institutionId + "|AA" + patronIdentifier + '|' + '\r';
+
+    callService(sipMessageBf.toString(),
+      testContext, vertx, result -> {
+        assertEquals(expectedString, result);
+      });
   }
 
   private String getFormattedDateString() {
     String pattern = "YYYYMMdd";
     SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern);
+    simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
     return simpleDateFormat.format(new Date());
   }
 
@@ -150,14 +186,14 @@ public class MainVerticleTests extends BaseTest {
 
     String expectedPreLocalTime = "98YYNYNN53" + getFormattedDateString();
     String expectedPostLocalTime =
-        "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|AFscreenMessages|AGline|\r";
+      "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|AFscreenMessages|AGline|\r";
     String expectedBlankSpaces = "    ";
 
     assertEquals(expectedPreLocalTime, acsResponse.substring(0, 18),
-        "preLocalTime substring is not as expected");
+      "preLocalTime substring is not as expected");
     assertEquals(expectedBlankSpaces, acsResponse.substring(18, 22),
-        "blank spaces substring is not as expected");
+      "blank spaces substring is not as expected");
     assertEquals(expectedPostLocalTime, acsResponse.substring(28),
-        "postLocalTime substring is not as expected");
+      "postLocalTime substring is not as expected");
   }
 }

--- a/src/test/java/org/folio/edge/sip2/api/support/BaseTest.java
+++ b/src/test/java/org/folio/edge/sip2/api/support/BaseTest.java
@@ -1,6 +1,5 @@
 package org.folio.edge.sip2.api.support;
 
-import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
@@ -17,8 +16,6 @@ import io.vertx.junit5.VertxTestContext;
 
 import java.io.IOException;
 import java.net.ServerSocket;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.EnumMap;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -160,13 +157,6 @@ public abstract class BaseTest {
         log.error("Failed to connect", res.cause());
       }
     });
-  }
-
-  protected String getFormattedLocalDateTime(ZonedDateTime dateTime) {
-    final ZonedDateTime d =  dateTime.truncatedTo(SECONDS);
-    final DateTimeFormatter formatter = DateTimeFormatter
-        .ofPattern("yyyyMMdd    HHmmss");
-    return formatter.format(d);
   }
 
   private void setMainVerticleInstance(String methodName) {

--- a/src/test/java/org/folio/edge/sip2/api/support/TestUtils.java
+++ b/src/test/java/org/folio/edge/sip2/api/support/TestUtils.java
@@ -1,0 +1,32 @@
+package org.folio.edge.sip2.api.support;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class TestUtils {
+
+  /**
+   * Utility method to get the local datetime formatted as SIP expects.
+   * @param dateTime Local datetime instance
+   * @return formatted into "yyyyMMdd    HHmmss"
+   */
+  public static String getFormattedLocalDateTime(ZonedDateTime dateTime) {
+    final ZonedDateTime d =  dateTime.truncatedTo(SECONDS);
+    final DateTimeFormatter formatter = DateTimeFormatter
+        .ofPattern("yyyyMMdd    HHmmss");
+    return formatter.format(d);
+  }
+
+  /**
+   * Method to get a fixed UTC clock for unit testing.
+   * @return
+   */
+  public static Clock getUtcFixedClock() {
+    return Clock.fixed(Instant.now(), ZoneOffset.UTC);
+  }
+}

--- a/src/test/java/org/folio/edge/sip2/handlers/CheckinHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/CheckinHandlerTests.java
@@ -13,11 +13,11 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
+
+import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.requests.Checkin;
 import org.folio.edge.sip2.domain.messages.responses.CheckinResponse;
 import org.folio.edge.sip2.handlers.freemarker.FreemarkerRepository;
@@ -35,7 +35,7 @@ public class CheckinHandlerTests {
       @Mock CirculationRepository mockCirculationRepository,
       Vertx vertx,
       VertxTestContext testContext) {
-    final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+    final Clock clock = TestUtils.getUtcFixedClock();
     final ZonedDateTime returnDate = ZonedDateTime.now();
     final String institutionId = "diku";
     final String itemIdentifier = "1234567890";
@@ -86,7 +86,7 @@ public class CheckinHandlerTests {
       @Mock CirculationRepository mockCirculationRepository,
       Vertx vertx,
       VertxTestContext testContext) {
-    final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+    final Clock clock = TestUtils.getUtcFixedClock();
     final ZonedDateTime returnDate = ZonedDateTime.now();
     final String institutionId = "diku";
     final String itemIdentifier = "1234567890";

--- a/src/test/java/org/folio/edge/sip2/handlers/CheckoutHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/CheckoutHandlerTests.java
@@ -13,10 +13,10 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+
+import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.requests.Checkout;
 import org.folio.edge.sip2.domain.messages.responses.CheckoutResponse;
 import org.folio.edge.sip2.handlers.freemarker.FreemarkerRepository;
@@ -34,7 +34,7 @@ public class CheckoutHandlerTests {
       @Mock CirculationRepository mockCirculationRepository,
       Vertx vertx,
       VertxTestContext testContext) {
-    final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+    final Clock clock = TestUtils.getUtcFixedClock();
     final ZonedDateTime nbDueDate = ZonedDateTime.now();
     final String institutionId = "diku";
     final String patronIdentifier = "0192837465";
@@ -94,7 +94,7 @@ public class CheckoutHandlerTests {
       @Mock CirculationRepository mockCirculationRepository,
       Vertx vertx,
       VertxTestContext testContext) {
-    final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+    final Clock clock = TestUtils.getUtcFixedClock();
     final ZonedDateTime nbDueDate = ZonedDateTime.now();
     final String institutionId = "diku";
     final String patronIdentifier = "0192837465";

--- a/src/test/java/org/folio/edge/sip2/handlers/EndPatronSessionHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/EndPatronSessionHandlerTests.java
@@ -10,11 +10,10 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 
 import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
+import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.requests.EndPatronSession;
 import org.folio.edge.sip2.handlers.freemarker.FreemarkerRepository;
 import org.folio.edge.sip2.session.SessionData;
@@ -30,7 +29,7 @@ public class EndPatronSessionHandlerTests {
     final String institutionId = "fs00000001";
     final String patronIdentifier = "patronId1234";
     final String patronPassword = "patronPassword";
-    final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+    final Clock clock = TestUtils.getUtcFixedClock();
 
     final EndPatronSession endPatronSessionRequest = EndPatronSession.builder()
         .patronIdentifier(patronIdentifier)

--- a/src/test/java/org/folio/edge/sip2/handlers/HandlersFactoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/HandlersFactoryTests.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import freemarker.template.Template;
+
+import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.handlers.freemarker.FreemarkerRepository;
 import org.folio.edge.sip2.parser.Command;
 import org.folio.edge.sip2.repositories.ConfigurationRepository;
@@ -14,22 +16,23 @@ public class HandlersFactoryTests {
   @Test
   public void canGetAcsStatusHandlerWithNullArguments() {
     ISip2RequestHandler acsStatusHandler = HandlersFactory
-        .getScStatusHandlerInstance(null, null, null);
+        .getScStatusHandlerInstance(null, null, null, null);
     assertNotNull(acsStatusHandler);
     assertTrue(acsStatusHandler instanceof SCStatusHandler);
   }
 
   @Test
-  public void canGetAcsStatusHandlerWithNonNlllArguments() {
-
-    DefaultResourceProvider resourceProvider = new DefaultResourceProvider();
-    ConfigurationRepository configRepo = new ConfigurationRepository(resourceProvider);
+  public void canGetAcsStatusHandlerWithNonNullArguments() {
+    DefaultResourceProvider resourceProvider =
+        new DefaultResourceProvider();
+    ConfigurationRepository configRepo = new ConfigurationRepository(resourceProvider,
+        TestUtils.getUtcFixedClock());
     Template freemarkerTemplate = FreemarkerRepository.getInstance()
         .getFreemarkerTemplate(Command.ACS_STATUS);
 
     ISip2RequestHandler acsStatusHandler = HandlersFactory
         .getScStatusHandlerInstance(configRepo, resourceProvider,
-            freemarkerTemplate);
+            freemarkerTemplate, null);
     assertNotNull(acsStatusHandler);
     assertTrue(acsStatusHandler instanceof SCStatusHandler);
   }

--- a/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
@@ -50,11 +50,9 @@ public class SCStatusHandlerTests {
               "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|"
               + "AFscreenMessages|AGline|";
           String expectedBlankSpaces = "    ";
-
           assertEquals(expectedPreLocalTime, sipMessage.substring(0, 18));
           assertEquals(expectedBlankSpaces, sipMessage.substring(18, 22));
           assertEquals(expectedPostLocalTime, sipMessage.substring(28));
-
           testContext.completeNow();
         })));
   }

--- a/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
@@ -7,12 +7,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.TimeZone;
 
+import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.enumerations.Messages;
 import org.folio.edge.sip2.domain.messages.enumerations.StatusCode;
 import org.folio.edge.sip2.domain.messages.requests.SCStatus;
@@ -30,6 +32,8 @@ public class SCStatusHandlerTests {
       VertxTestContext testContext) {
 
     DefaultResourceProvider defaultConfigurationProvider = new DefaultResourceProvider();
+    Clock clock = TestUtils.getUtcFixedClock();
+
 
     SCStatus.SCStatusBuilder statusBuilder = SCStatus.builder();
     statusBuilder.maxPrintWidth(20);
@@ -38,21 +42,23 @@ public class SCStatusHandlerTests {
     SCStatus status =  statusBuilder.build();
 
     SCStatusHandler handler = ((SCStatusHandler) HandlersFactory
-        .getScStatusHandlerInstance(null, defaultConfigurationProvider, null));
+        .getScStatusHandlerInstance(null, defaultConfigurationProvider, null, clock));
 
     handler.execute(status, null).setHandler(
         testContext.succeeding(sipMessage -> testContext.verify(() -> {
           // Because the sipMessage has a dateTime component that's supposed
           // to be current, we can't assert on the entirety of the string,
           // have to break it up into pieces.
-          String expectedPreLocalTime = "98YYNYNN53" + getFormattedDateString();
-          String expectedPostLocalTime =
-              "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|"
+
+          String expectedDateTimeString =
+              TestUtils.getFormattedLocalDateTime(ZonedDateTime.now(clock));
+
+          String expectedSipResponse = "98YYNYNN53"
+              + expectedDateTimeString
+              + "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|"
               + "AFscreenMessages|AGline|";
-          String expectedBlankSpaces = "    ";
-          assertEquals(expectedPreLocalTime, sipMessage.substring(0, 18));
-          assertEquals(expectedBlankSpaces, sipMessage.substring(18, 22));
-          assertEquals(expectedPostLocalTime, sipMessage.substring(28));
+
+          assertEquals(expectedSipResponse, sipMessage);
           testContext.completeNow();
         })));
   }
@@ -63,7 +69,8 @@ public class SCStatusHandlerTests {
       VertxTestContext testContext) {
     DefaultResourceProvider defaultConfigurationProvider = new DefaultResourceProvider();
     ConfigurationRepository configurationRepository =
-        new ConfigurationRepository(defaultConfigurationProvider);
+        new ConfigurationRepository(defaultConfigurationProvider,
+            Clock.fixed(Instant.now(), ZoneOffset.UTC));
 
     SCStatus.SCStatusBuilder statusBuilder = SCStatus.builder();
     statusBuilder.maxPrintWidth(20);
@@ -107,12 +114,5 @@ public class SCStatusHandlerTests {
     assertFalse(psm.getRequestScAcsResend());
     assertFalse(psm.getScAcsStatus());
     assertFalse(psm.getPatronInformation());
-  }
-
-  private String getFormattedDateString() {
-    String pattern = "YYYYMMdd";
-    SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern);
-    simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-    return simpleDateFormat.format(new Date());
   }
 }

--- a/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
@@ -11,6 +11,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.TimeZone;
 
 import org.folio.edge.sip2.domain.messages.enumerations.Messages;
 import org.folio.edge.sip2.domain.messages.enumerations.StatusCode;
@@ -25,8 +26,8 @@ public class SCStatusHandlerTests {
 
   @Test
   public void canExecuteASampleScStatusRequestUsingHandlersFactory(
-      Vertx vertx,
-      VertxTestContext testContext) {
+    Vertx vertx,
+    VertxTestContext testContext) {
 
     DefaultResourceProvider defaultConfigurationProvider = new DefaultResourceProvider();
 
@@ -37,34 +38,34 @@ public class SCStatusHandlerTests {
     SCStatus status =  statusBuilder.build();
 
     SCStatusHandler handler = ((SCStatusHandler) HandlersFactory
-        .getScStatusHandlerInstance(null, defaultConfigurationProvider, null));
+      .getScStatusHandlerInstance(null, defaultConfigurationProvider, null));
 
     handler.execute(status, null).setHandler(
-        testContext.succeeding(sipMessage -> testContext.verify(() -> {
-          // Because the sipMessage has a dateTime component that's supposed
-          // to be current, we can't assert on the entirety of the string,
-          // have to break it up into pieces.
-          String expectedPreLocalTime = "98YYNYNN53" + getFormattedDateString();
-          String expectedPostLocalTime = 
-              "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|"
-              + "AFscreenMessages|AGline|";
-          String expectedBlankSpaces = "    ";
-      
-          assertEquals(expectedPreLocalTime, sipMessage.substring(0, 18));
-          assertEquals(expectedBlankSpaces, sipMessage.substring(18, 22));
-          assertEquals(expectedPostLocalTime, sipMessage.substring(28));
-    
-          testContext.completeNow();
-        })));
+      testContext.succeeding(sipMessage -> testContext.verify(() -> {
+        // Because the sipMessage has a dateTime component that's supposed
+        // to be current, we can't assert on the entirety of the string,
+        // have to break it up into pieces.
+        String expectedPreLocalTime = "98YYNYNN53" + getFormattedDateString();
+        String expectedPostLocalTime =
+          "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|"
+            + "AFscreenMessages|AGline|";
+        String expectedBlankSpaces = "    ";
+
+        assertEquals(expectedPreLocalTime, sipMessage.substring(0, 18));
+        assertEquals(expectedBlankSpaces, sipMessage.substring(18, 22));
+        assertEquals(expectedPostLocalTime, sipMessage.substring(28));
+
+        testContext.completeNow();
+      })));
   }
 
   @Test
   public void cannotGetAValidResponseDueToMissingTemplate(
-      Vertx vertx,
-      VertxTestContext testContext) {
+    Vertx vertx,
+    VertxTestContext testContext) {
     DefaultResourceProvider defaultConfigurationProvider = new DefaultResourceProvider();
     ConfigurationRepository configurationRepository =
-        new ConfigurationRepository(defaultConfigurationProvider);
+      new ConfigurationRepository(defaultConfigurationProvider);
 
     SCStatus.SCStatusBuilder statusBuilder = SCStatus.builder();
     statusBuilder.maxPrintWidth(20);
@@ -75,10 +76,10 @@ public class SCStatusHandlerTests {
     SCStatusHandler handler = new SCStatusHandler(configurationRepository, null);
 
     handler.execute(status, null).setHandler(
-        testContext.failing(throwable -> testContext.verify(() -> {
-          assertEquals("", throwable.getMessage());
-          testContext.completeNow();
-        })));
+      testContext.failing(throwable -> testContext.verify(() -> {
+        assertEquals("", throwable.getMessage());
+        testContext.completeNow();
+      })));
   }
 
   @Test
@@ -91,7 +92,7 @@ public class SCStatusHandlerTests {
 
 
     SCStatusHandler.PackagedSupportedMessages psm =
-        new SCStatusHandler.PackagedSupportedMessages(supportedMessages);
+      new SCStatusHandler.PackagedSupportedMessages(supportedMessages);
     assertTrue(psm.getCheckIn());
     assertTrue(psm.getCheckOut());
     assertTrue(psm.getHold());
@@ -113,6 +114,7 @@ public class SCStatusHandlerTests {
   private String getFormattedDateString() {
     String pattern = "YYYYMMdd";
     SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern);
+    simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
     return simpleDateFormat.format(new Date());
   }
 }

--- a/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
@@ -26,8 +26,8 @@ public class SCStatusHandlerTests {
 
   @Test
   public void canExecuteASampleScStatusRequestUsingHandlersFactory(
-    Vertx vertx,
-    VertxTestContext testContext) {
+      Vertx vertx,
+      VertxTestContext testContext) {
 
     DefaultResourceProvider defaultConfigurationProvider = new DefaultResourceProvider();
 
@@ -38,34 +38,34 @@ public class SCStatusHandlerTests {
     SCStatus status =  statusBuilder.build();
 
     SCStatusHandler handler = ((SCStatusHandler) HandlersFactory
-      .getScStatusHandlerInstance(null, defaultConfigurationProvider, null));
+        .getScStatusHandlerInstance(null, defaultConfigurationProvider, null));
 
     handler.execute(status, null).setHandler(
-      testContext.succeeding(sipMessage -> testContext.verify(() -> {
-        // Because the sipMessage has a dateTime component that's supposed
-        // to be current, we can't assert on the entirety of the string,
-        // have to break it up into pieces.
-        String expectedPreLocalTime = "98YYNYNN53" + getFormattedDateString();
-        String expectedPostLocalTime =
-          "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|"
-            + "AFscreenMessages|AGline|";
-        String expectedBlankSpaces = "    ";
+        testContext.succeeding(sipMessage -> testContext.verify(() -> {
+          // Because the sipMessage has a dateTime component that's supposed
+          // to be current, we can't assert on the entirety of the string,
+          // have to break it up into pieces.
+          String expectedPreLocalTime = "98YYNYNN53" + getFormattedDateString();
+          String expectedPostLocalTime =
+              "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|"
+              + "AFscreenMessages|AGline|";
+          String expectedBlankSpaces = "    ";
 
-        assertEquals(expectedPreLocalTime, sipMessage.substring(0, 18));
-        assertEquals(expectedBlankSpaces, sipMessage.substring(18, 22));
-        assertEquals(expectedPostLocalTime, sipMessage.substring(28));
+          assertEquals(expectedPreLocalTime, sipMessage.substring(0, 18));
+          assertEquals(expectedBlankSpaces, sipMessage.substring(18, 22));
+          assertEquals(expectedPostLocalTime, sipMessage.substring(28));
 
-        testContext.completeNow();
-      })));
+          testContext.completeNow();
+        })));
   }
 
   @Test
   public void cannotGetAValidResponseDueToMissingTemplate(
-    Vertx vertx,
-    VertxTestContext testContext) {
+      Vertx vertx,
+      VertxTestContext testContext) {
     DefaultResourceProvider defaultConfigurationProvider = new DefaultResourceProvider();
     ConfigurationRepository configurationRepository =
-      new ConfigurationRepository(defaultConfigurationProvider);
+        new ConfigurationRepository(defaultConfigurationProvider);
 
     SCStatus.SCStatusBuilder statusBuilder = SCStatus.builder();
     statusBuilder.maxPrintWidth(20);
@@ -76,10 +76,10 @@ public class SCStatusHandlerTests {
     SCStatusHandler handler = new SCStatusHandler(configurationRepository, null);
 
     handler.execute(status, null).setHandler(
-      testContext.failing(throwable -> testContext.verify(() -> {
-        assertEquals("", throwable.getMessage());
-        testContext.completeNow();
-      })));
+        testContext.failing(throwable -> testContext.verify(() -> {
+          assertEquals("", throwable.getMessage());
+          testContext.completeNow();
+        })));
   }
 
   @Test
@@ -92,7 +92,7 @@ public class SCStatusHandlerTests {
 
 
     SCStatusHandler.PackagedSupportedMessages psm =
-      new SCStatusHandler.PackagedSupportedMessages(supportedMessages);
+        new SCStatusHandler.PackagedSupportedMessages(supportedMessages);
     assertTrue(psm.getCheckIn());
     assertTrue(psm.getCheckOut());
     assertTrue(psm.getHold());

--- a/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
@@ -18,11 +18,11 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
+
+import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.requests.Checkin;
 import org.folio.edge.sip2.domain.messages.requests.Checkout;
 import org.folio.edge.sip2.session.SessionData;
@@ -56,7 +56,7 @@ public class CirculationRepositoryTests {
   public void canCheckin(Vertx vertx,
       VertxTestContext testContext,
       @Mock IResourceProvider<IRequestData> mockFolioProvider) {
-    final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+    final Clock clock = TestUtils.getUtcFixedClock();
     final ZonedDateTime returnDate = ZonedDateTime.now();
     final String currentLocation = UUID.randomUUID().toString();
     final String itemIdentifier = "1234567890";
@@ -111,7 +111,7 @@ public class CirculationRepositoryTests {
   public void cannotCheckin(Vertx vertx,
       VertxTestContext testContext,
       @Mock IResourceProvider<IRequestData> mockFolioProvider) {
-    final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+    final Clock clock = TestUtils.getUtcFixedClock();
     final ZonedDateTime returnDate = ZonedDateTime.now();
     final String currentLocation = UUID.randomUUID().toString();
     final String itemIdentifier = "1234567890";
@@ -161,7 +161,7 @@ public class CirculationRepositoryTests {
   public void canCheckout(Vertx vertx,
       VertxTestContext testContext,
       @Mock IResourceProvider<IRequestData> mockFolioProvider) {
-    final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+    final Clock clock = TestUtils.getUtcFixedClock();
     final ZonedDateTime nbDueDate = ZonedDateTime.now().plusDays(30);
     final String patronIdentifier = "1029384756";
     final String itemIdentifier = "1234567890";
@@ -225,7 +225,7 @@ public class CirculationRepositoryTests {
   public void cannotCheckout(Vertx vertx,
       VertxTestContext testContext,
       @Mock IResourceProvider<IRequestData> mockFolioProvider) {
-    final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+    final Clock clock = TestUtils.getUtcFixedClock();
     final ZonedDateTime nbDueDate = ZonedDateTime.now().plusDays(30);
     final String patronIdentifier = "1029384756";
     final String itemIdentifier = "1234567890";

--- a/src/test/java/org/folio/edge/sip2/repositories/ConfigurationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/ConfigurationRepositoryTests.java
@@ -12,7 +12,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-import java.time.LocalDate;
+
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 
@@ -45,11 +45,11 @@ public class ConfigurationRepositoryTests {
   public void canGetValidAcsStatus(Vertx vertx, VertxTestContext testContext) {
     JsonArray supportedMsgs = new JsonArray();
     supportedMsgs.add(new JsonObject().put("messageName", "PATRON_INFORMATION")
-      .put("isSupported","Y"));
+                            .put("isSupported","Y"));
     supportedMsgs.add(new JsonObject().put("messageName", "RENEW")
-      .put("isSupported","N"));
+                            .put("isSupported","N"));
     supportedMsgs.add(new JsonObject().put("messageName", "BLOCK_PATRON")
-      .put("isSupported","Y"));
+                            .put("isSupported","Y"));
 
     JsonObject acsConfig = new JsonObject();
     acsConfig.put("onlineStatus", false);
@@ -78,58 +78,58 @@ public class ConfigurationRepositoryTests {
       .thenReturn(Future.succeededFuture(() -> defaultConfigurations));
 
     ConfigurationRepository configurationRepository =
-      new ConfigurationRepository(mockConfigProvider);
+        new ConfigurationRepository(mockConfigProvider);
     configurationRepository.getACSStatus().setHandler(
-      testContext.succeeding(status -> testContext.verify(() -> {
+        testContext.succeeding(status -> testContext.verify(() -> {
 
-        assertNotNull(status);
-        assertEquals(false, status.getOnLineStatus());
-        assertEquals(false, status.getCheckinOk());
-        assertEquals(true, status.getCheckoutOk());
-        assertEquals(false, status.getAcsRenewalPolicy());
-        assertEquals(true, status.getOffLineOk());
-        assertEquals(3, status.getTimeoutPeriod());
-        assertEquals(2, status.getRetriesAllowed());
-        assertEquals("1.23", status.getProtocolVersion());
-        assertEquals("fs00000010", status.getInstitutionId());
-        assertEquals("testing", status.getPrintLine());
-        assertEquals("Chalmers", status.getLibraryName());
-        assertEquals("Hello, welcome", status.getScreenMessage());
-        assertEquals("SE10", status.getTerminalLocation());
+          assertNotNull(status);
+          assertEquals(false, status.getOnLineStatus());
+          assertEquals(false, status.getCheckinOk());
+          assertEquals(true, status.getCheckoutOk());
+          assertEquals(false, status.getAcsRenewalPolicy());
+          assertEquals(true, status.getOffLineOk());
+          assertEquals(3, status.getTimeoutPeriod());
+          assertEquals(2, status.getRetriesAllowed());
+          assertEquals("1.23", status.getProtocolVersion());
+          assertEquals("fs00000010", status.getInstitutionId());
+          assertEquals("testing", status.getPrintLine());
+          assertEquals("Chalmers", status.getLibraryName());
+          assertEquals("Hello, welcome", status.getScreenMessage());
+          assertEquals("SE10", status.getTerminalLocation());
 
-        LocalDateTime currentDate = LocalDateTime.now(ZoneOffset.UTC);
+          LocalDateTime currentDate = LocalDateTime.now(ZoneOffset.UTC);
 
-        assertEquals(currentDate.getYear(), status.getDateTimeSync().getYear());
-        assertEquals(currentDate.getMonth(), status.getDateTimeSync().getMonth());
-        assertEquals(currentDate.getDayOfMonth(), status.getDateTimeSync().getDayOfMonth());
+          assertEquals(currentDate.getYear(), status.getDateTimeSync().getYear());
+          assertEquals(currentDate.getMonth(), status.getDateTimeSync().getMonth());
+          assertEquals(currentDate.getDayOfMonth(), status.getDateTimeSync().getDayOfMonth());
 
-        assertEquals(2, status.getSupportedMessages().size());
-        Messages[] supportedMsgsArr = status.getSupportedMessages().toArray(new Messages[2]);
+          assertEquals(2, status.getSupportedMessages().size());
+          Messages[] supportedMsgsArr = status.getSupportedMessages().toArray(new Messages[2]);
 
-        //note that the messages will be reordered because it's stored in a list.
-        //it's up to the appropriate handler to re-present the messages in the correct order
-        assertEquals(Messages.BLOCK_PATRON, supportedMsgsArr[0]);
-        assertEquals(Messages.PATRON_INFORMATION, supportedMsgsArr[1]);
+          //note that the messages will be reordered because it's stored in a list.
+          //it's up to the appropriate handler to re-present the messages in the correct order
+          assertEquals(Messages.BLOCK_PATRON, supportedMsgsArr[0]);
+          assertEquals(Messages.PATRON_INFORMATION, supportedMsgsArr[1]);
 
-        testContext.completeNow();
-      })));
+          testContext.completeNow();
+        })));
   }
 
   @Test
   public void canRetrieveTenantConfiguration(
-    Vertx vertx,
-    VertxTestContext testContext) {
+      Vertx vertx,
+      VertxTestContext testContext) {
     DefaultResourceProvider resourceProvider = new DefaultResourceProvider();
     ConfigurationRepository configRepo = new ConfigurationRepository(resourceProvider);
 
     configRepo.retrieveTenantConfiguration("fs00000010test").setHandler(
-      testContext.succeeding(testTenantConfig -> testContext.verify(() -> {
-        assertNotNull(testTenantConfig);
-        assertEquals("fs00000010test",
-          testTenantConfig.getString("tenantId"));
-        assertEquals("ASCII", testTenantConfig.getString("encoding"));
+        testContext.succeeding(testTenantConfig -> testContext.verify(() -> {
+          assertNotNull(testTenantConfig);
+          assertEquals("fs00000010test",
+              testTenantConfig.getString("tenantId"));
+          assertEquals("ASCII", testTenantConfig.getString("encoding"));
 
-        testContext.completeNow();
-      })));
+          testContext.completeNow();
+        })));
   }
 }

--- a/src/test/java/org/folio/edge/sip2/repositories/ConfigurationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/ConfigurationRepositoryTests.java
@@ -98,7 +98,6 @@ public class ConfigurationRepositoryTests {
           assertEquals("SE10", status.getTerminalLocation());
 
           LocalDateTime currentDate = LocalDateTime.now(ZoneOffset.UTC);
-
           assertEquals(currentDate.getYear(), status.getDateTimeSync().getYear());
           assertEquals(currentDate.getMonth(), status.getDateTimeSync().getMonth());
           assertEquals(currentDate.getDayOfMonth(), status.getDateTimeSync().getDayOfMonth());

--- a/src/test/java/org/folio/edge/sip2/repositories/ConfigurationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/ConfigurationRepositoryTests.java
@@ -13,6 +13,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 import org.folio.edge.sip2.domain.messages.enumerations.Messages;
 import org.junit.jupiter.api.Test;
@@ -43,11 +45,11 @@ public class ConfigurationRepositoryTests {
   public void canGetValidAcsStatus(Vertx vertx, VertxTestContext testContext) {
     JsonArray supportedMsgs = new JsonArray();
     supportedMsgs.add(new JsonObject().put("messageName", "PATRON_INFORMATION")
-                            .put("isSupported","Y"));
+      .put("isSupported","Y"));
     supportedMsgs.add(new JsonObject().put("messageName", "RENEW")
-                            .put("isSupported","N"));
+      .put("isSupported","N"));
     supportedMsgs.add(new JsonObject().put("messageName", "BLOCK_PATRON")
-                            .put("isSupported","Y"));
+      .put("isSupported","Y"));
 
     JsonObject acsConfig = new JsonObject();
     acsConfig.put("onlineStatus", false);
@@ -76,57 +78,58 @@ public class ConfigurationRepositoryTests {
       .thenReturn(Future.succeededFuture(() -> defaultConfigurations));
 
     ConfigurationRepository configurationRepository =
-        new ConfigurationRepository(mockConfigProvider);
+      new ConfigurationRepository(mockConfigProvider);
     configurationRepository.getACSStatus().setHandler(
-        testContext.succeeding(status -> testContext.verify(() -> {
+      testContext.succeeding(status -> testContext.verify(() -> {
 
-          assertNotNull(status);
-          assertEquals(false, status.getOnLineStatus());
-          assertEquals(false, status.getCheckinOk());
-          assertEquals(true, status.getCheckoutOk());
-          assertEquals(false, status.getAcsRenewalPolicy());
-          assertEquals(true, status.getOffLineOk());
-          assertEquals(3, status.getTimeoutPeriod());
-          assertEquals(2, status.getRetriesAllowed());
-          assertEquals("1.23", status.getProtocolVersion());
-          assertEquals("fs00000010", status.getInstitutionId());
-          assertEquals("testing", status.getPrintLine());
-          assertEquals("Chalmers", status.getLibraryName());
-          assertEquals("Hello, welcome", status.getScreenMessage());
-          assertEquals("SE10", status.getTerminalLocation());
+        assertNotNull(status);
+        assertEquals(false, status.getOnLineStatus());
+        assertEquals(false, status.getCheckinOk());
+        assertEquals(true, status.getCheckoutOk());
+        assertEquals(false, status.getAcsRenewalPolicy());
+        assertEquals(true, status.getOffLineOk());
+        assertEquals(3, status.getTimeoutPeriod());
+        assertEquals(2, status.getRetriesAllowed());
+        assertEquals("1.23", status.getProtocolVersion());
+        assertEquals("fs00000010", status.getInstitutionId());
+        assertEquals("testing", status.getPrintLine());
+        assertEquals("Chalmers", status.getLibraryName());
+        assertEquals("Hello, welcome", status.getScreenMessage());
+        assertEquals("SE10", status.getTerminalLocation());
 
-          LocalDate currentDate = LocalDate.now();
-          assertEquals(currentDate.getYear(), status.getDateTimeSync().getYear());
-          assertEquals(currentDate.getMonth(), status.getDateTimeSync().getMonth());
-          assertEquals(currentDate.getDayOfMonth(), status.getDateTimeSync().getDayOfMonth());
+        LocalDateTime currentDate = LocalDateTime.now(ZoneOffset.UTC);
 
-          assertEquals(2, status.getSupportedMessages().size());
-          Messages[] supportedMsgsArr = status.getSupportedMessages().toArray(new Messages[2]);
+        assertEquals(currentDate.getYear(), status.getDateTimeSync().getYear());
+        assertEquals(currentDate.getMonth(), status.getDateTimeSync().getMonth());
+        assertEquals(currentDate.getDayOfMonth(), status.getDateTimeSync().getDayOfMonth());
 
-          //note that the messages will be reordered because it's stored in a list.
-          //it's up to the appropriate handler to re-present the messages in the correct order
-          assertEquals(Messages.BLOCK_PATRON, supportedMsgsArr[0]);
-          assertEquals(Messages.PATRON_INFORMATION, supportedMsgsArr[1]);
+        assertEquals(2, status.getSupportedMessages().size());
+        Messages[] supportedMsgsArr = status.getSupportedMessages().toArray(new Messages[2]);
 
-          testContext.completeNow();
-        })));
+        //note that the messages will be reordered because it's stored in a list.
+        //it's up to the appropriate handler to re-present the messages in the correct order
+        assertEquals(Messages.BLOCK_PATRON, supportedMsgsArr[0]);
+        assertEquals(Messages.PATRON_INFORMATION, supportedMsgsArr[1]);
+
+        testContext.completeNow();
+      })));
   }
 
   @Test
   public void canRetrieveTenantConfiguration(
-      Vertx vertx,
-      VertxTestContext testContext) {
+    Vertx vertx,
+    VertxTestContext testContext) {
     DefaultResourceProvider resourceProvider = new DefaultResourceProvider();
     ConfigurationRepository configRepo = new ConfigurationRepository(resourceProvider);
 
     configRepo.retrieveTenantConfiguration("fs00000010test").setHandler(
-        testContext.succeeding(testTenantConfig -> testContext.verify(() -> {
-          assertNotNull(testTenantConfig);
-          assertEquals("fs00000010test",
-              testTenantConfig.getString("tenantId"));
-          assertEquals("ASCII", testTenantConfig.getString("encoding"));
+      testContext.succeeding(testTenantConfig -> testContext.verify(() -> {
+        assertNotNull(testTenantConfig);
+        assertEquals("fs00000010test",
+          testTenantConfig.getString("tenantId"));
+        assertEquals("ASCII", testTenantConfig.getString("encoding"));
 
-          testContext.completeNow();
-        })));
+        testContext.completeNow();
+      })));
   }
 }

--- a/src/test/java/org/folio/edge/sip2/repositories/ConfigurationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/ConfigurationRepositoryTests.java
@@ -2,7 +2,7 @@ package org.folio.edge.sip2.repositories;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -13,32 +13,33 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
+import java.time.Clock;
+import java.time.ZonedDateTime;
 
+import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.enumerations.Messages;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(VertxExtension.class)
+@ExtendWith({VertxExtension.class, MockitoExtension.class})
 public class ConfigurationRepositoryTests {
 
   @Test
-  public void canCreateConfigurationRepo() {
+  public void canCreateConfigurationRepo(@Mock IResourceProvider mockConfig, @Mock Clock clock) {
     @SuppressWarnings("unchecked")
-    IResourceProvider<Object> mockConfig = mock(IResourceProvider.class);
-    ConfigurationRepository configRepo = new ConfigurationRepository(mockConfig);
+    ConfigurationRepository configRepo = new ConfigurationRepository(mockConfig, clock);
     assertNotNull(configRepo);
   }
 
   @Test
-  public void cannotCreateConfigurationRepoWhenConfigProviderIsNull() {
-    try {
-      new ConfigurationRepository(null);
-      fail("expected an exception to be thrown");
-    } catch (IllegalArgumentException ex) {
-      assertEquals("configGateway is null", ex.getMessage());
-    }
+  public void cannotCreateConfigurationRepoWhenConfigProviderIsNull(@Mock Clock clock) {
+
+    final NullPointerException thrown = assertThrows(
+        NullPointerException.class, () -> new ConfigurationRepository(null, clock));
+
+    assertEquals("ConfigGateway cannot be null", thrown.getMessage());
   }
 
   @Test
@@ -60,7 +61,6 @@ public class ConfigurationRepositoryTests {
     acsConfig.put("offlineOk", true);
     acsConfig.put("timeoutPeriod", 3);
     acsConfig.put("retriesAllowed", 2);
-    acsConfig.put("dateTimeSync", "2019-04-05 13:26:13");
     acsConfig.put("protocolVersion", "1.23");
     acsConfig.put("institutionId", "fs00000010");
     acsConfig.put("printLine", "testing");
@@ -77,8 +77,10 @@ public class ConfigurationRepositoryTests {
     when(mockConfigProvider.retrieveResource(null))
       .thenReturn(Future.succeededFuture(() -> defaultConfigurations));
 
+    Clock clock = TestUtils.getUtcFixedClock();
+
     ConfigurationRepository configurationRepository =
-        new ConfigurationRepository(mockConfigProvider);
+        new ConfigurationRepository(mockConfigProvider, clock);
     configurationRepository.getACSStatus().setHandler(
         testContext.succeeding(status -> testContext.verify(() -> {
 
@@ -96,11 +98,7 @@ public class ConfigurationRepositoryTests {
           assertEquals("Chalmers", status.getLibraryName());
           assertEquals("Hello, welcome", status.getScreenMessage());
           assertEquals("SE10", status.getTerminalLocation());
-
-          LocalDateTime currentDate = LocalDateTime.now(ZoneOffset.UTC);
-          assertEquals(currentDate.getYear(), status.getDateTimeSync().getYear());
-          assertEquals(currentDate.getMonth(), status.getDateTimeSync().getMonth());
-          assertEquals(currentDate.getDayOfMonth(), status.getDateTimeSync().getDayOfMonth());
+          assertEquals(ZonedDateTime.now(clock), status.getDateTimeSync());
 
           assertEquals(2, status.getSupportedMessages().size());
           Messages[] supportedMsgsArr = status.getSupportedMessages().toArray(new Messages[2]);
@@ -117,9 +115,9 @@ public class ConfigurationRepositoryTests {
   @Test
   public void canRetrieveTenantConfiguration(
       Vertx vertx,
-      VertxTestContext testContext) {
+      VertxTestContext testContext, @Mock Clock clock) {
     DefaultResourceProvider resourceProvider = new DefaultResourceProvider();
-    ConfigurationRepository configRepo = new ConfigurationRepository(resourceProvider);
+    ConfigurationRepository configRepo = new ConfigurationRepository(resourceProvider, clock);
 
     configRepo.retrieveTenantConfiguration("fs00000010test").setHandler(
         testContext.succeeding(testTenantConfig -> testContext.verify(() -> {


### PR DESCRIPTION
Assigned agreed upon values to the default ACS configuration file. 
Return UTC timestamp for transaction date instead of local (server) time. Adjusted tests upon making this change. 