### PR TITLE
SIP2-37: return proper patron status and screen messages

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -6,6 +6,22 @@
     {
       "id": "login",
       "version": "5.0"
+    },
+    {
+      "id": "circulation",
+      "version": "7.0"
+    },
+    {
+      "id": "users",
+      "version": "15.0"
+    },
+    {
+      "id": "configuration",
+      "version": "2.0"
+    },
+    {
+      "id": "feesfines",
+      "version": "15.0"
     }
   ],
   "permissionSets": [],

--- a/src/main/java/org/folio/edge/sip2/modules/ApplicationModule.java
+++ b/src/main/java/org/folio/edge/sip2/modules/ApplicationModule.java
@@ -14,6 +14,7 @@ import java.time.Clock;
 import javax.inject.Named;
 import org.folio.edge.sip2.handlers.freemarker.FreemarkerRepository;
 import org.folio.edge.sip2.repositories.CirculationRepository;
+import org.folio.edge.sip2.repositories.FeeFinesRepository;
 import org.folio.edge.sip2.repositories.FolioResourceProvider;
 import org.folio.edge.sip2.repositories.IRequestData;
 import org.folio.edge.sip2.repositories.IResourceProvider;
@@ -21,7 +22,7 @@ import org.folio.edge.sip2.repositories.LoginRepository;
 import org.folio.edge.sip2.repositories.UsersRepository;
 
 /**
- * Module to bind dependencies for {@code CirculationRespository}.
+ * Module to bind dependencies for injection.
  *
  * @author mreno-EBSCO
  *
@@ -33,6 +34,7 @@ public class ApplicationModule extends AbstractModule {
         .to(FolioResourceProvider.class).asEagerSingleton();
     bind(Clock.class).toInstance(Clock.systemUTC());
     bind(CirculationRepository.class);
+    bind(FeeFinesRepository.class);
     bind(LoginRepository.class);
     bind(UsersRepository.class);
   }

--- a/src/main/java/org/folio/edge/sip2/repositories/FeeFinesRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/FeeFinesRepository.java
@@ -29,7 +29,7 @@ public class FeeFinesRepository {
    *
    * @param userId the user's ID
    * @param sessionData session data
-   * @return the manual blocks list in raw JSON
+   * @return the manual blocks list in raw JSON or {@code null} if there was an error
    */
   public Future<JsonObject> getManualBlocksByUserId(
       String userId,

--- a/src/main/java/org/folio/edge/sip2/repositories/FeeFinesRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/FeeFinesRepository.java
@@ -1,0 +1,80 @@
+package org.folio.edge.sip2.repositories;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.inject.Inject;
+import org.folio.edge.sip2.session.SessionData;
+
+/**
+ * Provides interaction with the feefines service.
+ *
+ * @author mreno-EBSCO
+ *
+ */
+public class FeeFinesRepository {
+  private final IResourceProvider<IRequestData> resourceProvider;
+
+  @Inject
+  FeeFinesRepository(IResourceProvider<IRequestData> resourceProvider) {
+    this.resourceProvider = Objects.requireNonNull(resourceProvider,
+        "Resource provider cannot be null");
+  }
+
+  /**
+   * Get a patron's manual blocks.
+   *
+   * @param userId the user's ID
+   * @param sessionData session data
+   * @return the manual blocks list in raw JSON
+   */
+  public Future<JsonObject> getManualBlocksByUserId(
+      String userId,
+      SessionData sessionData) {
+    Objects.requireNonNull(userId, "userId cannot be null");
+    Objects.requireNonNull(sessionData, "sessionData cannot be null");
+
+    final Map<String, String> headers = new HashMap<>();
+    headers.put("accept", "application/json");
+
+    final GetManualBlocksByUserIdRequestData getManualBlocksByUserIdRequestData =
+        new GetManualBlocksByUserIdRequestData(userId, headers, sessionData);
+    final Future<IResource> result =
+        resourceProvider.retrieveResource(getManualBlocksByUserIdRequestData);
+
+    return result
+        .otherwise(() -> null)
+        .map(IResource::getResource);
+  }
+
+  private class GetManualBlocksByUserIdRequestData implements IRequestData {
+    private final String userId;
+    private final Map<String, String> headers;
+    private final SessionData sessionData;
+
+    private GetManualBlocksByUserIdRequestData(String barcode, Map<String, String> headers,
+        SessionData sessionData) {
+      this.userId = barcode;
+      this.headers = Collections.unmodifiableMap(new HashMap<>(headers));
+      this.sessionData = sessionData;
+    }
+
+    @Override
+    public String getPath() {
+      return "/manualblocks?query=userId==" + userId;
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+      return headers;
+    }
+
+    @Override
+    public SessionData getSessionData() {
+      return sessionData;
+    }
+  }
+}

--- a/src/test/java/org/folio/edge/sip2/repositories/FeeFinesRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/FeeFinesRepositoryTests.java
@@ -1,0 +1,138 @@
+package org.folio.edge.sip2.repositories;
+
+import static org.folio.edge.sip2.api.support.TestUtils.getJsonFromFile;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.when;
+
+import io.vertx.core.Future;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.NoStackTraceThrowable;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import java.util.UUID;
+import org.folio.edge.sip2.session.SessionData;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith({VertxExtension.class, MockitoExtension.class})
+public class FeeFinesRepositoryTests {
+  private static final String FIELD_TOTAL_RECORDS = "totalRecords";
+  private static final String FIELD_MANUALBLOCKS = "manualblocks";
+
+  @Test
+  public void canCreateFeeFinesRepository(
+      @Mock IResourceProvider<IRequestData> mockFolioResource) {
+    final FeeFinesRepository usersRepository =
+        new FeeFinesRepository(mockFolioResource);
+
+    assertNotNull(usersRepository);
+  }
+
+  @Test
+  public void cannotCreateFeeFinesRepositoryWhenResourceProviderIsNull() {
+    final NullPointerException thrown = assertThrows(
+        NullPointerException.class,
+        () -> new FeeFinesRepository(null));
+
+    assertEquals("Resource provider cannot be null", thrown.getMessage());
+  }
+
+  @Test
+  public void canGetManualBlocksByUserId(Vertx vertx,
+      VertxTestContext testContext,
+      @Mock IResourceProvider<IRequestData> mockFolioProvider) {
+
+    final String manualBlocksResponseJson = getJsonFromFile("json/no_manual_blocks_response.json");
+    final JsonObject manualBlocksResponse = new JsonObject(manualBlocksResponseJson);
+
+    when(mockFolioProvider.retrieveResource(any()))
+        .thenReturn(Future.succeededFuture(new FolioResource(manualBlocksResponse,
+            MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
+
+    final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
+
+    final FeeFinesRepository feeFinesRepository = new FeeFinesRepository(mockFolioProvider);
+    feeFinesRepository.getManualBlocksByUserId(UUID.randomUUID().toString(),
+        sessionData).setHandler(
+            testContext.succeeding(manualBlocks -> testContext.verify(() -> {
+              assertNotNull(manualBlocks);
+              assertNotNull(manualBlocks.getJsonArray(FIELD_MANUALBLOCKS));
+              assertEquals(0, manualBlocks.getJsonArray(FIELD_MANUALBLOCKS).size());
+              assertEquals(0, manualBlocks.getInteger(FIELD_TOTAL_RECORDS));
+
+              testContext.completeNow();
+            })));
+  }
+
+  @Test
+  public void cannotGetManualBlocksByUserId(Vertx vertx,
+      VertxTestContext testContext,
+      @Mock IResourceProvider<IRequestData> mockFolioProvider) {
+    when(mockFolioProvider.retrieveResource(any()))
+        .thenReturn(Future.failedFuture(new NoStackTraceThrowable("Test failure")));
+
+    final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
+
+    final FeeFinesRepository feeFinesRepository = new FeeFinesRepository(mockFolioProvider);
+    feeFinesRepository.getManualBlocksByUserId(UUID.randomUUID().toString(),
+        sessionData).setHandler(
+            testContext.succeeding(manualBlocks -> testContext.verify(() -> {
+              assertNull(manualBlocks);
+
+              testContext.completeNow();
+            })));
+  }
+
+  @Test
+  public void canGetManualBlocksListByUserId(Vertx vertx,
+      VertxTestContext testContext,
+      @Mock IResourceProvider<IRequestData> mockFolioProvider) {
+
+    final String manualBlocksResponseJson = getJsonFromFile("json/manual_blocks_response.json");
+    final JsonObject manualBlocksResponse = new JsonObject(manualBlocksResponseJson);
+
+    final String userId = "a23eac4b-955e-451c-b4ff-6ec2f5e63e23";
+
+    when(mockFolioProvider.retrieveResource(
+        argThat(arg -> arg.getPath().endsWith("userId==" + userId))))
+        .thenReturn(Future.succeededFuture(new FolioResource(manualBlocksResponse,
+            MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
+
+    final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
+
+    final FeeFinesRepository feeFinesRepository = new FeeFinesRepository(mockFolioProvider);
+    feeFinesRepository.getManualBlocksByUserId(userId, sessionData).setHandler(
+        testContext.succeeding(manualBlocks -> testContext.verify(() -> {
+          assertNotNull(manualBlocks);
+          assertEquals(1, manualBlocks.getInteger(FIELD_TOTAL_RECORDS));
+
+          final JsonArray manualBlocksArray = manualBlocks.getJsonArray(FIELD_MANUALBLOCKS);
+          assertNotNull(manualBlocksArray);
+          assertEquals(1, manualBlocksArray.size());
+
+          final JsonObject manualBlock = manualBlocksArray.getJsonObject(0);
+          assertNotNull(manualBlock);
+          assertEquals(userId, manualBlock.getString("userId"));
+          assertEquals("Manual", manualBlock.getString("type"));
+          assertEquals("test block", manualBlock.getString("desc"));
+          assertEquals("Collect money", manualBlock.getString("staffInformation"));
+          assertEquals("Pay your fines!", manualBlock.getString("patronMessage"));
+          assertTrue(manualBlock.getBoolean("borrowing"));
+          assertTrue(manualBlock.getBoolean("renewals"));
+          assertTrue(manualBlock.getBoolean("requests"));
+
+          testContext.completeNow();
+        })));
+  }
+}

--- a/src/test/java/org/folio/edge/sip2/repositories/FeeFinesRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/FeeFinesRepositoryTests.java
@@ -19,6 +19,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.util.UUID;
+import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.session.SessionData;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,7 +50,7 @@ public class FeeFinesRepositoryTests {
   }
 
   @Test
-  public void canGetManualBlocksByUserId(Vertx vertx,
+  public void canGetManualBlocksByUserIdWithNoBlocksApplied(Vertx vertx,
       VertxTestContext testContext,
       @Mock IResourceProvider<IRequestData> mockFolioProvider) {
 
@@ -60,7 +61,7 @@ public class FeeFinesRepositoryTests {
         .thenReturn(Future.succeededFuture(new FolioResource(manualBlocksResponse,
             MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
 
-    final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
+    final SessionData sessionData = TestUtils.getMockedSessionData();
 
     final FeeFinesRepository feeFinesRepository = new FeeFinesRepository(mockFolioProvider);
     feeFinesRepository.getManualBlocksByUserId(UUID.randomUUID().toString(),
@@ -82,7 +83,7 @@ public class FeeFinesRepositoryTests {
     when(mockFolioProvider.retrieveResource(any()))
         .thenReturn(Future.failedFuture(new NoStackTraceThrowable("Test failure")));
 
-    final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
+    final SessionData sessionData = TestUtils.getMockedSessionData();
 
     final FeeFinesRepository feeFinesRepository = new FeeFinesRepository(mockFolioProvider);
     feeFinesRepository.getManualBlocksByUserId(UUID.randomUUID().toString(),
@@ -95,7 +96,7 @@ public class FeeFinesRepositoryTests {
   }
 
   @Test
-  public void canGetManualBlocksListByUserId(Vertx vertx,
+  public void canGetManualBlocksByUserIdWithBlocksApplied(Vertx vertx,
       VertxTestContext testContext,
       @Mock IResourceProvider<IRequestData> mockFolioProvider) {
 
@@ -109,7 +110,7 @@ public class FeeFinesRepositoryTests {
         .thenReturn(Future.succeededFuture(new FolioResource(manualBlocksResponse,
             MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
 
-    final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
+    final SessionData sessionData = TestUtils.getMockedSessionData();
 
     final FeeFinesRepository feeFinesRepository = new FeeFinesRepository(mockFolioProvider);
     feeFinesRepository.getManualBlocksByUserId(userId, sessionData).setHandler(

--- a/src/test/resources/json/manual_blocks_response.json
+++ b/src/test/resources/json/manual_blocks_response.json
@@ -1,0 +1,21 @@
+{
+  "manualblocks" : [ {
+    "type" : "Manual",
+    "desc" : "test block",
+    "staffInformation" : "Collect money",
+    "patronMessage" : "Pay your fines!",
+    "expirationDate" : "2019-06-22T04:00:00.000+0000",
+    "borrowing" : true,
+    "renewals" : true,
+    "requests" : true,
+    "userId" : "a23eac4b-955e-451c-b4ff-6ec2f5e63e23",
+    "metadata" : {
+      "createdDate" : "2019-05-16T19:43:47.262+0000",
+      "createdByUserId" : "299318d2-51c0-5ddb-82e9-084e02ec756e",
+      "updatedDate" : "2019-05-16T19:43:47.262+0000",
+      "updatedByUserId" : "299318d2-51c0-5ddb-82e9-084e02ec756e"
+    },
+    "id" : "43ec8e43-4a78-45b0-a46c-88426346d3df"
+  } ],
+  "totalRecords" : 1
+}

--- a/src/test/resources/json/no_manual_blocks_response.json
+++ b/src/test/resources/json/no_manual_blocks_response.json
@@ -1,0 +1,4 @@
+{
+  "manualblocks" : [ ],
+  "totalRecords" : 0
+}


### PR DESCRIPTION
If the patron is invalid or blocked in some way, we will now return the patron status to reflect this and generic screen messages:

```
Your library card number cannot be located.  Please see a staff member for assistance.
There are unresolved issues with your account.  Please see a staff member for assistance.
```