### PR TITLE
SIP2-61: Enable PIN verification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>2.9.8</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -124,6 +131,14 @@
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
       <version>1.1.5</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
     <!-- Test dependencies -->
     <dependency>
@@ -332,7 +347,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.1.1</version>
         <executions>
           <execution>
             <id>analyze</id>
@@ -349,7 +363,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
         <configuration>
           <preparationGoals>clean verify</preparationGoals>
           <tagNameFormat>v@{project.version}</tagNameFormat>
@@ -358,5 +371,23 @@
         </configuration>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <!--
+           The super pom declares these dependencies and versions. Eclipse warns when versions
+           are specified for plugins that are controlled by pluginManagement. By declaring them
+           here we avoid these warnings and ensure we are getting the expected versions, in case
+           the super pom changes versions for some reason.
+      -->
+      <plugins>
+        <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.1.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.5.3</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 </project>

--- a/src/main/java/org/folio/edge/sip2/modules/ApplicationModule.java
+++ b/src/main/java/org/folio/edge/sip2/modules/ApplicationModule.java
@@ -19,6 +19,7 @@ import org.folio.edge.sip2.repositories.FolioResourceProvider;
 import org.folio.edge.sip2.repositories.IRequestData;
 import org.folio.edge.sip2.repositories.IResourceProvider;
 import org.folio.edge.sip2.repositories.LoginRepository;
+import org.folio.edge.sip2.repositories.PasswordVerifier;
 import org.folio.edge.sip2.repositories.UsersRepository;
 
 /**
@@ -37,6 +38,7 @@ public class ApplicationModule extends AbstractModule {
     bind(FeeFinesRepository.class);
     bind(LoginRepository.class);
     bind(UsersRepository.class);
+    bind(PasswordVerifier.class);
   }
 
   @Provides

--- a/src/main/java/org/folio/edge/sip2/repositories/ConfigurationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/ConfigurationRepository.java
@@ -152,7 +152,7 @@ public class ConfigurationRepository {
                                         String configKeyLocale, ACSStatusBuilder builder,
                                         SessionData sessionData) {
 
-    addTenantConfig(sets.get(configKeyTenant), builder);
+    addTenantConfig(sets.get(configKeyTenant), sessionData, builder);
     addSCStationConfig(sets.get(configKeySC), builder);
     addLocaleConfig(sets.get(configKeyLocale), sessionData);
     builder.institutionId(sessionData.getTenant());
@@ -166,7 +166,8 @@ public class ConfigurationRepository {
     }
   }
 
-  private void addTenantConfig(JsonObject config, ACSStatusBuilder builder) {
+  private void addTenantConfig(JsonObject config, SessionData sessionData, 
+      ACSStatusBuilder builder) {
     if (config != null) {
       builder.onLineStatus(true);
       builder.statusUpdateOk(config.getBoolean("statusUpdateOk"));
@@ -174,6 +175,8 @@ public class ConfigurationRepository {
       builder.protocolVersion("2.00");
       builder.supportedMessages(getSupportedMessagesFromJson(
           config.getJsonArray("supportedMessages")));
+      sessionData.setPatronPasswordVerificationRequired(
+          config.getBoolean("patronPasswordVerificationRequired", Boolean.FALSE));
     }
   }
 

--- a/src/main/java/org/folio/edge/sip2/repositories/LoginRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/LoginRepository.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.domain.messages.requests.Login;
 import org.folio.edge.sip2.domain.messages.responses.LoginResponse;
 import org.folio.edge.sip2.session.SessionData;
+import org.folio.edge.sip2.utils.Utils;
 
 /**
  * Provides interaction with the login service.
@@ -35,6 +36,7 @@ public class LoginRepository {
    * Perform a login.
    *
    * @param login the login domain object
+   * @param sessionData shared session data
    * @return the login response domain object
    */
   public Future<LoginResponse> login(Login login, SessionData sessionData) {
@@ -65,6 +67,27 @@ public class LoginRepository {
               .ok(resource.getResource() == null ? FALSE : TRUE)
               .build());
         });
