### PR TITLE
SIP2-58: Add the title identifier (AJ) to the checkin response

### DIFF
--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -82,8 +82,11 @@ public class CirculationRepository {
               .transactionDate(OffsetDateTime.now(clock))
               .institutionId(institutionId)
               .itemIdentifier(itemIdentifier)
-              .titleIdentifier(resource.getResource() == null ? null
-                  : getChildString(resource.getResource(), "item", "title"))
+              // if the title is not available, use the item identifier passed in to the checkin.
+              // this allows the kiosk to show something related to the item that could be used
+              // by the patron to identify which item this checkin response applies to.
+              .titleIdentifier(resource.getResource() == null ? itemIdentifier
+                  : getChildString(resource.getResource(), "item", "title", itemIdentifier))
               // this is probably not the permanent location
               // this might require a call to inventory
               .permanentLocation(

--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -82,6 +82,8 @@ public class CirculationRepository {
               .transactionDate(OffsetDateTime.now(clock))
               .institutionId(institutionId)
               .itemIdentifier(itemIdentifier)
+              .titleIdentifier(resource.getResource() == null ? null
+                  : getChildString(resource.getResource(), "item", "title"))
               // this is probably not the permanent location
               // this might require a call to inventory
               .permanentLocation(

--- a/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
@@ -115,6 +115,63 @@ public class CirculationRepositoryTests {
   }
 
   @Test
+  public void canCheckinWithTitleIdentifier(Vertx vertx,
+      VertxTestContext testContext,
+      @Mock IResourceProvider<IRequestData> mockFolioProvider) {
+    final Clock clock = TestUtils.getUtcFixedClock();
+    final OffsetDateTime returnDate = OffsetDateTime.now();
+    final String currentLocation = UUID.randomUUID().toString();
+    final String itemIdentifier = "1234567890";
+    final String titleIdentifier = "Some Cool Book";
+    final Checkin checkin = Checkin.builder()
+        .noBlock(FALSE)
+        .transactionDate(OffsetDateTime.now())
+        .returnDate(returnDate)
+        .currentLocation(currentLocation)
+        .institutionId("diku")
+        .itemIdentifier(itemIdentifier)
+        .terminalPassword("1234")
+        .itemProperties("Some property of this item")
+        .cancel(FALSE)
+        .build();
+
+    final JsonObject response = new JsonObject()
+        .put("item", new JsonObject()
+            .put("title", titleIdentifier)
+            .put("location", new JsonObject()
+                .put("name", "Main Library")));
+    when(mockFolioProvider.createResource(any()))
+        .thenReturn(Future.succeededFuture(new FolioResource(response,
+            MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
+
+    final SessionData sessionData = TestUtils.getMockedSessionData();
+
+    final CirculationRepository circulationRepository =
+        new CirculationRepository(mockFolioProvider, clock);
+    circulationRepository.performCheckinCommand(checkin, sessionData).setHandler(
+        testContext.succeeding(checkinResponse -> testContext.verify(() -> {
+          assertNotNull(checkinResponse);
+          assertTrue(checkinResponse.getOk());
+          assertTrue(checkinResponse.getResensitize());
+          assertNull(checkinResponse.getMagneticMedia());
+          assertFalse(checkinResponse.getAlert());
+          assertEquals(OffsetDateTime.now(clock), checkinResponse.getTransactionDate());
+          assertEquals("diku", checkinResponse.getInstitutionId());
+          assertEquals(itemIdentifier, checkinResponse.getItemIdentifier());
+          assertEquals("Main Library", checkinResponse.getPermanentLocation());
+          assertEquals(titleIdentifier, checkinResponse.getTitleIdentifier());
+          assertNull(checkinResponse.getSortBin());
+          assertNull(checkinResponse.getPatronIdentifier());
+          assertNull(checkinResponse.getMediaType());
+          assertNull(checkinResponse.getItemProperties());
+          assertNull(checkinResponse.getScreenMessage());
+          assertNull(checkinResponse.getPrintLine());
+
+          testContext.completeNow();
+        })));
+  }
+
+  @Test
   public void cannotCheckin(Vertx vertx,
       VertxTestContext testContext,
       @Mock IResourceProvider<IRequestData> mockFolioProvider) {

--- a/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
@@ -67,61 +67,6 @@ public class CirculationRepositoryTests {
     final OffsetDateTime returnDate = OffsetDateTime.now();
     final String currentLocation = UUID.randomUUID().toString();
     final String itemIdentifier = "1234567890";
-    final Checkin checkin = Checkin.builder()
-        .noBlock(FALSE)
-        .transactionDate(OffsetDateTime.now())
-        .returnDate(returnDate)
-        .currentLocation(currentLocation)
-        .institutionId("diku")
-        .itemIdentifier(itemIdentifier)
-        .terminalPassword("1234")
-        .itemProperties("Some property of this item")
-        .cancel(FALSE)
-        .build();
-
-    final JsonObject response = new JsonObject()
-        .put("item", new JsonObject()
-            .put("location", new JsonObject()
-                .put("name", "Main Library")));
-    when(mockFolioProvider.createResource(any()))
-        .thenReturn(Future.succeededFuture(new FolioResource(response,
-            MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
-
-    final SessionData sessionData = TestUtils.getMockedSessionData();
-
-    final CirculationRepository circulationRepository =
-        new CirculationRepository(mockFolioProvider, clock);
-    circulationRepository.performCheckinCommand(checkin, sessionData).setHandler(
-        testContext.succeeding(checkinResponse -> testContext.verify(() -> {
-          assertNotNull(checkinResponse);
-          assertTrue(checkinResponse.getOk());
-          assertTrue(checkinResponse.getResensitize());
-          assertNull(checkinResponse.getMagneticMedia());
-          assertFalse(checkinResponse.getAlert());
-          assertEquals(OffsetDateTime.now(clock), checkinResponse.getTransactionDate());
-          assertEquals("diku", checkinResponse.getInstitutionId());
-          assertEquals(itemIdentifier, checkinResponse.getItemIdentifier());
-          assertEquals("Main Library", checkinResponse.getPermanentLocation());
-          assertNull(checkinResponse.getTitleIdentifier());
-          assertNull(checkinResponse.getSortBin());
-          assertNull(checkinResponse.getPatronIdentifier());
-          assertNull(checkinResponse.getMediaType());
-          assertNull(checkinResponse.getItemProperties());
-          assertNull(checkinResponse.getScreenMessage());
-          assertNull(checkinResponse.getPrintLine());
-
-          testContext.completeNow();
-        })));
-  }
-
-  @Test
-  public void canCheckinWithTitleIdentifier(Vertx vertx,
-      VertxTestContext testContext,
-      @Mock IResourceProvider<IRequestData> mockFolioProvider) {
-    final Clock clock = TestUtils.getUtcFixedClock();
-    final OffsetDateTime returnDate = OffsetDateTime.now();
-    final String currentLocation = UUID.randomUUID().toString();
-    final String itemIdentifier = "1234567890";
     final String titleIdentifier = "Some Cool Book";
     final Checkin checkin = Checkin.builder()
         .noBlock(FALSE)
@@ -172,6 +117,61 @@ public class CirculationRepositoryTests {
   }
 
   @Test
+  public void canCheckinWithoutTitleIdentifier(Vertx vertx,
+      VertxTestContext testContext,
+      @Mock IResourceProvider<IRequestData> mockFolioProvider) {
+    final Clock clock = TestUtils.getUtcFixedClock();
+    final OffsetDateTime returnDate = OffsetDateTime.now();
+    final String currentLocation = UUID.randomUUID().toString();
+    final String itemIdentifier = "1234567890";
+    final Checkin checkin = Checkin.builder()
+        .noBlock(FALSE)
+        .transactionDate(OffsetDateTime.now())
+        .returnDate(returnDate)
+        .currentLocation(currentLocation)
+        .institutionId("diku")
+        .itemIdentifier(itemIdentifier)
+        .terminalPassword("1234")
+        .itemProperties("Some property of this item")
+        .cancel(FALSE)
+        .build();
+
+    final JsonObject response = new JsonObject()
+        .put("item", new JsonObject()
+            .put("location", new JsonObject()
+                .put("name", "Main Library")));
+    when(mockFolioProvider.createResource(any()))
+        .thenReturn(Future.succeededFuture(new FolioResource(response,
+            MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
+
+    final SessionData sessionData = TestUtils.getMockedSessionData();
+
+    final CirculationRepository circulationRepository =
+        new CirculationRepository(mockFolioProvider, clock);
+    circulationRepository.performCheckinCommand(checkin, sessionData).setHandler(
+        testContext.succeeding(checkinResponse -> testContext.verify(() -> {
+          assertNotNull(checkinResponse);
+          assertTrue(checkinResponse.getOk());
+          assertTrue(checkinResponse.getResensitize());
+          assertNull(checkinResponse.getMagneticMedia());
+          assertFalse(checkinResponse.getAlert());
+          assertEquals(OffsetDateTime.now(clock), checkinResponse.getTransactionDate());
+          assertEquals("diku", checkinResponse.getInstitutionId());
+          assertEquals(itemIdentifier, checkinResponse.getItemIdentifier());
+          assertEquals("Main Library", checkinResponse.getPermanentLocation());
+          assertEquals(itemIdentifier, checkinResponse.getTitleIdentifier());
+          assertNull(checkinResponse.getSortBin());
+          assertNull(checkinResponse.getPatronIdentifier());
+          assertNull(checkinResponse.getMediaType());
+          assertNull(checkinResponse.getItemProperties());
+          assertNull(checkinResponse.getScreenMessage());
+          assertNull(checkinResponse.getPrintLine());
+
+          testContext.completeNow();
+        })));
+  }
+
+  @Test
   public void cannotCheckin(Vertx vertx,
       VertxTestContext testContext,
       @Mock IResourceProvider<IRequestData> mockFolioProvider) {
@@ -209,7 +209,7 @@ public class CirculationRepositoryTests {
           assertEquals("diku", checkinResponse.getInstitutionId());
           assertEquals(itemIdentifier, checkinResponse.getItemIdentifier());
           assertEquals("", checkinResponse.getPermanentLocation());
-          assertNull(checkinResponse.getTitleIdentifier());
+          assertEquals(itemIdentifier, checkinResponse.getTitleIdentifier());
           assertNull(checkinResponse.getSortBin());
           assertNull(checkinResponse.getPatronIdentifier());
           assertNull(checkinResponse.getMediaType());


### PR DESCRIPTION
The self service kiosk being tested in Chalmers has a requirement that the title identifier (AJ) must be present in the SIP checkin response. However, this field is optional in SIP, so we ignored it to limit scope. This requirement was unknown and could not be known until actual integration testing.

We now add the title of the item into AJ field for the SIP checkin response. If title is not present, then we do not send it and the original error is shown in the kiosk. In this case, it is expected since there is likely a database problem here in that the title is not set in FOLIO.