### PR TITLE
SIP2-60: metrics for edge-sip2

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,71 @@ $ java -jar edge-sip2-fat.jar -conf '{"port":1234,"okapiUrl":"https://folio-snap
 
 For local development, there is no requirement to encrypt communications from a SIP2 client to edge-sip2. Unencrypted TCP sockets are the default when launching edge-sip2 as described in the [Configuration](#configuration) section. Encrypted communication from a SIP2 client is only required when explicitly configured via the [above options](#security) and is up to the developer to provide that secure connection for edge-sip2.
 
+## Metrics
+
+This module makes use of [Micrometer](https://micrometer.io) to collect SIP2, Vert.x and JVM metrics. The metrics need to be collected by a monitoring system backed. This is where Micrometer provides flexibility, by allowing the module to code to the Micrometer interface, which is vendor neutral. Once determined, the vendor specific backend binding is provided runtime and can be easily replaced.
+
+### Enabling Vert.x metrics
+
+By default, metrics are disabled. To enable Vert.x metrics pass the following Java argument:
+
+```
+-Dvertx.metrics.options.enabled=true
+```
+
+With metrics enabled, configuration must be supplied to the verticle. This can be done as follows:
+
+```
+ -options '{"metricsOptions":{"labels":["LOCAL","REMOTE","HTTP_PATH","HTTP_METHOD","HTTP_CODE","CLASS_NAME"],"enabled":true,"prometheusOptions":{"enabled":true,"startEmbeddedServer":true,"embeddedServerOptions":{"port":8081}}}}'
+```
+
+The `metricsOptions` here indicate that the verticle should collect metrics with the supplied list of `labels`. Some of these labels, like `REMOTE`, may lead to high cardinality metrics. The default `labels` list is "HTTP\_METHOD", "HTTP\_CODE", "POOL\_TYPE" and "EB\_SIDE".
+
+Also specified here are `prometheusOptions`. In this case, the backend will be [Prometheus](https://prometheus.io). Prometheus "scrapes" metrics via HTTP at a specified interval. The options specified here allow Vert.x to create an HTTP server to handle metrics scraping. Prometheus setup is outside the scope of this document. Other bindings could be used, like [InfluxDB](https://www.influxdata.com/products/influxdb-overview/).
+
+### Available metrics
+
+For a list of Vert.x metrics (HTTP Client and Net Server are the primary sources for metrics in this module) see: [Vert.x core tools metrics](https://vertx.io/docs/vertx-micrometer-metrics/java/#_vert_x_core_tools_metrics)
+
+The following metrics are supplied by this module:
+
+|Metric name|Labels|Type|Description|
+|-----------|------|----|-----------|
+|`org_folio_edge_sip2_command_timer`|`command`|Timer|SIP2 command execution time|
+|`org_folio_edge_sip2_invalidMessage_errors`|`port`|Counter|A count of invalid message errors|
+|`org_folio_edge_sip2_request_errors`|`port`|Counter|A count of request errors|
+|`org_folio_edge_sip2_response_errors`|`port`|Counter|A count of response errors|
+|`org_folio_edge_sip2_scResend_errors`|`port`|Counter|A count of SC resend errors, which occurs when the module fails to send the SC a resend message when the prior received message was not understood|
+|`org_folio_edge_sip2_socket_errors`|`port`|Counter|A count of socket errors|
+
+JVM metrics (memory, GC, threads, etc.) are supplied as well.
+
+### Building with metrics
+
+The Maven pom.xml contains 2 profiles, `metrics-prometheus` and `metrics-influxdb`. Building with either or both of these profiles active will include the appropriate dependencies required to use metrics with that registry.
+
+```
+$ mvn install -P metrics-prometheus
+```
+
+### Launching with the community Docker image
+
+If metrics need to be enabled, it is probably best to add any required runtime binding jars to the fat jar as part of a build. If this is not possible, the module can still be launched via the community Docker image. N.B., we may find that this approach cumbersome and may need to come up with an alternative approach.
+
+Copy the appropriate runtime binding jars to a directory:
+
+```
+$ cp micrometer-registry-prometheus-1.1.5.jar simpleclient_common-0.5.0.jar simpleclient-0.5.0.jar /my/metrics/libs
+```
+
+Then run a container from the FOLIO docker hub image (either snapshot `folioci/edge-sip2` or released `folioorg/edge-sip2`):
+
+```
+$ docker run -v /my/metrics/libs:/metrics -p 6443:6443 --expose 8081 -p 8081:8081  -e JAVA_OPTIONS="-Dvertx.metrics.options.enabled=true " -e JAVA_CLASSPATH=/metrics/*:/usr/verticles/edge-sip2-fat.jar -e JAVA_MAIN_CLASS=io.vertx.core.Launcher folioci/edge-sip2 run org.folio.edge.sip2.MainVerticle -conf '{"port":6443,"okapiUrl":"https://folio-okapi.example.com","tenant":"diku","messageDelimiter":"\r","errorDetectionEnabled":true,"charset":"ISO-8859-1"}' -options '{"metricsOptions":{"labels":["LOCAL","REMOTE","HTTP_PATH","HTTP_METHOD","HTTP_CODE","CLASS_NAME"],"enabled":true,"prometheusOptions":{"enabled":true,"startEmbeddedServer":true,"embeddedServerOptions":{"port":8081}}}}'
+```
+
+This example shows how to launch with the Prometheus binding. Since Prometheus needs to scrape the metrics, we need to expose port for the HTTP server.
+
 ## Additional information
 
 [SIP2 Specification](http://multimedia.3m.com/mws/media/355361O/sip2-protocol.pdf)

--- a/pom.xml
+++ b/pom.xml
@@ -79,22 +79,30 @@
       <artifactId>vertx-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-micrometer-metrics</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-junit5</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.freemarker</groupId>
@@ -102,26 +110,47 @@
       <version>2.3.28</version>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>2.27.0</version>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <version>4.2.2</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <version>1.1.5</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-junit5</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-web-client</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.28.2</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>2.27.0</version>
+      <version>2.28.2</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.inject</groupId>
-      <artifactId>guice</artifactId>
-      <version>4.2.2</version>
-      <classifier>no_aop</classifier>
     </dependency>
   </dependencies>
 
@@ -150,11 +179,42 @@
     </repository>
   </repositories>
 
+  <profiles>
+    <profile>
+      <id>metrics-prometheus</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>io.micrometer</groupId>
+          <artifactId>micrometer-registry-prometheus</artifactId>
+          <version>1.1.5</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>metrics-influxdb</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>io.micrometer</groupId>
+          <artifactId>micrometer-registry-influx</artifactId>
+          <version>1.1.5</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>3.8.1</version>
         <configuration>
           <source>${maven.compiler.source}</source>
           <target>${maven.compiler.target}</target>
@@ -268,6 +328,33 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.1.1</version>
+        <executions>
+          <execution>
+            <id>analyze</id>
+            <goals>
+              <goal>analyze-only</goal>
+            </goals>
+            <configuration>
+              <ignoreNonCompile>true</ignoreNonCompile>
+              <failOnWarning>true</failOnWarning>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>2.5.3</version>
+        <configuration>
+          <preparationGoals>clean verify</preparationGoals>
+          <tagNameFormat>v@{project.version}</tagNameFormat>
+          <pushChanges>false</pushChanges>
+          <localCheckout>true</localCheckout>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
     </dependencies>
   </dependencyManagement>
   <dependencies>
+    <!-- Application dependencies -->
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
@@ -124,7 +125,7 @@
       <artifactId>micrometer-core</artifactId>
       <version>1.1.5</version>
     </dependency>
-
+    <!-- Test dependencies -->
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-junit5</artifactId>

--- a/src/main/java/org/folio/edge/sip2/domain/PreviousMessage.java
+++ b/src/main/java/org/folio/edge/sip2/domain/PreviousMessage.java
@@ -17,10 +17,8 @@ public class PreviousMessage {
    * @param response - the SIP response that corresponds to the @message.
    */
   public PreviousMessage(Message<Object> message, String response) {
-    if (message.isErrorDetectionEnabled()) {
-      previousRequestSequenceNo = message.getSequenceNumber();
-      previousRequestChecksum = message.getChecksumsString();
-    }
+    previousRequestSequenceNo = message.getSequenceNumber();
+    previousRequestChecksum = message.getChecksumsString();
     previousMessageResponse = response;
   }
 

--- a/src/main/java/org/folio/edge/sip2/metrics/Metrics.java
+++ b/src/main/java/org/folio/edge/sip2/metrics/Metrics.java
@@ -1,0 +1,129 @@
+package org.folio.edge.sip2.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.vertx.micrometer.backends.BackendRegistries;
+import java.util.Optional;
+import org.folio.edge.sip2.parser.Command;
+
+public final class Metrics {
+  private static final String METRICS_PREFIX = "org.folio.edge.sip2.";
+  private static final String ERRORS_SUFFIX = ".errors";
+
+  private static final String COUNTER_SOCKET_ERRORS = METRICS_PREFIX + "socket" + ERRORS_SUFFIX;
+  private static final String COUNTER_REQUEST_ERRORS = METRICS_PREFIX + "request" + ERRORS_SUFFIX;
+  private static final String COUNTER_RESPONSE_ERRORS = METRICS_PREFIX + "response" + ERRORS_SUFFIX;
+  private static final String COUNTER_SC_RESEND_ERRORS =
+      METRICS_PREFIX + "scResend" + ERRORS_SUFFIX;
+  private static final String COUNTER_INVALID_MESSAGE_ERRORS =
+      METRICS_PREFIX + "invalidMessage" + ERRORS_SUFFIX;
+
+  private static final String SIP2_COMMAND_TAG = "command";
+  private static final String SIP2_COMMAND_TIMER_NAME = METRICS_PREFIX + "command.timer";
+
+  private final MeterRegistry registry = Optional.ofNullable(BackendRegistries.getDefaultNow())
+      .orElse(new SimpleMeterRegistry());
+  private final Counter socketErrorCounter;
+  private final Counter requestErrorCounter;
+  private final Counter responseErrorCounter;
+  private final Counter scResendErrorCounter;
+  private final Counter invalidMessageErrorCounter;
+  private final JvmGcMetrics jvmGcMetrics;
+
+  Metrics(int port) {
+    socketErrorCounter = Counter.builder(COUNTER_SOCKET_ERRORS)
+        .tag("port", Integer.toString(port))
+        .register(registry);
+    requestErrorCounter = Counter.builder(COUNTER_REQUEST_ERRORS)
+        .tag("port", Integer.toString(port))
+        .register(registry);
+    responseErrorCounter = Counter.builder(COUNTER_RESPONSE_ERRORS)
+        .tag("port", Integer.toString(port))
+        .register(registry);
+    scResendErrorCounter = Counter.builder(COUNTER_SC_RESEND_ERRORS)
+        .tag("port", Integer.toString(port))
+        .register(registry);
+    invalidMessageErrorCounter = Counter.builder(COUNTER_INVALID_MESSAGE_ERRORS)
+        .tag("port", Integer.toString(port))
+        .register(registry);
+
+    // Load JVM instrumentation
+    new ClassLoaderMetrics().bindTo(registry);
+    new JvmMemoryMetrics().bindTo(registry);
+    jvmGcMetrics = new JvmGcMetrics();
+    jvmGcMetrics.bindTo(registry);
+    new ProcessorMetrics().bindTo(registry);
+    new JvmThreadMetrics().bindTo(registry);
+  }
+
+  public static Metrics getMetrics(int port) {
+    return new Metrics(port);
+  }
+
+  public void socketError() {
+    socketErrorCounter.increment();
+  }
+
+  double socketErrorCount() {
+    return socketErrorCounter.count();
+  }
+
+  public void requestError() {
+    requestErrorCounter.increment();
+  }
+
+  double requestErrorCount() {
+    return requestErrorCounter.count();
+  }
+
+  public void responseError() {
+    responseErrorCounter.increment();
+  }
+
+  double responseErrorCount() {
+    return responseErrorCounter.count();
+  }
+
+  public void scResendError() {
+    scResendErrorCounter.increment();
+  }
+
+  double scResendErrorCount() {
+    return scResendErrorCounter.count();
+  }
+
+  public void invalidMessageError() {
+    invalidMessageErrorCounter.increment();
+  }
+
+  double invalidMessageErrorCount() {
+    return invalidMessageErrorCounter.count();
+  }
+
+  public Timer.Sample sample() {
+    return Timer.start(registry);
+  }
+
+  public Timer commandTimer(Command command) {
+    return registry.timer(SIP2_COMMAND_TIMER_NAME, SIP2_COMMAND_TAG, command.toString());
+  }
+
+  /**
+   * Closes any metrics that need to be closed.
+   */
+  public void stop() {
+    jvmGcMetrics.close();
+    socketErrorCounter.close();
+    requestErrorCounter.close();
+    responseErrorCounter.close();
+    scResendErrorCounter.close();
+    invalidMessageErrorCounter.close();
+  }
+}

--- a/src/main/java/org/folio/edge/sip2/parser/Message.java
+++ b/src/main/java/org/folio/edge/sip2/parser/Message.java
@@ -51,10 +51,6 @@ public class Message<R> {
     return checksumString;
   }
 
-  public boolean isErrorDetectionEnabled() {
-    return sequenceNumber != null;
-  }
-
   public String getTimezone() {
     return timezone;
   }

--- a/src/main/java/org/folio/edge/sip2/parser/Parser.java
+++ b/src/main/java/org/folio/edge/sip2/parser/Parser.java
@@ -67,6 +67,14 @@ public final class Parser {
   public Message<Object> parseMessage(String message) {
     log.debug("Message to parse: {}", message);
 
+    // All messages must have at least a 2 character command code. 
+    if (message == null || message.length() < 2) {
+      return Message.builder()
+          .command(UNKNOWN)
+          .valid(false)
+          .build();
+    }
+
     // Try to get the command first so it can be used in error detection
     final Command command = parseCommandIdentifier(message);
 
@@ -248,13 +256,7 @@ public final class Parser {
   }
 
   private Command parseCommandIdentifier(String message) {
-    final Command command;
-
-    if (message != null && message.length() >= 2) {
-      command = Command.find(message.substring(0, 2));
-    } else {
-      command = UNKNOWN;
-    }
+    final Command command = Command.find(message.substring(0, 2));
 
     log.debug("Found command: {}", command);
 

--- a/src/main/java/org/folio/edge/sip2/parser/Parser.java
+++ b/src/main/java/org/folio/edge/sip2/parser/Parser.java
@@ -2,6 +2,7 @@ package org.folio.edge.sip2.parser;
 
 import static java.lang.Boolean.FALSE;
 import static org.folio.edge.sip2.parser.Command.REQUEST_ACS_RESEND;
+import static org.folio.edge.sip2.parser.Command.UNKNOWN;
 
 import java.nio.charset.Charset;
 import org.apache.logging.log4j.LogManager;
@@ -173,6 +174,7 @@ public final class Parser {
       return builder.build();
     } else {
       return Message.builder()
+        .command(command)
         .valid(false)
         .checksumString(ed.checksum)
         .sequenceNumber(ed.sequenceNumber)
@@ -246,9 +248,16 @@ public final class Parser {
   }
 
   private Command parseCommandIdentifier(String message) {
-    String commandString = message.substring(0, 2);
-    Command command = Command.find(commandString);
+    final Command command;
+
+    if (message != null && message.length() >= 2) {
+      command = Command.find(message.substring(0, 2));
+    } else {
+      command = UNKNOWN;
+    }
+
     log.debug("Found command: {}", command);
+
     return command;
   }
 

--- a/src/test/java/org/folio/edge/sip2/metrics/MetricsTests.java
+++ b/src/test/java/org/folio/edge/sip2/metrics/MetricsTests.java
@@ -1,0 +1,86 @@
+package org.folio.edge.sip2.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.micrometer.core.instrument.Timer;
+import org.folio.edge.sip2.parser.Command;
+import org.junit.jupiter.api.Test;
+
+class MetricsTests {
+  @Test
+  void testGetMetrics() {
+    final Metrics m = Metrics.getMetrics(1234);
+    assertNotNull(m);
+  }
+
+  @Test
+  void testSocketError() {
+    final Metrics m = Metrics.getMetrics(1234);
+    m.socketError();
+    m.socketError();
+    assertEquals(2, m.socketErrorCount());
+  }
+
+  @Test
+  void testRequestError() {
+    final Metrics m = Metrics.getMetrics(1234);
+    m.requestError();
+    m.requestError();
+    m.requestError();
+    assertEquals(3, m.requestErrorCount());
+  }
+
+  @Test
+  void testResponseError() {
+    final Metrics m = Metrics.getMetrics(1234);
+    m.responseError();
+    assertEquals(1, m.responseErrorCount());
+  }
+
+  @Test
+  void testScResendError() {
+    final Metrics m = Metrics.getMetrics(1234);
+    m.scResendError();
+    m.scResendError();
+    m.scResendError();
+    m.scResendError();
+    m.scResendError();
+    assertEquals(5, m.scResendErrorCount());
+  }
+
+  @Test
+  void testInvalidMessageError() {
+    final Metrics m = Metrics.getMetrics(1234);
+    m.invalidMessageError();
+    m.invalidMessageError();
+    m.invalidMessageError();
+    m.invalidMessageError();
+    assertEquals(4, m.invalidMessageErrorCount());
+  }
+
+  @Test
+  void testSample() {
+    final Metrics m = Metrics.getMetrics(1234);
+    final Timer.Sample sample = m.sample();
+    assertNotNull(sample);
+  }
+
+  @Test
+  void testCommandTimer() {
+    final Metrics m = Metrics.getMetrics(1234);
+    final Timer.Sample sample = m.sample();
+    final Timer timer = m.commandTimer(Command.UNKNOWN);
+    assertNotNull(timer);
+    final long time = sample.stop(timer);
+    assertTrue(time > 0L);
+  }
+
+  @Test
+  void testStop() {
+    final Metrics m = Metrics.getMetrics(1234);
+    assertNotNull(m);
+    m.stop();
+  }
+}

--- a/src/test/java/org/folio/edge/sip2/parser/ParserTests.java
+++ b/src/test/java/org/folio/edge/sip2/parser/ParserTests.java
@@ -731,7 +731,8 @@ class ParserTests {
             + "AApatron_id|AC|AD1234|AOuniversity_id|BON|"));
 
     assertTrue(message.isValid());
-    assertTrue(message.isErrorDetectionEnabled());
+    assertNotNull(message.getSequenceNumber());
+    assertNotNull(message.getChecksumsString());
     assertEquals(RENEW_ALL, message.getCommand());
     assertTrue(message.getRequest() instanceof RenewAll);
 
@@ -760,7 +761,6 @@ class ParserTests {
             + "AApatron_id|AC|AD1234|AOuniversity_id|BON|", sequenceNumber));
 
     assertTrue(message.isValid());
-    assertTrue(message.isErrorDetectionEnabled());
     assertEquals(1, message.getSequenceNumber());
     assertEquals("EB3B", message.getChecksumsString());
     assertEquals(RENEW_ALL, message.getCommand());


### PR DESCRIPTION
Add support for Micrometer collection of metrics for delivery to a runtime defined backend. Micrometer claims to be the SLF4J for metrics, in that we code to a vendor agnostic API and rely on vendor specific bindings, that can be easily swapped in or out, to deliver metrics.

Also fixed a problem when bad data is received (the command was not being set to unknown).

Added a dependency analysis plugin for maven to better sort out dependencies (explicit vs implicit).

Added missing release maven plugin for when we do release.

Updated versions of dependencies. Note, we cannot update to Vert.x 3.7.1 unless one of these is done:
https://github.com/vert-x3/vertx-web/issues/1315
https://issues.folio.org/browse/SIP2-63

Added extensive documentation to the README for metrics setup and use.