+  }
+
+  /**
+   * Perform a login.
+   *
+   * @param patronUserName the patron's user name
+   * @param patronPassword the patron's password
+   * @param sessionData shared session data
+   * @return the login response domain object
+   */
+  public Future<IResource> patronLogin(String patronUserName, String patronPassword,
+      SessionData sessionData) {
+    final JsonObject credentials = new JsonObject()
+        .put("username", patronUserName)
+        .put("password", patronPassword);
+
+    final Future<IResource> result = resourceProvider
+        .createResource(new LoginRequestData(credentials, sessionData));
+
+    return result
+        .otherwise(Utils::handleErrors);
   }
 
   private class LoginRequestData implements IRequestData {

--- a/src/main/java/org/folio/edge/sip2/repositories/PasswordVerifier.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/PasswordVerifier.java
@@ -1,0 +1,74 @@
+package org.folio.edge.sip2.repositories;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
+import io.vertx.core.Future;
+import java.util.Objects;
+import javax.inject.Inject;
+import org.folio.edge.sip2.repositories.domain.PatronPasswordVerificationRecords;
+import org.folio.edge.sip2.session.SessionData;
+
+/**
+ * Verifies passwords sent via SIP2.
+ * 
+ * @author mreno-EBSCO
+ */
+public class PasswordVerifier {
+  private final UsersRepository usersRepository;
+  private final LoginRepository loginRepository;
+
+  @Inject
+  PasswordVerifier(UsersRepository usersRepository, LoginRepository loginRepository) {
+    this.usersRepository = Objects.requireNonNull(usersRepository,
+        "Users repository cannot be null");
+    this.loginRepository = Objects.requireNonNull(loginRepository,
+        "Login repository cannot be null");
+  }
+
+  /**
+   * Verifies a patron password if required to do so, otherwise it simple returns an empty
+   * {@code PatronPasswordVerificationRecords} object.
+   * @param patronIdentifier the patron identifier
+   * @param patronPassword the patron password
+   * @param sessionData session data
+   * @return info about the user and whether or not the password was valid
+   */
+  public Future<PatronPasswordVerificationRecords> verifyPatronPassword(
+      String patronIdentifier,
+      String patronPassword,
+      SessionData sessionData) {
+    Objects.requireNonNull(patronIdentifier, "patronIdentifier cannot be null");
+    Objects.requireNonNull(sessionData, "sessionData cannot be null");
+
+    final Future<PatronPasswordVerificationRecords> loginFuture;
+
+    if (sessionData.isPatronPasswordVerificationRequired()) {
+      loginFuture = usersRepository.getUserByBarcode(patronIdentifier, sessionData)
+          .compose(user -> {
+            if (user == null) {
+              return Future.succeededFuture(PatronPasswordVerificationRecords.builder()
+                  .passwordVerified(FALSE)
+                  .build());
+            }
+
+            return loginRepository.patronLogin(user.getUsername(), patronPassword, sessionData)
+                .map(resource -> {
+                  final PatronPasswordVerificationRecords.Builder builder =
+                      PatronPasswordVerificationRecords.builder().user(user);
+                  if (resource.getResource() == null) {
+                    builder.errorMessages(resource.getErrorMessages());
+                    builder.passwordVerified(FALSE);
+                  } else {
+                    builder.passwordVerified(TRUE);
+                  }
+                  return builder.build();
+                });
+          });
+    } else {
+      loginFuture = Future.succeededFuture(PatronPasswordVerificationRecords.builder().build());
+    }
+
+    return loginFuture;
+  }
+}

--- a/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
@@ -36,8 +36,10 @@ import org.folio.edge.sip2.domain.messages.requests.PatronInformation;
 import org.folio.edge.sip2.domain.messages.responses.EndSessionResponse;
 import org.folio.edge.sip2.domain.messages.responses.PatronInformationResponse;
 import org.folio.edge.sip2.domain.messages.responses.PatronInformationResponse.PatronInformationResponseBuilder;
+import org.folio.edge.sip2.repositories.domain.Address;
+import org.folio.edge.sip2.repositories.domain.Personal;
+import org.folio.edge.sip2.repositories.domain.User;
 import org.folio.edge.sip2.session.SessionData;
-import org.folio.edge.sip2.utils.Utils;
 
 /**
  * Provides interaction with the patron required services. This repository is a go-between for
@@ -60,20 +62,20 @@ public class PatronRepository {
   private final UsersRepository usersRepository;
   private final CirculationRepository circulationRepository;
   private final FeeFinesRepository feeFinesRepository;
-  private final LoginRepository loginRepository;
+  private final PasswordVerifier passwordVerifier;
   private final Clock clock;
 
   @Inject
   PatronRepository(UsersRepository usersRepository, CirculationRepository circulationRepository,
-      FeeFinesRepository feeFinesRepository, LoginRepository loginRepository, Clock clock) {
+      FeeFinesRepository feeFinesRepository, PasswordVerifier passwordVerifier, Clock clock) {
     this.usersRepository = Objects.requireNonNull(usersRepository,
         "Users repository cannot be null");
     this.circulationRepository = Objects.requireNonNull(circulationRepository,
         "Circulation repository cannot be null");
     this.feeFinesRepository = Objects.requireNonNull(feeFinesRepository,
         "FeeFines repository cannot be null");
-    this.loginRepository = Objects.requireNonNull(loginRepository,
-        "Login repository cannot be null");
+    this.passwordVerifier = Objects.requireNonNull(passwordVerifier,
+        "Password verifier cannot be null");
     this.clock = Objects.requireNonNull(clock, "Clock cannot be null");
   }
 
@@ -89,44 +91,38 @@ public class PatronRepository {
     Objects.requireNonNull(patronInformation, "patronInformation cannot be null");
     Objects.requireNonNull(sessionData, "sessionData cannot be null");
 
-    final String barcode = patronInformation.getPatronIdentifier();
+    final String patronIdentifier = patronInformation.getPatronIdentifier();
+    final String patronPassword = patronInformation.getPatronPassword();
 
-    // Look up the patron by barcode
-    final Future<JsonObject> result = usersRepository.getUserByBarcode(barcode, sessionData);
-    return result.compose(user -> {
-      if (user == null || !user.getBoolean("active", FALSE).booleanValue()) {
-        return invalidPatron(patronInformation, null);
-      } else {
-        final String userId = user.getString("id");
-        if (userId == null) {
-          // Something is really messed up if the id is missing
-          log.error("User with barcode {} is missing the \"id\" field", barcode);
-          return invalidPatron(patronInformation, null);
-        }
-
-        final Future<IResource> loginFuture;
-        final boolean patronPasswordVerificationRequired =
-            sessionData.isPatronPasswordVerificationRequired();
-        if (patronPasswordVerificationRequired) {
-          loginFuture = loginRepository.patronLogin(user.getString("username"),
-              patronInformation.getPatronPassword(),
-              sessionData);
-        } else {
-          loginFuture = Future.succeededFuture();
-        }
-
-        return loginFuture.compose(login -> {
-          // This means we tried to log in as the patron and failed in some way
-          if (login != null && !login.getErrorMessages().isEmpty()) {
+    return passwordVerifier.verifyPatronPassword(patronIdentifier, patronPassword, sessionData)
+        .compose(verification -> {
+          if (FALSE.equals(verification.getPasswordVerified())) {
             return invalidPatron(patronInformation, FALSE);
-          } else {
-            return validPatron(userId, user.getJsonObject("personal", new JsonObject()),
-                patronInformation, sessionData, patronPasswordVerificationRequired
-                && patronInformation.getPatronPassword() != null ? TRUE : null);
           }
+          final Future<User> userFuture;
+          if (verification.getPasswordVerified() == null) {
+            userFuture = usersRepository.getUserByBarcode(patronIdentifier, sessionData);
+          } else {
+            userFuture = Future.succeededFuture(verification.getUser());
+          }
+
+          return userFuture.compose(user -> {
+            if (user == null || FALSE.equals(user.getActive())) {
+              return invalidPatron(patronInformation, null);
+            } else {
+              final String userId = user.getId();
+              if (userId == null) {
+                // Something is really messed up if the id is missing
+                log.error("User with patron identifier {} is missing the \"id\" field",
+                    patronIdentifier);
+                return invalidPatron(patronInformation, verification.getPasswordVerified());
+              }
+
+              return validPatron(userId, user.getPersonal(), patronInformation, sessionData,
+                  verification.getPasswordVerified());
+            }
+          });
         });
-      }
-    });
   }
 
   /**
@@ -144,34 +140,19 @@ public class PatronRepository {
     Objects.requireNonNull(endPatronSession, "endPatronSession cannot be null");
     Objects.requireNonNull(sessionData, "sessionData cannot be null");
 
-    final Future<IResource> loginFuture;
-    if (sessionData.isPatronPasswordVerificationRequired()) {
-      final String patronIdentifier = endPatronSession.getPatronIdentifier();
-      final String patronPassword = endPatronSession.getPatronPassword();
+    final String patronIdentifier = endPatronSession.getPatronIdentifier();
+    final String patronPassword = endPatronSession.getPatronPassword();
 
-      loginFuture = usersRepository.getUserByBarcode(patronIdentifier, sessionData)
-          .compose(user -> {
-            if (user == null) {
-              return Future.succeededFuture(
-                  Utils.handleErrors(new Exception("Patron not found: " + patronIdentifier)));
-            }
-
-            return loginRepository.patronLogin(user.getString("username"), patronPassword,
-                sessionData);
-          });
-    } else {
-      loginFuture = Future.succeededFuture();
-    }
-
-    return loginFuture.map(login -> EndSessionResponse.builder()
-        .endSession(login == null || login.getErrorMessages().isEmpty())
-        .transactionDate(OffsetDateTime.now(clock))
-        .institutionId(endPatronSession.getInstitutionId())
-        .patronIdentifier(endPatronSession.getPatronIdentifier())
-        .build());
+    return passwordVerifier.verifyPatronPassword(patronIdentifier, patronPassword, sessionData)
+        .map(verification -> EndSessionResponse.builder()
+          .endSession(!FALSE.equals(verification.getPasswordVerified()))
+          .transactionDate(OffsetDateTime.now(clock))
+          .institutionId(endPatronSession.getInstitutionId())
+          .patronIdentifier(endPatronSession.getPatronIdentifier())
+          .build());
   }
 
-  private Future<PatronInformationResponse> validPatron(String userId, JsonObject personal,
+  private Future<PatronInformationResponse> validPatron(String userId, Personal personal,
       PatronInformation patronInformation, SessionData sessionData, Boolean validPassword) {
     // Now that we have a valid patron, we can retrieve data from circulation
     final PatronInformationResponseBuilder builder = PatronInformationResponse.builder();
@@ -271,12 +252,12 @@ public class PatronRepository {
     return records.getInteger(FIELD_TOTAL_RECORDS, Integer.valueOf(0)).intValue();
   }
 
-  private PatronInformationResponseBuilder addPersonalData(JsonObject personal,
+  private PatronInformationResponseBuilder addPersonalData(Personal personal,
       PatronInformationResponseBuilder builder) {
     final String personalName = getPatronPersonalName(personal);
     final String homeAddress = getPatronHomeAddress(personal);
-    final String emailAddress = personal.getString("email");
-    final String homePhoneNumber = personal.getString("phone");
+    final String emailAddress = personal == null ? null : personal.getEmail();
+    final String homePhoneNumber = personal == null ? null : personal.getPhone();
 
     return builder.personalName(personalName)
         .homeAddress(homeAddress)
@@ -342,39 +323,43 @@ public class PatronRepository {
     });
   }
 
-  private String getPatronPersonalName(JsonObject personal) {
-    final Optional<String> firstName = Optional.ofNullable(personal.getString("firstName"));
-    final Optional<String> middleName = Optional.ofNullable(personal.getString("middleName"));
-    final Optional<String> lastName = Optional.ofNullable(personal.getString("lastName"));
+  private String getPatronPersonalName(Personal personal) {
+    if (personal != null) {
+      return Stream.of(personal.getFirstName(), personal.getMiddleName(), personal.getLastName())
+          .filter(Objects::nonNull)
+          .collect(Collectors.joining(" "));
+    }
 
-    return Stream.of(firstName, middleName, lastName)
-        .filter(Optional::isPresent)
-        .map(Optional::get)
-        .collect(Collectors.joining(" "));
+    return "";
   }
 
-  private String getPatronHomeAddress(JsonObject personal) {
-    final JsonArray addresses = personal.getJsonArray("addresses", new JsonArray());
-    // For now, we will do the following:
-    // 1. if the address list > 0, pick the "primaryAddress"
-    // 2. if no "primaryAddress", pick the first address
-    // 3. no addresses, return null (home address is an optional field)
-    // In the future, we should use the UUID of the home address type to select the home address
-    // and if no match, then return null so as to not expose other addresses.
-    // This can be cleaned up a bit when we get to Java 11.
-    Optional<String> addressString = addresses.stream()
-        .map(o -> (JsonObject) o)
-        .filter(address -> address.getBoolean("primaryAddress", FALSE).booleanValue())
-        .findFirst()
-        .map(Optional::of)
-        .orElseGet(() -> addresses.stream()
-            .map(o -> (JsonObject) o)
-            .findFirst()
-            .map(Optional::of)
-            .orElse(Optional.empty()))
-        .map(this::toHomeAddress);
+  private String getPatronHomeAddress(Personal personal) {
+    if (personal != null) {
+      return Optional.ofNullable(personal.getAddresses())
+          .map(addresses -> {
+            // For now, we will do the following:
+            // 1. if the address list > 0, pick the "primaryAddress"
+            // 2. if no "primaryAddress", pick the first address
+            // 3. no addresses, return null (home address is an optional field)
+            // In the future, we should use the UUID of the home address type to select the home
+            // address and if no match, then return null so as to not expose other addresses.
+            // This can be cleaned up a bit when we get to Java 11.
+            Optional<String> addressString = addresses.stream()
+                .filter(address -> TRUE.equals(address.getPrimaryAddress()))
+                .findFirst()
+                .map(Optional::of)
+                .orElseGet(() -> addresses.stream()
+                    .findFirst()
+                    .map(Optional::of)
+                    .orElse(Optional.empty()))
+                .map(this::toHomeAddress);
 
-    return addressString.orElse(null);
+            return addressString.orElse(null);
+          })
+          .orElse(null);
+    }
+
+    return null;
   }
 
   private List<String> getTitles(JsonArray items) {
@@ -423,13 +408,13 @@ public class PatronRepository {
         .collect(Collectors.toList());
   }
 
-  private String toHomeAddress(JsonObject address) {
-    final Optional<String> addressLine1 = Optional.ofNullable(address.getString("addressLine1"));
-    final Optional<String> addressLine2 = Optional.ofNullable(address.getString("addressLine2"));
-    final Optional<String> city = Optional.ofNullable(address.getString("city"));
-    final Optional<String> region = Optional.ofNullable(address.getString("region"));
-    final Optional<String> postalCode = Optional.ofNullable(address.getString("postalCode"));
-    final Optional<String> countryId = Optional.ofNullable(address.getString("countryId"));
+  private String toHomeAddress(Address address) {
+    final Optional<String> addressLine1 = Optional.ofNullable(address.getAddressLine1());
+    final Optional<String> addressLine2 = Optional.ofNullable(address.getAddressLine2());
+    final Optional<String> city = Optional.ofNullable(address.getCity());
+    final Optional<String> region = Optional.ofNullable(address.getRegion());
+    final Optional<String> postalCode = Optional.ofNullable(address.getPostalCode());
+    final Optional<String> countryId = Optional.ofNullable(address.getCountryId());
 
     // Not to sure about this format. It is one line and looks like:
     // 123 Fake Street, Anytown, CA 12345-1234 US

--- a/src/main/java/org/folio/edge/sip2/repositories/UsersRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/UsersRepository.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import javax.inject.Inject;
+import org.folio.edge.sip2.repositories.domain.User;
 import org.folio.edge.sip2.session.SessionData;
 
 /**
@@ -32,7 +33,7 @@ public class UsersRepository {
    * @param sessionData session data
    * @return the user details in raw JSON
    */
-  public Future<JsonObject> getUserByBarcode(
+  public Future<User> getUserByBarcode(
       String barcode,
       SessionData sessionData) {
     Objects.requireNonNull(barcode, "barcode cannot be null");
@@ -51,8 +52,8 @@ public class UsersRepository {
         .map(this::getUserFromList);
   }
 
-  private JsonObject getUserFromList(JsonObject userList) {
-    final JsonObject user;
+  private User getUserFromList(JsonObject userList) {
+    final User user;
 
     if (userList == null || userList.getInteger("totalRecords",
         Integer.valueOf(0)).intValue() == 0) {
@@ -63,7 +64,7 @@ public class UsersRepository {
         user = null;
       } else {
         // there should be only 1 user, if the barcode exists
-        user = users.getJsonObject(0);
+        user = users.getJsonObject(0).mapTo(User.class);
       }
     }
 

--- a/src/main/java/org/folio/edge/sip2/repositories/UsersRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/UsersRepository.java
@@ -84,7 +84,7 @@ public class UsersRepository {
 
     @Override
     public String getPath() {
-      return "/users?limit=1&query=barcode==" + barcode;
+      return "/users?limit=1&query=(barcode==" + barcode + " or externalSystemId==" + barcode + ')';
     }
 
     @Override

--- a/src/main/java/org/folio/edge/sip2/repositories/domain/Address.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/domain/Address.java
@@ -1,0 +1,113 @@
+package org.folio.edge.sip2.repositories.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+@JsonDeserialize(builder = Address.Builder.class)
+public class Address {
+  private final String addressLine1;
+  private final String addressLine2;
+  private final String city;
+  private final String region;
+  private final String postalCode;
+  private final String countryId;
+  private final Boolean primaryAddress;
+
+  private Address(Builder builder) {
+    addressLine1 = builder.addressLine1;
+    addressLine2 = builder.addressLine2;
+    city = builder.city;
+    region = builder.region;
+    postalCode = builder.postalCode;
+    countryId = builder.countryId;
+    primaryAddress = builder.primaryAddress;
+  }
+
+  public String getAddressLine1() {
+    return addressLine1;
+  }
+
+  public String getAddressLine2() {
+    return addressLine2;
+  }
+
+  public String getCity() {
+    return city;
+  }
+
+  public String getRegion() {
+    return region;
+  }
+
+  public String getPostalCode() {
+    return postalCode;
+  }
+
+  public String getCountryId() {
+    return countryId;
+  }
+
+  public Boolean getPrimaryAddress() {
+    return primaryAddress;
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonPOJOBuilder
+  public static class Builder {
+    private String addressLine1;
+    private String addressLine2;
+    private String city;
+    private String region;
+    private String postalCode;
+    private String countryId;
+    private Boolean primaryAddress;
+
+    @JsonProperty
+    public Builder addressLine1(String addressLine1) {
+      this.addressLine1 = addressLine1;
+      return this;
+    }
+
+    @JsonProperty
+    public Builder addressLine2(String addressLine2) {
+      this.addressLine2 = addressLine2;
+      return this;
+    }
+
+    @JsonProperty
+    public Builder city(String city) {
+      this.city = city;
+      return this;
+    }
+
+    @JsonProperty
+    public Builder region(String region) {
+      this.region = region;
+      return this;
+    }
+
+    @JsonProperty
+    public Builder postalCode(String postalCode) {
+      this.postalCode = postalCode;
+      return this;
+    }
+
+    @JsonProperty
+    public Builder countryId(String countryId) {
+      this.countryId = countryId;
+      return this;
+    }
+
+    @JsonProperty
+    public Builder primaryAddress(Boolean primaryAddress) {
+      this.primaryAddress = primaryAddress;
+      return this;
+    }
+
+    public Address build() {
+      return new Address(this);
+    }
+  }
+}

--- a/src/main/java/org/folio/edge/sip2/repositories/domain/PatronPasswordVerificationRecords.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/domain/PatronPasswordVerificationRecords.java
@@ -1,0 +1,59 @@
+package org.folio.edge.sip2.repositories.domain;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class PatronPasswordVerificationRecords {
+  private final User user;
+  private final Boolean passwordVerified;
+  private final List<String> errorMessages;
+
+  private PatronPasswordVerificationRecords(Builder builder) {
+    this.user = builder.user;
+    this.passwordVerified = builder.passwordVerified;
+    this.errorMessages = builder.errorMessages == null ? null :
+      Collections.unmodifiableList(new ArrayList<>(builder.errorMessages));
+  }
+
+  public User getUser() {
+    return user;
+  }
+
+  public Boolean getPasswordVerified() {
+    return passwordVerified;
+  }
+
+  public List<String> getErrorMessages() {
+    return errorMessages;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private User user;
+    private Boolean passwordVerified;
+    private List<String> errorMessages;
+
+    public Builder user(User user) {
+      this.user = user;
+      return this;
+    }
+
+    public Builder passwordVerified(Boolean passwordVerified) {
+      this.passwordVerified = passwordVerified;
+      return this;
+    }
+
+    public Builder errorMessages(List<String> errorMessages) {
+      this.errorMessages = errorMessages;
+      return this;
+    }
+
+    public PatronPasswordVerificationRecords build() {
+      return new PatronPasswordVerificationRecords(this);
+    }
+  }
+}

--- a/src/main/java/org/folio/edge/sip2/repositories/domain/Personal.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/domain/Personal.java
@@ -1,0 +1,104 @@
+package org.folio.edge.sip2.repositories.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@JsonDeserialize(builder = Personal.Builder.class)
+public class Personal {
+  private final String firstName;
+  private final String middleName;
+  private final String lastName;
+  private final List<Address> addresses;
+  private final String email;
+  private final String phone;
+
+  private Personal(Builder builder) {
+    firstName = builder.firstName;
+    middleName = builder.middleName;
+    lastName = builder.lastName;
+    addresses = builder.addresses == null ? null :
+      Collections.unmodifiableList(new ArrayList<>(builder.addresses));
+    email = builder.email;
+    phone = builder.phone;
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public String getMiddleName() {
+    return middleName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public List<Address> getAddresses() {
+    return addresses;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public String getPhone() {
+    return phone;
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonPOJOBuilder
+  public static class Builder {
+    private String firstName;
+    private String middleName;
+    private String lastName;
+    private List<Address> addresses;
+    private String email;
+    private String phone;
+
+    @JsonProperty
+    public Builder firstName(String firstName) {
+      this.firstName = firstName;
+      return this;
+    }
+
+    @JsonProperty
+    public Builder middleName(String middleName) {
+      this.middleName = middleName;
+      return this;
+    }
+
+    @JsonProperty
+    public Builder lastName(String lastName) {
+      this.lastName = lastName;
+      return this;
+    }
+
+    @JsonProperty
+    public Builder addresses(List<Address> addresses) {
+      this.addresses = addresses;
+      return this;
+    }
+
+    @JsonProperty
+    public Builder email(String email) {
+      this.email = email;
+      return this;
+    }
+
+    @JsonProperty
+    public Builder phone(String phone) {
+      this.phone = phone;
+      return this;
+    }
+
+    public Personal build() {
+      return new Personal(this);
+    }
+  }
+}

--- a/src/main/java/org/folio/edge/sip2/repositories/domain/User.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/domain/User.java
@@ -1,0 +1,87 @@
+package org.folio.edge.sip2.repositories.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+@JsonDeserialize(builder = User.Builder.class)
+public class User {
+  private final String id;
+  private final String barcode;
+  private final String username;
+  private final Boolean active;
+  private final Personal personal;
+
+  private User(Builder builder) {
+    id = builder.id;
+    barcode = builder.barcode;
+    username = builder.username;
+    active = builder.active;
+    personal = builder.personal;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getBarcode() {
+    return barcode;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public Boolean getActive() {
+    return active;
+  }
+
+  public Personal getPersonal() {
+    return personal;
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonPOJOBuilder
+  public static class Builder {
+    private String id;
+    private String barcode;
+    private String username;
+    private Boolean active;
+    private Personal personal;
+
+    @JsonProperty
+    public Builder id(String id) {
+      this.id = id;
+      return this;
+    }
+
+    @JsonProperty
+    public Builder barcode(String barcode) {
+      this.barcode = barcode;
+      return this;
+    }
+
+    @JsonProperty
+    public Builder username(String username) {
+      this.username = username;
+      return this;
+    }
+
+    @JsonProperty
+    public Builder active(Boolean active) {
+      this.active = active;
+      return this;
+    }
+
+    @JsonProperty
+    public Builder personal(Personal personal) {
+      this.personal = personal;
+      return this;
+    }
+
+    public User build() {
+      return new User(this);
+    }
+  }
+}

--- a/src/main/java/org/folio/edge/sip2/session/SessionData.java
+++ b/src/main/java/org/folio/edge/sip2/session/SessionData.java
@@ -15,6 +15,7 @@ public class SessionData {
   private String password; // should we really save this?
   private PreviousMessage previousMessage;
   private String timeZone;
+  private boolean patronPasswordVerificationRequired;
 
   private SessionData(String tenant, char fieldDelimiter,
       boolean errorDetectionEnabled, String charset) {
@@ -94,6 +95,14 @@ public class SessionData {
 
   public void setTimeZone(String timeZone) {
     this.timeZone = timeZone;
+  }
+
+  public boolean isPatronPasswordVerificationRequired() {
+    return patronPasswordVerificationRequired;
+  }
+
+  public void setPatronPasswordVerificationRequired(boolean patronPasswordVerificationRequired) {
+    this.patronPasswordVerificationRequired = patronPasswordVerificationRequired;
   }
 
   public static SessionData createSession(String tenant, char fieldDelimiter,

--- a/src/test/java/org/folio/edge/sip2/handlers/EndPatronSessionHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/EndPatronSessionHandlerTests.java
@@ -1,30 +1,38 @@
 package org.folio.edge.sip2.handlers;
 
+import static java.lang.Boolean.TRUE;
 import static org.folio.edge.sip2.parser.Command.END_SESSION_RESPONSE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import freemarker.template.Template;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-
 import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.requests.EndPatronSession;
+import org.folio.edge.sip2.domain.messages.responses.EndSessionResponse;
 import org.folio.edge.sip2.handlers.freemarker.FreemarkerRepository;
+import org.folio.edge.sip2.repositories.PatronRepository;
 import org.folio.edge.sip2.session.SessionData;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith({VertxExtension.class})
+@ExtendWith({VertxExtension.class, MockitoExtension.class})
 public class EndPatronSessionHandlerTests {
   @Test
-  public void canSuccessfullyGetEndPatronSessionResponse(Vertx vertx,
-                                                         VertxTestContext testContext) {
+  public void canSuccessfullyGetEndPatronSessionResponse(
+      @Mock PatronRepository mockPatronRepository,
+      Vertx vertx,
+      VertxTestContext testContext) {
 
     final String institutionId = "fs00000001";
     final String patronIdentifier = "patronId1234";
@@ -39,11 +47,19 @@ public class EndPatronSessionHandlerTests {
         .transactionDate(OffsetDateTime.now(clock))
         .build();
 
+    when(mockPatronRepository.performEndPatronSessionCommand(any(), any()))
+        .thenReturn(Future.succeededFuture(EndSessionResponse.builder()
+          .endSession(TRUE)
+          .transactionDate(OffsetDateTime.now(clock))
+          .institutionId(institutionId)
+          .patronIdentifier(patronIdentifier)
+          .build()));
     Template template = FreemarkerRepository
         .getInstance()
         .getFreemarkerTemplate(END_SESSION_RESPONSE);
 
-    final EndPatronSessionHandler handler = new EndPatronSessionHandler(template);
+    final EndPatronSessionHandler handler =
+        new EndPatronSessionHandler(mockPatronRepository, template);
 
     final SessionData sessionData = TestUtils.getMockedSessionData();
     sessionData.setPassword("some random password");
@@ -60,9 +76,9 @@ public class EndPatronSessionHandlerTests {
 
           //through the magic of Pass-by-Reference, sessionData was updated
           //and we can see its updated values without having it explicitly being returned
-          assertNull(sessionData.getAuthenticationToken());
-          assertNull(sessionData.getUsername());
-          assertNull(sessionData.getPassword());
+          assertEquals("abcdefghijklmnop", sessionData.getAuthenticationToken());
+          assertEquals("JoeSmith", sessionData.getUsername());
+          assertEquals("some random password", sessionData.getPassword());
 
           testContext.completeNow();
         })));

--- a/src/test/java/org/folio/edge/sip2/repositories/PasswordVerifierTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/PasswordVerifierTests.java
@@ -1,0 +1,152 @@
+package org.folio.edge.sip2.repositories;
+
+import static org.folio.edge.sip2.api.support.TestUtils.getJsonFromFile;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import java.util.Collections;
+import java.util.List;
+import org.folio.edge.sip2.api.support.TestUtils;
+import org.folio.edge.sip2.repositories.domain.User;
+import org.folio.edge.sip2.session.SessionData;
+import org.folio.edge.sip2.utils.Utils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith({VertxExtension.class, MockitoExtension.class})
+class PasswordVerifierTests {
+  @Test
+  void canVerifyPassword(
+      Vertx vertx,
+      VertxTestContext testContext,
+      @Mock UsersRepository mockUsersRepository,
+      @Mock LoginRepository mockLoginRepository) {
+    final String patronIdentifier = "1234567890";
+
+    final String userResponseJson = getJsonFromFile("json/user_response.json");
+    final User userResponse = Json.decodeValue(userResponseJson, User.class);
+    when(mockUsersRepository.getUserByBarcode(eq(patronIdentifier), any()))
+        .thenReturn(Future.succeededFuture(userResponse));
+    when(mockLoginRepository.patronLogin(eq("leslie"), eq("0989"), any()))
+        .thenReturn(Future.succeededFuture(() -> new JsonObject()));
+
+    final SessionData sessionData = TestUtils.getMockedSessionData();
+    sessionData.setPatronPasswordVerificationRequired(true);
+
+    final PasswordVerifier passwordVerifier = new PasswordVerifier(mockUsersRepository,
+        mockLoginRepository);
+    passwordVerifier.verifyPatronPassword(patronIdentifier, "0989", sessionData).setHandler(
+        testContext.succeeding(verification -> testContext.verify(() -> {
+          assertNotNull(verification);
+          assertEquals("997383903573496", verification.getUser().getBarcode());
+          assertEquals("leslie", verification.getUser().getUsername());
+          assertTrue(verification.getPasswordVerified());
+          assertNull(verification.getErrorMessages());
+
+          testContext.completeNow();
+        })));
+  }
+
+  @Test
+  void canVerifyPasswordPatronNotFound(
+      Vertx vertx,
+      VertxTestContext testContext,
+      @Mock UsersRepository mockUsersRepository,
+      @Mock LoginRepository mockLoginRepository) {
+    final String patronIdentifier = "1234567890";
+
+    when(mockUsersRepository.getUserByBarcode(eq(patronIdentifier), any()))
+        .thenReturn(Future.succeededFuture(null));
+
+    final SessionData sessionData = TestUtils.getMockedSessionData();
+    sessionData.setPatronPasswordVerificationRequired(true);
+
+    final PasswordVerifier passwordVerifier = new PasswordVerifier(mockUsersRepository,
+        mockLoginRepository);
+    passwordVerifier.verifyPatronPassword(patronIdentifier, "0989", sessionData).setHandler(
+        testContext.succeeding(verification -> testContext.verify(() -> {
+          assertNotNull(verification);
+          assertNull(verification.getUser());
+          assertFalse(verification.getPasswordVerified());
+          assertNull(verification.getErrorMessages());
+
+          testContext.completeNow();
+        })));
+  }
+
+  @Test
+  void canVerifyPasswordBadPassword(
+      Vertx vertx,
+      VertxTestContext testContext,
+      @Mock UsersRepository mockUsersRepository,
+      @Mock LoginRepository mockLoginRepository) {
+    final String patronIdentifier = "1234567890";
+
+    final String userResponseJson = getJsonFromFile("json/user_response.json");
+    final User userResponse = Json.decodeValue(userResponseJson, User.class);
+    when(mockUsersRepository.getUserByBarcode(eq(patronIdentifier), any()))
+        .thenReturn(Future.succeededFuture(userResponse));
+    when(mockLoginRepository.patronLogin(eq("leslie"), eq("0989"), any()))
+        .thenReturn(Future.succeededFuture(Utils.handleErrors(new RequestThrowable(null) {
+          private static final long serialVersionUID = -9126223501276281006L;
+          public List<String> getErrorMessages() {
+            return Collections.singletonList("Password does not match");
+          }
+        })));
+
+    final SessionData sessionData = TestUtils.getMockedSessionData();
+    sessionData.setPatronPasswordVerificationRequired(true);
+
+    final PasswordVerifier passwordVerifier = new PasswordVerifier(mockUsersRepository,
+        mockLoginRepository);
+    passwordVerifier.verifyPatronPassword(patronIdentifier, "0989", sessionData).setHandler(
+        testContext.succeeding(verification -> testContext.verify(() -> {
+          assertNotNull(verification);
+          assertEquals("997383903573496", verification.getUser().getBarcode());
+          assertEquals("leslie", verification.getUser().getUsername());
+          assertFalse(verification.getPasswordVerified());
+          assertEquals(Collections.singletonList("Password does not match"),
+              verification.getErrorMessages());
+
+          testContext.completeNow();
+        })));
+  }
+
+  @Test
+  void canVerifyPasswordNotRequired(
+      Vertx vertx,
+      VertxTestContext testContext,
+      @Mock UsersRepository mockUsersRepository,
+      @Mock LoginRepository mockLoginRepository) {
+    final String patronIdentifier = "1234567890";
+
+    final SessionData sessionData = TestUtils.getMockedSessionData();
+    sessionData.setPatronPasswordVerificationRequired(false);
+
+    final PasswordVerifier passwordVerifier = new PasswordVerifier(mockUsersRepository,
+        mockLoginRepository);
+    passwordVerifier.verifyPatronPassword(patronIdentifier, "0989", sessionData).setHandler(
+        testContext.succeeding(verification -> testContext.verify(() -> {
+          assertNotNull(verification);
+          assertNull(verification.getUser());
+          assertNull(verification.getPasswordVerified());
+          assertNull(verification.getErrorMessages());
+
+          testContext.completeNow();
+        })));
+  }
+}

--- a/src/test/java/org/folio/edge/sip2/repositories/UsersRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/UsersRepositoryTests.java
@@ -60,7 +60,7 @@ public class UsersRepositoryTests {
     usersRepository.getUserByBarcode("997383903573496", sessionData).setHandler(
         testContext.succeeding(user -> testContext.verify(() -> {
           assertNotNull(user);
-          assertEquals("997383903573496", user.getString("barcode"));
+          assertEquals("997383903573496", user.getBarcode());
 
           testContext.completeNow();
         })));

--- a/src/test/resources/json/user_response.json
+++ b/src/test/resources/json/user_response.json
@@ -2,6 +2,7 @@
   "username" : "leslie",
   "id" : "4f0e711c-d583-41e0-9555-b62f1725023f",
   "barcode" : "997383903573496",
+  "externalSystemId": "abc123",
   "active" : true,
   "type" : "patron",
   "patronGroup" : "bdc2b6d4-5ceb-4a12-ab46-249b9a68473e",


### PR DESCRIPTION
We will now verify any command with a patron password sent if the tenant setting `patronPasswordVerificationRequired` is set to true. In this case, we attempt to log in to FOLIO. If we succeed, then the patron password is valid and the command can continue. If not, we shortcut the command and return a SIP2 message indicating command failure. If the setting is not true, then we do not attempt login and proceed with the command as usual.

SIP2-66 was also fixed here since end patron session sends a patron password.

SIP2-68 was also addressed in order to provide for a way to set the requirement for password verification.