### PR TITLE
add zero padding to timeout and retries numbers

### DIFF
--- a/src/main/resources/templates/acs-status.ftl
+++ b/src/main/resources/templates/acs-status.ftl
@@ -23,8 +23,8 @@ ${ACSStatus.checkoutOk}<#rt>
 ${ACSStatus.acsRenewalPolicy}<#rt>
 ${ACSStatus.statusUpdateOk}<#rt>
 ${ACSStatus.offLineOk}<#rt>
-${ACSStatus.timeoutPeriod}<#rt>
-${ACSStatus.retriesAllowed}<#rt>
+${ACSStatus.timeoutPeriod?string("000")}<#rt>
+${ACSStatus.retriesAllowed?string("000")}<#rt>
 ${formatDateTime(ACSStatus.dateTimeSync, "yyyyMMdd    HHmmss")}<#t>
 ${ACSStatus.protocolVersion}|<#rt>
 AO${ACSStatus.institutionId}|<#rt>

--- a/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
+++ b/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
@@ -183,16 +183,16 @@ public class MainVerticleTests extends BaseTest {
 
     log.info("ACS response: " + acsResponse);
 
-    String expectedPreLocalTime = "98YYNYNN53" + getFormattedDateString();
+    String expectedPreLocalTime = "98YYNYNN005003" + getFormattedDateString();
     String expectedPostLocalTime =
         "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|AFscreenMessages|AGline|\r";
     String expectedBlankSpaces = "    ";
 
-    assertEquals(expectedPreLocalTime, acsResponse.substring(0, 18),
+    assertEquals(expectedPreLocalTime, acsResponse.substring(0, 22),
         "preLocalTime substring is not as expected");
-    assertEquals(expectedBlankSpaces, acsResponse.substring(18, 22),
+    assertEquals(expectedBlankSpaces, acsResponse.substring(22, 26),
         "blank spaces substring is not as expected");
-    assertEquals(expectedPostLocalTime, acsResponse.substring(28),
+    assertEquals(expectedPostLocalTime, acsResponse.substring(32),
         "postLocalTime substring is not as expected");
   }
 }

--- a/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
@@ -53,7 +53,7 @@ public class SCStatusHandlerTests {
           String expectedDateTimeString =
               TestUtils.getFormattedLocalDateTime(ZonedDateTime.now(clock));
 
-          String expectedSipResponse = "98YYNYNN53"
+          String expectedSipResponse = "98YYNYNN005003"
               + expectedDateTimeString
               + "1.23|AOfs00000010test|AMChalmers|BXYNNNYNYNNNNNNNYN|ANTL01|"
               + "AFscreenMessages|AGline|";


### PR DESCRIPTION
The timeout and retries fields are fixed length fields of 3 characters.  Currently it only displays a number "3" or "5" without any preceding 0's.  Modified the ACS status template to print out the numbers appropriately padded and modified the tests' expectations. 