### PR TITLE
SIP2-38: Add support for TLS (SSL) startup via vertx config

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ $ java -jar edge-sip2-fat.jar -conf '{"port":1234,"okapiUrl":"https://folio-snap
 |`path`|string|File system path to JKS key store|
 |`password`|string|The password for the JKS key store|
 
+#### Security concerns for developers
+
+For local development, there is no requirement to encrypt communications from a SIP2 client to edge-sip2. Unencrypted TCP sockets are the default when launching edge-sip2 as described in the [Configuration](#configuration) section. Encrypted communication from a SIP2 client is only required when explicitly configured via the [above options](#security) and is up to the developer to provide that secure connection for edge-sip2.
+
 ## Additional information
 
 [SIP2 Specification](http://multimedia.3m.com/mws/media/355361O/sip2-protocol.pdf)

--- a/README.md
+++ b/README.md
@@ -13,13 +13,74 @@ issue requests and receive responses in Standard Interchange Protocol v2 (SIP2).
 These requests will be serviced by FOLIO APIs and the responses will be based on
 FOLIO results for all supported (TBD) SIP2 commands.
 
-## Security
-
-TBD (most likely stunnel)
-
 ## Configuration
 
-TBD
+The edge-sip2 module can be launched via `edge-sip2-fat.jar` as follows:
+
+```bash
+$ java -jar edge-sip2-fat.jar -conf '{"port":1234,"okapiUrl":"https://folio-snapshot-okapi.aws.indexdata.com","tenant":"diku"}'
+```
+
+|Config option|Type|Description|
+|-------------|----|-----------|
+|`port`|int|The port the module will use to bind, typically 1024 < port < 65,535.|
+|`okapiUrl`|string|The URL of the Okapi server used by FOLIO.|
+|`tenant`|string|The FOLIO assigned tenant ID. Multi-tenant support TBD.|
+|`fieldDelimiter`|string|The character that the self service kiosk will use when encoding SIP messages. Defaults to "\|".|
+|`errorDetectionEnabled`|boolean|Indicates whether or not the self service kiosk will be using SIP error detection in messages sent to and from this module. Defaults to "false".|
+|`charset`|string|The character set SIP messages must be encoded with when sent and received by the self service kiosk. The charset must be defined as a "Canonical Name for java.nio API". See: [Supported Encodings](https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html). Default is "IBM850".|
+|`messageDelimiter`|string|The character sequence that indicates the end of a single SIP message. This is available in case the self check kiosk is not compliant with the SIP specification. The default is "\\r"|
+|`netServerOptions`|JSON object|Configuration options for the server. These are Vertx options and are numerous. See: [NetServerOptions](https://vertx.io/docs/apidocs/io/vertx/core/net/NetServerOptions.html).|
+
+## Security
+
+The SIP protocol does not consider security apart from providing the possibility of SC/ACS negotiated encryption algorithm for the password and user ID, which seems unlikely to be used. All communication over the wire, via TCP, is plain text. This may be fine in an environment that is locked down in some way. However, FOLIO, along with this module, can be hosted in the cloud and plain text communication is not acceptable.
+
+We **_strongly_** recommend securing communication from the SC to edge-sip2. To this end, edge-sip2 can be configured to use TLS to encrypt communication. This requires the SC to communicate with TLS as well. It is our understanding that most self service kiosks do not have this ability natively and third party solutions must be employed. One such solution is `stunnel`.
+
+A typical `stunnel` deployment will involve installing the `stunnel` service either on the SC or a machine that is locked down with the SC and provides a port that the SC will be configured to connect to for SIP communication. The SIP commands are then sent to and received from the `stunnel` port unencrypted. Communication from the `stunnel` to the TLS termination end point will be encrypted. There are several ways to terminate TLS and the advantages/disadvantages of these is out of scope for this document. Here, we will focus on enabling TLS termination via the edge-sip2 module. This is done via simple launch configuration options.
+
+`stunnel` can be downloaded here: [https://www.stunnel.org/downloads.html](https://www.stunnel.org/downloads.html)
+
+Example FOLIO configuration section for `stunnel.conf`:
+
+```ini
+[FOLIO]
+key = stunnel.pem
+cert = stunnel.pem
+client = yes
+accept = 127.0.0.1:5555
+connect = sip2.example.com:6443
+```
+Example edge-sip2 configuration:
+
+```bash
+$ java -jar edge-sip2-fat.jar -conf '{"port":1234,"okapiUrl":"https://folio-snapshot-okapi.aws.indexdata.com","tenant":"diku","netServerOptions":{"ssl":true,"pemKeyCertOptions":{"certPaths":["cert.crt"],"keyPaths":["cert.key"]}}}'
+```
+
+|Config option|Type|Description|
+|-------------|----|-----------|
+|`ssl`|boolean|Indicates whether or not to enable SSL (TLS) support for the server|
+|`pemKeyCertOptions`|JSON object|Used when the certificate is in PEM format|
+|`pfxKeyCertOptions`|JSON object|Used when the certificate is in PFX format|
+|`keyStoreOptions`|JSON object|Used when the certificate is in JKS (Java Keystore) format|
+
+|`pemKeyCertOptions`|type|Description|
+|-------------------|----|-----------|
+|`certPath`|string|File system path to a PEM formatted certificate|
+|`certPaths`|JSON array of strings|File system paths to PEM formatted certificates|
+|`keyPath`|string|File system path to PEM formatted key|
+|`keyPaths`|JSON array of strings|File system paths to PEM formatted keys|
+
+|`pfxKeyCertOptions`|type|Description|
+|-------------------|----|-----------|
+|`path`|string|File system path to PFX (PKCS #12) store|
+|`password`|string|The password for the PFX (PKCS #12) store|
+
+|`keyStoreOptions`|type|Description|
+|-----------------|----|-----------|
+|`path`|string|File system path to JKS key store|
+|`password`|string|The password for the JKS key store|
 
 ## Additional information
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -196,7 +196,7 @@
             <property name="ignoreFinal" value="false"/>
             <property name="allowedAbbreviationLength" value="1"/>
             <!-- Begin modification mreno-EBSCO -->
-            <property name="allowedAbbreviations" value="PWD,UID,ACS,SC"/>
+            <property name="allowedAbbreviations" value="PWD,UID,ACS,SC,TLS"/>
             <!-- End modification mreno-EBSCO -->
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -6,7 +6,7 @@
     </Console>
   </Appenders>
   <Loggers>
-    <Root level="debug">
+    <Root level="${sys:loglevel:-info}">
       <AppenderRef ref="STDOUT"/>
     </Root>
   </Loggers>

--- a/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
+++ b/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
@@ -79,7 +79,7 @@ public class MainVerticleTests extends BaseTest {
   }
 
   @Test
-  @Tag("ErrorDetectionEnabled")
+  @Tag(ERROR_DETECTION_ENABLED)
   public void canGetCsResendMessageWhenSendingInvalidMessage(
       Vertx vertx, VertxTestContext testContext) {
     String scStatusMessage = "9900401.00AY1AZAAAA\r";
@@ -177,7 +177,7 @@ public class MainVerticleTests extends BaseTest {
   }
 
   @Test
-  @Tag("TLSEnabled")
+  @Tag(TLS_ENABLED)
   void canConnectWithTLS(Vertx vertx, VertxTestContext testContext, TestInfo testInfo) {
     callService("990231.23\r", testContext, vertx, testInfo, result -> {
       assertTrue(result.contains("Problems handling the request"));

--- a/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
+++ b/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
@@ -18,6 +18,7 @@ import org.folio.edge.sip2.api.support.TestUtils;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 /**
  * Integration tests for SIP service.
@@ -45,34 +46,34 @@ public class MainVerticleTests extends BaseTest {
   }
 
   @Test
-  public void canMakeARequest(Vertx vertex, VertxTestContext testContext) {
+  public void canMakeARequest(Vertx vertx, VertxTestContext testContext) {
     callService("9300CNMartin|COpassword|\r",
-        testContext, vertex, result -> {
+        testContext, vertx, result -> {
           final String expectedString = "941\r";
           assertEquals(expectedString, result);
         });
   }
 
   @Test
-  public void cannotCheckoutWithInvalidCommandCode(Vertx vertex, VertxTestContext testContext) {
-    callService("blablabalb\r", testContext, vertex, result -> {
+  public void cannotCheckoutWithInvalidCommandCode(Vertx vertx, VertxTestContext testContext) {
+    callService("blablabalb\r", testContext, vertx, result -> {
       assertTrue(result.contains("Problems handling the request"));
     });
   }
 
   @Disabled("Need mock Okapi")
   @Test
-  public void canMakeValidSCStatusRequest(Vertx vertex, VertxTestContext testContext) {
+  public void canMakeValidSCStatusRequest(Vertx vertx, VertxTestContext testContext) {
     callService("9900401.00AY1AZFCA5\r",
-        testContext, vertex, result -> {
+        testContext, vertx, result -> {
           validateExpectedACSStatus(result);
       });
   }
 
   @Test
   public void canMakeInvalidStatusRequestAndGetExpectedErrorMessage(
-      Vertx vertex, VertxTestContext testContext) {
-    callService("990231.23\r", testContext, vertex, result -> {
+      Vertx vertx, VertxTestContext testContext) {
+    callService("990231.23\r", testContext, vertx, result -> {
       assertTrue(result.contains("Problems handling the request"));
     });
   }
@@ -173,6 +174,14 @@ public class MainVerticleTests extends BaseTest {
         testContext, vertx, result -> {
           assertEquals(expectedString, result);
         });
+  }
+
+  @Test
+  @Tag("TLSEnabled")
+  void canConnectWithTLS(Vertx vertx, VertxTestContext testContext, TestInfo testInfo) {
+    callService("990231.23\r", testContext, vertx, testInfo, result -> {
+      assertTrue(result.contains("Problems handling the request"));
+    });
   }
 
   private String getFormattedDateString() {

--- a/src/test/java/org/folio/edge/sip2/api/support/BaseTest.java
+++ b/src/test/java/org/folio/edge/sip2/api/support/BaseTest.java
@@ -39,6 +39,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith({VertxExtension.class, MockitoExtension.class})
 public abstract class BaseTest {
+  protected static final String TLS_ENABLED = "TLSEnabled";
+  protected static final String ERROR_DETECTION_ENABLED = "ErrorDetectionEnabled";
+
   protected static Logger log = LogManager.getLogger();
 
   @Mock
@@ -64,12 +67,12 @@ public abstract class BaseTest {
 
     JsonObject sipConfig = new JsonObject();
     sipConfig.put("port", port);
-    if (testInfo.getTags().contains("ErrorDetectionEnabled")) {
+    if (testInfo.getTags().contains(ERROR_DETECTION_ENABLED)) {
       sipConfig.put("errorDetectionEnabled", true);
     }
     sipConfig.put("okapiUrl", "http://example.com");
     sipConfig.put("tenant", "diku");
-    if (testInfo.getTags().contains("TLSEnabled")) {
+    if (testInfo.getTags().contains(TLS_ENABLED)) {
       final SelfSignedCertificate certificate = SelfSignedCertificate.create();
       sipConfig.put("netServerOptions", new JsonObject()
           .put("ssl", true)
@@ -149,7 +152,7 @@ public abstract class BaseTest {
     options.setIdleTimeout(2);
     options.setIdleTimeoutUnit(TimeUnit.SECONDS);
 
-    if (testInfo != null && testInfo.getTags().contains("TLSEnabled")) {
+    if (testInfo != null && testInfo.getTags().contains(TLS_ENABLED)) {
       options.setSsl(true);
       options.setTrustAll(true);
     }
@@ -160,7 +163,7 @@ public abstract class BaseTest {
       if (res.succeeded()) {
         log.debug("Shaking hands...");
         NetSocket socket = res.result();
-        if (testInfo != null && testInfo.getTags().contains("TLSEnabled")) {
+        if (testInfo != null && testInfo.getTags().contains(TLS_ENABLED)) {
           assertTrue(socket.isSsl());
         } else {
           assertFalse(socket.isSsl());

--- a/src/test/java/org/folio/edge/sip2/api/support/BaseTest.java
+++ b/src/test/java/org/folio/edge/sip2/api/support/BaseTest.java
@@ -1,5 +1,7 @@
 package org.folio.edge.sip2.api.support;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
@@ -11,6 +13,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.SelfSignedCertificate;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 
@@ -66,7 +69,12 @@ public abstract class BaseTest {
     }
     sipConfig.put("okapiUrl", "http://example.com");
     sipConfig.put("tenant", "diku");
-
+    if (testInfo.getTags().contains("TLSEnabled")) {
+      final SelfSignedCertificate certificate = SelfSignedCertificate.create();
+      sipConfig.put("netServerOptions", new JsonObject()
+          .put("ssl", true)
+          .put("pemKeyCertOptions", certificate.keyCertOptions().toJson()));
+    }
     DeploymentOptions opt = new DeploymentOptions();
     opt.setConfig(sipConfig);
 
@@ -95,7 +103,6 @@ public abstract class BaseTest {
     options.setConnectTimeout(2);
     options.setIdleTimeout(2);
     options.setIdleTimeoutUnit(TimeUnit.SECONDS);
-
     NetClient tcpClient = vertx.createNetClient(options);
 
     tcpClient.connect(port, "localhost", res -> {
@@ -121,21 +128,31 @@ public abstract class BaseTest {
     });
   }
 
+  public void callService(String sipMessage, VertxTestContext testContext,
+      Vertx vertx, Handler<String> testHandler) {
+    callService(sipMessage, testContext, vertx, null, testHandler);
+  }
 
   /**
    * Calls the service.
    * @param sipMessage the sip message to send.
    * @param testContext the vertx test context.
    * @param vertx the vertx instance.
+   * @param testInfo info about the test.
    * @param testHandler the handler for this test.
    */
   public void callService(String sipMessage, VertxTestContext testContext,
-                          Vertx vertx, Handler<String> testHandler) {
+                          Vertx vertx, TestInfo testInfo, Handler<String> testHandler) {
 
     NetClientOptions options = new NetClientOptions();
     options.setConnectTimeout(2);
     options.setIdleTimeout(2);
     options.setIdleTimeoutUnit(TimeUnit.SECONDS);
+
+    if (testInfo != null && testInfo.getTags().contains("TLSEnabled")) {
+      options.setSsl(true);
+      options.setTrustAll(true);
+    }
 
     NetClient tcpClient = vertx.createNetClient(options);
 
@@ -143,7 +160,11 @@ public abstract class BaseTest {
       if (res.succeeded()) {
         log.debug("Shaking hands...");
         NetSocket socket = res.result();
-
+        if (testInfo != null && testInfo.getTags().contains("TLSEnabled")) {
+          assertTrue(socket.isSsl());
+        } else {
+          assertFalse(socket.isSsl());
+        }
         socket.handler(buffer -> {
           String message = buffer.getString(0, buffer.length());
           testContext.verify(() -> testHandler.handle(message));


### PR DESCRIPTION
Vertx already supports SSL/TLS but we need to be able to configure it. Now we allow startup config (JSON) to be passed to the existing `NetServerOptions` that can contain SSL specific options or any net server option if some other setting might be necessary. When not specified, SSL/TLS support is not enabled.

Also changed `log4j2.xml` to accept a system supplied variable to set the log level at runtime. To enable, pass `-Dloglevel=debug` (or whatever level) to the VM. The default level is "info".

Finally, added some config and security documentation to the README.md file.