### PR TITLE
SIP2-65: Return patron identifer when user name components are empty

### DIFF
--- a/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
@@ -92,13 +92,12 @@ public class PatronRepository {
         return invalidPatron(patronInformation);
       } else {
         final String userId = user.getString("id");
-        final JsonObject personal =  user.getJsonObject("personal", new JsonObject());
         if (userId == null) {
           // Something is really messed up if the id is missing
           log.error("User with barcode {} is missing the \"id\" field", barcode);
           return invalidPatron(patronInformation);
         }
-        return validPatron(userId,personal,
+        return validPatron(userId,user.getJsonObject("personal", new JsonObject()),
             patronInformation, sessionData);
       }
     });

--- a/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
@@ -35,7 +35,6 @@ import org.folio.edge.sip2.domain.messages.requests.PatronInformation;
 import org.folio.edge.sip2.domain.messages.responses.PatronInformationResponse;
 import org.folio.edge.sip2.domain.messages.responses.PatronInformationResponse.PatronInformationResponseBuilder;
 import org.folio.edge.sip2.session.SessionData;
-import sun.rmi.runtime.Log;
 
 /**
  * Provides interaction with the patron required services. This repository is a go-between for

--- a/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
@@ -331,8 +331,7 @@ public class PatronRepository {
           .collect(Collectors.collectingAndThen(Collectors.joining(" "),
               s -> s.isEmpty() ? defaultPersonalName : s));
     }
-
-    return "";
+    return defaultPersonalName;
   }
 
   private String getPatronHomeAddress(Personal personal) {

--- a/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
@@ -252,8 +252,9 @@ public class PatronRepository {
     return records.getInteger(FIELD_TOTAL_RECORDS, Integer.valueOf(0)).intValue();
   }
 
-  private PatronInformationResponseBuilder addPersonalData(Personal personal, String patronIdentifier,
-                                                           PatronInformationResponseBuilder builder) {
+  private PatronInformationResponseBuilder addPersonalData(Personal personal,
+                                                     String patronIdentifier,
+                                                     PatronInformationResponseBuilder builder) {
     String personalName = getPatronPersonalName(personal);
     personalName = personalName.isEmpty() ? patronIdentifier : personalName;
     final String homeAddress = getPatronHomeAddress(personal);

--- a/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
@@ -97,7 +97,7 @@ public class PatronRepository {
           log.error("User with barcode {} is missing the \"id\" field", barcode);
           return invalidPatron(patronInformation);
         }
-        return validPatron(userId,user.getJsonObject("personal", new JsonObject()),
+        return validPatron(userId, user.getJsonObject("personal", new JsonObject()),
             patronInformation, sessionData);
       }
     });

--- a/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
@@ -55,9 +55,9 @@ public class PatronRepository {
   private static final Logger log = LogManager.getLogger();
   // These really should come from FOLIO
   static final String MESSAGE_INVALID_PATRON =
-      "Your library card number cannot be located.  Please see a staff member for assistance.";
+      "Your library card number cannot be located. Please see a staff member for assistance.";
   static final String MESSAGE_BLOCKED_PATRON =
-      "There are unresolved issues with your account.  Please see a staff member for assistance.";
+      "There are unresolved issues with your account. Please see a staff member for assistance.";
 
   private final UsersRepository usersRepository;
   private final CirculationRepository circulationRepository;
@@ -255,8 +255,7 @@ public class PatronRepository {
   private PatronInformationResponseBuilder addPersonalData(Personal personal,
                                                      String patronIdentifier,
                                                      PatronInformationResponseBuilder builder) {
-    String personalName = getPatronPersonalName(personal);
-    personalName = personalName.isEmpty() ? patronIdentifier : personalName;
+    final String personalName = getPatronPersonalName(personal, patronIdentifier);
     final String homeAddress = getPatronHomeAddress(personal);
     final String emailAddress = personal == null ? null : personal.getEmail();
     final String homePhoneNumber = personal == null ? null : personal.getPhone();
@@ -325,11 +324,12 @@ public class PatronRepository {
     });
   }
 
-  private String getPatronPersonalName(Personal personal) {
+  private String getPatronPersonalName(Personal personal, String defaultPersonalName) {
     if (personal != null) {
       return Stream.of(personal.getFirstName(), personal.getMiddleName(), personal.getLastName())
           .filter(Objects::nonNull)
-          .collect(Collectors.joining(" "));
+          .collect(Collectors.collectingAndThen(Collectors.joining(" "),
+              s -> s.isEmpty() ? defaultPersonalName : s));
     }
 
     return "";

--- a/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
@@ -572,7 +572,7 @@ public class PatronRepositoryTests {
           assertEquals(0, patronInformationResponse.getUnavailableHoldsCount());
           assertEquals("diku", patronInformationResponse.getInstitutionId());
           assertEquals(patronIdentifier, patronInformationResponse.getPatronIdentifier());
-          assertNull(patronInformationResponse.getPersonalName());
+          assertEquals(patronIdentifier, patronInformationResponse.getPersonalName());
           assertFalse(patronInformationResponse.getValidPatron());
           assertNull(patronInformationResponse.getValidPatronPassword());
           assertNull(patronInformationResponse.getCurrencyType());
@@ -641,7 +641,7 @@ public class PatronRepositoryTests {
           assertEquals(0, patronInformationResponse.getUnavailableHoldsCount());
           assertEquals("diku", patronInformationResponse.getInstitutionId());
           assertEquals(patronIdentifier, patronInformationResponse.getPatronIdentifier());
-          assertNull(patronInformationResponse.getPersonalName());
+          assertEquals(patronIdentifier,patronInformationResponse.getPersonalName());
           assertFalse(patronInformationResponse.getValidPatron());
           assertNull(patronInformationResponse.getValidPatronPassword());
           assertNull(patronInformationResponse.getCurrencyType());
@@ -710,7 +710,7 @@ public class PatronRepositoryTests {
           assertEquals(0, patronInformationResponse.getUnavailableHoldsCount());
           assertEquals("diku", patronInformationResponse.getInstitutionId());
           assertEquals(patronIdentifier, patronInformationResponse.getPatronIdentifier());
-          assertNull(patronInformationResponse.getPersonalName());
+          assertEquals(patronIdentifier, patronInformationResponse.getPersonalName());
           assertFalse(patronInformationResponse.getValidPatron());
           assertNull(patronInformationResponse.getValidPatronPassword());
           assertNull(patronInformationResponse.getCurrencyType());

--- a/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
@@ -119,14 +119,14 @@ public class PatronRepositoryTests {
     final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
     final String patronIdentifier = "1234567890";
     final PatronInformation patronInformation = PatronInformation.builder()
-      .language(ENGLISH)
-      .transactionDate(OffsetDateTime.now())
-      .summary(RECALL_ITEMS)
-      .institutionId("diku")
-      .patronIdentifier(patronIdentifier)
-      .terminalPassword("1234")
-      .patronPassword("0989")
-      .build();
+        .language(ENGLISH)
+        .transactionDate(OffsetDateTime.now())
+        .summary(RECALL_ITEMS)
+        .institutionId("diku")
+        .patronIdentifier(patronIdentifier)
+        .terminalPassword("1234")
+        .patronPassword("0989")
+        .build();
 
     final String userResponseJson = getJsonFromFile("json/user_response.json");
     final JsonObject userResponse = new JsonObject(userResponseJson);
@@ -152,62 +152,62 @@ public class PatronRepositoryTests {
     when(mockCirculationRepository.getLoansByUserId(any(), any(), any(), any()))
       .thenReturn(Future.succeededFuture(openLoansResponse));
     when(mockCirculationRepository.getRequestsByItemId(
-      any(), eq("Recall"), any(), any(), any()))
-      .thenReturn(Future.succeededFuture(recallsResponse),
+        any(), eq("Recall"), any(), any(), any()))
+        .thenReturn(Future.succeededFuture(recallsResponse),
         Future.succeededFuture(new JsonObject().put("requests", new JsonArray())),
         Future.succeededFuture(new JsonObject().put("requests", new JsonArray())));
 
     final SessionData sessionData = TestUtils.getMockedSessionData();
 
     final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
-      mockCirculationRepository, mockFeeFinesRepository, clock);
+        mockCirculationRepository, mockFeeFinesRepository, clock);
     patronRepository.performPatronInformationCommand(patronInformation, sessionData).setHandler(
-      testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
-        assertNotNull(patronInformationResponse);
-        assertNotNull(patronInformationResponse.getPatronStatus());
-        assertTrue(patronInformationResponse.getPatronStatus().isEmpty());
-        assertEquals(ENGLISH, patronInformationResponse.getLanguage());
-        assertEquals(OffsetDateTime.now(clock), patronInformationResponse.getTransactionDate());
-        assertEquals(2, patronInformationResponse.getHoldItemsCount());
-        assertEquals(1, patronInformationResponse.getOverdueItemsCount());
-        assertNull(patronInformationResponse.getChargedItemsCount());
-        assertNull(patronInformationResponse.getFineItemsCount());
-        assertEquals(1, patronInformationResponse.getRecallItemsCount());
-        assertNull(patronInformationResponse.getUnavailableHoldsCount());
-        assertEquals("diku", patronInformationResponse.getInstitutionId());
-        assertEquals(patronIdentifier, patronInformationResponse.getPatronIdentifier());
-        assertEquals("Darius Auer", patronInformationResponse.getPersonalName());
-        assertNull(patronInformationResponse.getHoldItemsLimit());
-        assertNull(patronInformationResponse.getOverdueItemsLimit());
-        assertNull(patronInformationResponse.getChargedItemsLimit());
-        assertTrue(patronInformationResponse.getValidPatron());
-        assertNull(patronInformationResponse.getValidPatronPassword());
-        assertNull(patronInformationResponse.getCurrencyType());
-        assertNull(patronInformationResponse.getFeeAmount());
-        assertNull(patronInformationResponse.getFeeLimit());
-        assertNotNull(patronInformationResponse.getHoldItems());
-        assertTrue(patronInformationResponse.getHoldItems().isEmpty());
-        assertNotNull(patronInformationResponse.getOverdueItems());
-        assertTrue(patronInformationResponse.getOverdueItems().isEmpty());
-        assertNotNull(patronInformationResponse.getChargedItems());
-        assertTrue(patronInformationResponse.getChargedItems().isEmpty());
-        assertNotNull(patronInformationResponse.getFineItems());
-        assertTrue(patronInformationResponse.getFineItems().isEmpty());
-        assertNotNull(patronInformationResponse.getRecallItems());
-        assertEquals(Arrays.asList("1990 to 2010"), patronInformationResponse.getRecallItems());
-        assertNotNull(patronInformationResponse.getUnavailableHoldItems());
-        assertTrue(patronInformationResponse.getUnavailableHoldItems().isEmpty());
-        assertEquals("00430 Denis Parks, Indianapolis, FL 14654-6001 US",
-          patronInformationResponse.getHomeAddress());
-        assertEquals("earnestine@sipes-stokes-and-durgan.so",
-          patronInformationResponse.getEmailAddress());
-        assertEquals("(916)599-0326",
-          patronInformationResponse.getHomePhoneNumber());
-        assertNull(patronInformationResponse.getScreenMessage());
-        assertNull(patronInformationResponse.getPrintLine());
+        testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
+          assertNotNull(patronInformationResponse);
+          assertNotNull(patronInformationResponse.getPatronStatus());
+          assertTrue(patronInformationResponse.getPatronStatus().isEmpty());
+          assertEquals(ENGLISH, patronInformationResponse.getLanguage());
+          assertEquals(OffsetDateTime.now(clock), patronInformationResponse.getTransactionDate());
+          assertEquals(2, patronInformationResponse.getHoldItemsCount());
+          assertEquals(1, patronInformationResponse.getOverdueItemsCount());
+          assertNull(patronInformationResponse.getChargedItemsCount());
+          assertNull(patronInformationResponse.getFineItemsCount());
+          assertEquals(1, patronInformationResponse.getRecallItemsCount());
+          assertNull(patronInformationResponse.getUnavailableHoldsCount());
+          assertEquals("diku", patronInformationResponse.getInstitutionId());
+          assertEquals(patronIdentifier, patronInformationResponse.getPatronIdentifier());
+          assertEquals("Darius Auer", patronInformationResponse.getPersonalName());
+          assertNull(patronInformationResponse.getHoldItemsLimit());
+          assertNull(patronInformationResponse.getOverdueItemsLimit());
+          assertNull(patronInformationResponse.getChargedItemsLimit());
+          assertTrue(patronInformationResponse.getValidPatron());
+          assertNull(patronInformationResponse.getValidPatronPassword());
+          assertNull(patronInformationResponse.getCurrencyType());
+          assertNull(patronInformationResponse.getFeeAmount());
+          assertNull(patronInformationResponse.getFeeLimit());
+          assertNotNull(patronInformationResponse.getHoldItems());
+          assertTrue(patronInformationResponse.getHoldItems().isEmpty());
+          assertNotNull(patronInformationResponse.getOverdueItems());
+          assertTrue(patronInformationResponse.getOverdueItems().isEmpty());
+          assertNotNull(patronInformationResponse.getChargedItems());
+          assertTrue(patronInformationResponse.getChargedItems().isEmpty());
+          assertNotNull(patronInformationResponse.getFineItems());
+          assertTrue(patronInformationResponse.getFineItems().isEmpty());
+          assertNotNull(patronInformationResponse.getRecallItems());
+          assertEquals(Arrays.asList("1990 to 2010"), patronInformationResponse.getRecallItems());
+          assertNotNull(patronInformationResponse.getUnavailableHoldItems());
+          assertTrue(patronInformationResponse.getUnavailableHoldItems().isEmpty());
+          assertEquals("00430 Denis Parks, Indianapolis, FL 14654-6001 US",
+              patronInformationResponse.getHomeAddress());
+          assertEquals("earnestine@sipes-stokes-and-durgan.so",
+              patronInformationResponse.getEmailAddress());
+          assertEquals("(916)599-0326",
+              patronInformationResponse.getHomePhoneNumber());
+          assertNull(patronInformationResponse.getScreenMessage());
+          assertNull(patronInformationResponse.getPrintLine());
 
-        testContext.completeNow();
-      })));
+          testContext.completeNow();
+        })));
   }
 
   @SuppressWarnings("unchecked")
@@ -916,24 +916,25 @@ public class PatronRepositoryTests {
   @ParameterizedTest
   @MethodSource("provideManualBlocks")
   void canPatronInformationWithManualBlocksDetails(JsonObject manualBlocksResponse,
-                                                   Set<PatronStatus> expectedPatronStatus, List<String> expectedScreenMessage, Vertx vertx,
-                                                   VertxTestContext testContext,
-                                                   @Mock UsersRepository mockUsersRepository,
-                                                   @Mock CirculationRepository mockCirculationRepository,
-                                                   @Mock FeeFinesRepository mockFeeFinesRepository) {
+                                         Set<PatronStatus> expectedPatronStatus,
+                                         List<String> expectedScreenMessage, Vertx vertx,
+                                         VertxTestContext testContext,
+                                         @Mock UsersRepository mockUsersRepository,
+                                         @Mock CirculationRepository mockCirculationRepository,
+                                         @Mock FeeFinesRepository mockFeeFinesRepository) {
     final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
     final String patronIdentifier = "1234567890";
     final PatronInformation patronInformation = PatronInformation.builder()
-      .language(ENGLISH)
-      .transactionDate(OffsetDateTime.now())
-      .summary(Summary.RECALL_ITEMS)
-      .institutionId("diku")
-      .patronIdentifier(patronIdentifier)
-      .terminalPassword("1234")
-      .patronPassword("0989")
-      .startItem(Integer.valueOf(2))
-      .endItem(Integer.valueOf(2))
-      .build();
+          .language(ENGLISH)
+          .transactionDate(OffsetDateTime.now())
+          .summary(Summary.RECALL_ITEMS)
+          .institutionId("diku")
+          .patronIdentifier(patronIdentifier)
+          .terminalPassword("1234")
+          .patronPassword("0989")
+          .startItem(Integer.valueOf(2))
+          .endItem(Integer.valueOf(2))
+          .build();
 
     final String userResponseJson = getJsonFromFile("json/user_response2.json");
     final JsonObject userResponse = new JsonObject(userResponseJson);
@@ -952,50 +953,50 @@ public class PatronRepositoryTests {
     final SessionData sessionData = TestUtils.getMockedSessionData();
 
     final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
-      mockCirculationRepository, mockFeeFinesRepository, clock);
+        mockCirculationRepository, mockFeeFinesRepository, clock);
     patronRepository.performPatronInformationCommand(patronInformation, sessionData).setHandler(
-      testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
-        assertNotNull(patronInformationResponse);
-        assertEquals(expectedPatronStatus,
-          patronInformationResponse.getPatronStatus());
-        assertEquals(ENGLISH, patronInformationResponse.getLanguage());
-        assertEquals(OffsetDateTime.now(clock), patronInformationResponse.getTransactionDate());
-        assertEquals(0, patronInformationResponse.getHoldItemsCount());
-        assertEquals(0, patronInformationResponse.getOverdueItemsCount());
-        assertNull(patronInformationResponse.getChargedItemsCount());
-        assertNull(patronInformationResponse.getFineItemsCount());
-        assertEquals(0, patronInformationResponse.getRecallItemsCount());
-        assertNull(patronInformationResponse.getUnavailableHoldsCount());
-        assertEquals("diku", patronInformationResponse.getInstitutionId());
-        assertEquals(patronIdentifier, patronInformationResponse.getPatronIdentifier());
-        assertEquals("Darius Auer", patronInformationResponse.getPersonalName());
-        assertTrue(patronInformationResponse.getValidPatron());
-        assertNull(patronInformationResponse.getValidPatronPassword());
-        assertNull(patronInformationResponse.getCurrencyType());
-        assertNull(patronInformationResponse.getFeeAmount());
-        assertNull(patronInformationResponse.getFeeLimit());
-        assertNotNull(patronInformationResponse.getHoldItems());
-        assertTrue(patronInformationResponse.getHoldItems().isEmpty());
-        assertNotNull(patronInformationResponse.getOverdueItems());
-        assertTrue(patronInformationResponse.getOverdueItems().isEmpty());
-        assertNotNull(patronInformationResponse.getChargedItems());
-        assertTrue(patronInformationResponse.getChargedItems().isEmpty());
-        assertNotNull(patronInformationResponse.getFineItems());
-        assertTrue(patronInformationResponse.getFineItems().isEmpty());
-        assertNotNull(patronInformationResponse.getRecallItems());
-        assertTrue(patronInformationResponse.getRecallItems().isEmpty());
-        assertNotNull(patronInformationResponse.getUnavailableHoldItems());
-        assertTrue(patronInformationResponse.getUnavailableHoldItems().isEmpty());
-        assertNull(patronInformationResponse.getHomeAddress());
-        assertEquals("earnestine@sipes-stokes-and-durgan.so",
-          patronInformationResponse.getEmailAddress());
-        assertEquals("(916)599-0326",
-          patronInformationResponse.getHomePhoneNumber());
-        assertEquals(expectedScreenMessage, patronInformationResponse.getScreenMessage());
-        assertNull(patronInformationResponse.getPrintLine());
+        testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
+          assertNotNull(patronInformationResponse);
+          assertEquals(expectedPatronStatus,
+              patronInformationResponse.getPatronStatus());
+          assertEquals(ENGLISH, patronInformationResponse.getLanguage());
+          assertEquals(OffsetDateTime.now(clock), patronInformationResponse.getTransactionDate());
+          assertEquals(0, patronInformationResponse.getHoldItemsCount());
+          assertEquals(0, patronInformationResponse.getOverdueItemsCount());
+          assertNull(patronInformationResponse.getChargedItemsCount());
+          assertNull(patronInformationResponse.getFineItemsCount());
+          assertEquals(0, patronInformationResponse.getRecallItemsCount());
+          assertNull(patronInformationResponse.getUnavailableHoldsCount());
+          assertEquals("diku", patronInformationResponse.getInstitutionId());
+          assertEquals(patronIdentifier, patronInformationResponse.getPatronIdentifier());
+          assertEquals("Darius Auer", patronInformationResponse.getPersonalName());
+          assertTrue(patronInformationResponse.getValidPatron());
+          assertNull(patronInformationResponse.getValidPatronPassword());
+          assertNull(patronInformationResponse.getCurrencyType());
+          assertNull(patronInformationResponse.getFeeAmount());
+          assertNull(patronInformationResponse.getFeeLimit());
+          assertNotNull(patronInformationResponse.getHoldItems());
+          assertTrue(patronInformationResponse.getHoldItems().isEmpty());
+          assertNotNull(patronInformationResponse.getOverdueItems());
+          assertTrue(patronInformationResponse.getOverdueItems().isEmpty());
+          assertNotNull(patronInformationResponse.getChargedItems());
+          assertTrue(patronInformationResponse.getChargedItems().isEmpty());
+          assertNotNull(patronInformationResponse.getFineItems());
+          assertTrue(patronInformationResponse.getFineItems().isEmpty());
+          assertNotNull(patronInformationResponse.getRecallItems());
+          assertTrue(patronInformationResponse.getRecallItems().isEmpty());
+          assertNotNull(patronInformationResponse.getUnavailableHoldItems());
+          assertTrue(patronInformationResponse.getUnavailableHoldItems().isEmpty());
+          assertNull(patronInformationResponse.getHomeAddress());
+          assertEquals("earnestine@sipes-stokes-and-durgan.so",
+              patronInformationResponse.getEmailAddress());
+          assertEquals("(916)599-0326",
+              patronInformationResponse.getHomePhoneNumber());
+          assertEquals(expectedScreenMessage, patronInformationResponse.getScreenMessage());
+          assertNull(patronInformationResponse.getPrintLine());
 
-        testContext.completeNow();
-      })));
+          testContext.completeNow();
+        })));
   }
 
   private static JsonObject getManualBlockJsonObject(boolean borrowing, boolean renewals,

--- a/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import junitparams.converters.Param;
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.enumerations.PatronStatus;
 import org.folio.edge.sip2.domain.messages.enumerations.Summary;

--- a/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
@@ -1455,10 +1455,4 @@ public class PatronRepositoryTests {
             EnumSet.noneOf(PatronStatus.class),
             null));
   }
-
-  private static Stream personalFileArguments(){
-    return Stream.of(
-      Arguments.of("json/user_response_with_no_personal.json"),
-      Arguments.of("json/user_response_wo_personal_names.json"));
-  }
 }

--- a/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
@@ -238,21 +238,21 @@ public class PatronRepositoryTests {
   @SuppressWarnings("unchecked")
   @Test
   public void canPerformPatronInformationWithNoUserName(VertxTestContext testContext,
-                                                        @Mock UsersRepository mockUsersRepository,
-                                                        @Mock CirculationRepository mockCirculationRepository,
-                                                        @Mock FeeFinesRepository mockFeeFinesRepository,
-                                                        @Mock PasswordVerifier mockPasswordVerifier) {
+                                            @Mock UsersRepository mockUsersRepository,
+                                            @Mock CirculationRepository mockCirculationRepository,
+                                            @Mock FeeFinesRepository mockFeeFinesRepository,
+                                            @Mock PasswordVerifier mockPasswordVerifier) {
     final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
     final String patronIdentifier = "1234567890";
     final PatronInformation patronInformation = PatronInformation.builder()
-      .language(ENGLISH)
-      .transactionDate(OffsetDateTime.now())
-      .summary(RECALL_ITEMS)
-      .institutionId("diku")
-      .patronIdentifier(patronIdentifier)
-      .terminalPassword("1234")
-      .patronPassword("0989")
-      .build();
+        .language(ENGLISH)
+        .transactionDate(OffsetDateTime.now())
+        .summary(RECALL_ITEMS)
+        .institutionId("diku")
+        .patronIdentifier(patronIdentifier)
+        .terminalPassword("1234")
+        .patronPassword("0989")
+        .build();
 
     final String userResponseJson = getJsonFromFile("json/user_response_wo_personal_names.json");
     final User userResponse = Json.decodeValue(userResponseJson, User.class);
@@ -278,84 +278,84 @@ public class PatronRepositoryTests {
     when(mockCirculationRepository.getLoansByUserId(any(), any(), any(), any()))
       .thenReturn(Future.succeededFuture(openLoansResponse));
     when(mockCirculationRepository.getRequestsByItemId(
-      any(), eq("Recall"), any(), any(), any()))
-      .thenReturn(Future.succeededFuture(recallsResponse),
-        Future.succeededFuture(new JsonObject().put("requests", new JsonArray())),
-        Future.succeededFuture(new JsonObject().put("requests", new JsonArray())));
+        any(), eq("Recall"), any(), any(), any()))
+          .thenReturn(Future.succeededFuture(recallsResponse),
+            Future.succeededFuture(new JsonObject().put("requests", new JsonArray())),
+            Future.succeededFuture(new JsonObject().put("requests", new JsonArray())));
     when(mockPasswordVerifier.verifyPatronPassword(eq(patronIdentifier), eq("0989"), any()))
       .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder().build()));
 
     final SessionData sessionData = TestUtils.getMockedSessionData();
 
     final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
-      mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
+        mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
     patronRepository.performPatronInformationCommand(patronInformation, sessionData).setHandler(
-      testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
-        assertNotNull(patronInformationResponse);
-        assertNotNull(patronInformationResponse.getPatronStatus());
-        assertTrue(patronInformationResponse.getPatronStatus().isEmpty());
-        assertEquals(ENGLISH, patronInformationResponse.getLanguage());
-        assertEquals(OffsetDateTime.now(clock), patronInformationResponse.getTransactionDate());
-        assertEquals(2, patronInformationResponse.getHoldItemsCount());
-        assertEquals(1, patronInformationResponse.getOverdueItemsCount());
-        assertNull(patronInformationResponse.getChargedItemsCount());
-        assertNull(patronInformationResponse.getFineItemsCount());
-        assertEquals(1, patronInformationResponse.getRecallItemsCount());
-        assertNull(patronInformationResponse.getUnavailableHoldsCount());
-        assertEquals("diku", patronInformationResponse.getInstitutionId());
-        assertEquals(patronIdentifier, patronInformationResponse.getPatronIdentifier());
-        assertEquals(patronIdentifier, patronInformationResponse.getPersonalName());
-        assertNull(patronInformationResponse.getHoldItemsLimit());
-        assertNull(patronInformationResponse.getOverdueItemsLimit());
-        assertNull(patronInformationResponse.getChargedItemsLimit());
-        assertTrue(patronInformationResponse.getValidPatron());
-        assertNull(patronInformationResponse.getValidPatronPassword());
-        assertNull(patronInformationResponse.getCurrencyType());
-        assertNull(patronInformationResponse.getFeeAmount());
-        assertNull(patronInformationResponse.getFeeLimit());
-        assertNotNull(patronInformationResponse.getHoldItems());
-        assertTrue(patronInformationResponse.getHoldItems().isEmpty());
-        assertNotNull(patronInformationResponse.getOverdueItems());
-        assertTrue(patronInformationResponse.getOverdueItems().isEmpty());
-        assertNotNull(patronInformationResponse.getChargedItems());
-        assertTrue(patronInformationResponse.getChargedItems().isEmpty());
-        assertNotNull(patronInformationResponse.getFineItems());
-        assertTrue(patronInformationResponse.getFineItems().isEmpty());
-        assertNotNull(patronInformationResponse.getRecallItems());
-        assertEquals(Arrays.asList("1990 to 2010"), patronInformationResponse.getRecallItems());
-        assertNotNull(patronInformationResponse.getUnavailableHoldItems());
-        assertTrue(patronInformationResponse.getUnavailableHoldItems().isEmpty());
-        assertEquals("00430 Denis Parks, Indianapolis, FL 14654-6001 US",
-          patronInformationResponse.getHomeAddress());
-        assertEquals("earnestine@sipes-stokes-and-durgan.so",
-          patronInformationResponse.getEmailAddress());
-        assertEquals("(916)599-0326",
-          patronInformationResponse.getHomePhoneNumber());
-        assertNull(patronInformationResponse.getScreenMessage());
-        assertNull(patronInformationResponse.getPrintLine());
+        testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
+          assertNotNull(patronInformationResponse);
+          assertNotNull(patronInformationResponse.getPatronStatus());
+          assertTrue(patronInformationResponse.getPatronStatus().isEmpty());
+          assertEquals(ENGLISH, patronInformationResponse.getLanguage());
+          assertEquals(OffsetDateTime.now(clock), patronInformationResponse.getTransactionDate());
+          assertEquals(2, patronInformationResponse.getHoldItemsCount());
+          assertEquals(1, patronInformationResponse.getOverdueItemsCount());
+          assertNull(patronInformationResponse.getChargedItemsCount());
+          assertNull(patronInformationResponse.getFineItemsCount());
+          assertEquals(1, patronInformationResponse.getRecallItemsCount());
+          assertNull(patronInformationResponse.getUnavailableHoldsCount());
+          assertEquals("diku", patronInformationResponse.getInstitutionId());
+          assertEquals(patronIdentifier, patronInformationResponse.getPatronIdentifier());
+          assertEquals(patronIdentifier, patronInformationResponse.getPersonalName());
+          assertNull(patronInformationResponse.getHoldItemsLimit());
+          assertNull(patronInformationResponse.getOverdueItemsLimit());
+          assertNull(patronInformationResponse.getChargedItemsLimit());
+          assertTrue(patronInformationResponse.getValidPatron());
+          assertNull(patronInformationResponse.getValidPatronPassword());
+          assertNull(patronInformationResponse.getCurrencyType());
+          assertNull(patronInformationResponse.getFeeAmount());
+          assertNull(patronInformationResponse.getFeeLimit());
+          assertNotNull(patronInformationResponse.getHoldItems());
+          assertTrue(patronInformationResponse.getHoldItems().isEmpty());
+          assertNotNull(patronInformationResponse.getOverdueItems());
+          assertTrue(patronInformationResponse.getOverdueItems().isEmpty());
+          assertNotNull(patronInformationResponse.getChargedItems());
+          assertTrue(patronInformationResponse.getChargedItems().isEmpty());
+          assertNotNull(patronInformationResponse.getFineItems());
+          assertTrue(patronInformationResponse.getFineItems().isEmpty());
+          assertNotNull(patronInformationResponse.getRecallItems());
+          assertEquals(Arrays.asList("1990 to 2010"), patronInformationResponse.getRecallItems());
+          assertNotNull(patronInformationResponse.getUnavailableHoldItems());
+          assertTrue(patronInformationResponse.getUnavailableHoldItems().isEmpty());
+          assertEquals("00430 Denis Parks, Indianapolis, FL 14654-6001 US",
+              patronInformationResponse.getHomeAddress());
+          assertEquals("earnestine@sipes-stokes-and-durgan.so",
+              patronInformationResponse.getEmailAddress());
+          assertEquals("(916)599-0326",
+              patronInformationResponse.getHomePhoneNumber());
+          assertNull(patronInformationResponse.getScreenMessage());
+          assertNull(patronInformationResponse.getPrintLine());
 
-        testContext.completeNow();
-      })));
+          testContext.completeNow();
+        })));
   }
 
   @SuppressWarnings("unchecked")
   @Test
   public void canPerformPatronInformationWithNoPersonalInfo(VertxTestContext testContext,
-                                                        @Mock UsersRepository mockUsersRepository,
-                                                        @Mock CirculationRepository mockCirculationRepository,
-                                                        @Mock FeeFinesRepository mockFeeFinesRepository,
-                                                        @Mock PasswordVerifier mockPasswordVerifier) {
+                                        @Mock UsersRepository mockUsersRepository,
+                                        @Mock CirculationRepository mockCirculationRepository,
+                                        @Mock FeeFinesRepository mockFeeFinesRepository,
+                                        @Mock PasswordVerifier mockPasswordVerifier) {
     final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
     final String patronIdentifier = "1234567890";
     final PatronInformation patronInformation = PatronInformation.builder()
-      .language(ENGLISH)
-      .transactionDate(OffsetDateTime.now())
-      .summary(RECALL_ITEMS)
-      .institutionId("diku")
-      .patronIdentifier(patronIdentifier)
-      .terminalPassword("1234")
-      .patronPassword("0989")
-      .build();
+        .language(ENGLISH)
+        .transactionDate(OffsetDateTime.now())
+        .summary(RECALL_ITEMS)
+        .institutionId("diku")
+        .patronIdentifier(patronIdentifier)
+        .terminalPassword("1234")
+        .patronPassword("0989")
+        .build();
 
     final String userResponseJson = getJsonFromFile("json/user_response_with_no_personal.json");
     final User userResponse = Json.decodeValue(userResponseJson, User.class);
@@ -381,61 +381,61 @@ public class PatronRepositoryTests {
     when(mockCirculationRepository.getLoansByUserId(any(), any(), any(), any()))
       .thenReturn(Future.succeededFuture(openLoansResponse));
     when(mockCirculationRepository.getRequestsByItemId(
-      any(), eq("Recall"), any(), any(), any()))
-      .thenReturn(Future.succeededFuture(recallsResponse),
-        Future.succeededFuture(new JsonObject().put("requests", new JsonArray())),
-        Future.succeededFuture(new JsonObject().put("requests", new JsonArray())));
+        any(), eq("Recall"), any(), any(), any()))
+          .thenReturn(Future.succeededFuture(recallsResponse),
+            Future.succeededFuture(new JsonObject().put("requests", new JsonArray())),
+            Future.succeededFuture(new JsonObject().put("requests", new JsonArray())));
     when(mockPasswordVerifier.verifyPatronPassword(eq(patronIdentifier), eq("0989"), any()))
       .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder().build()));
 
     final SessionData sessionData = TestUtils.getMockedSessionData();
 
     final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
-      mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
+        mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
     patronRepository.performPatronInformationCommand(patronInformation, sessionData).setHandler(
-      testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
-        assertNotNull(patronInformationResponse);
-        assertNotNull(patronInformationResponse.getPatronStatus());
-        assertTrue(patronInformationResponse.getPatronStatus().isEmpty());
-        assertEquals(ENGLISH, patronInformationResponse.getLanguage());
-        assertEquals(OffsetDateTime.now(clock), patronInformationResponse.getTransactionDate());
-        assertEquals(2, patronInformationResponse.getHoldItemsCount());
-        assertEquals(1, patronInformationResponse.getOverdueItemsCount());
-        assertNull(patronInformationResponse.getChargedItemsCount());
-        assertNull(patronInformationResponse.getFineItemsCount());
-        assertEquals(1, patronInformationResponse.getRecallItemsCount());
-        assertNull(patronInformationResponse.getUnavailableHoldsCount());
-        assertEquals("diku", patronInformationResponse.getInstitutionId());
-        assertEquals(patronIdentifier, patronInformationResponse.getPatronIdentifier());
-        assertEquals(patronIdentifier, patronInformationResponse.getPersonalName());
-        assertNull(patronInformationResponse.getHoldItemsLimit());
-        assertNull(patronInformationResponse.getOverdueItemsLimit());
-        assertNull(patronInformationResponse.getChargedItemsLimit());
-        assertTrue(patronInformationResponse.getValidPatron());
-        assertNull(patronInformationResponse.getValidPatronPassword());
-        assertNull(patronInformationResponse.getCurrencyType());
-        assertNull(patronInformationResponse.getFeeAmount());
-        assertNull(patronInformationResponse.getFeeLimit());
-        assertNotNull(patronInformationResponse.getHoldItems());
-        assertTrue(patronInformationResponse.getHoldItems().isEmpty());
-        assertNotNull(patronInformationResponse.getOverdueItems());
-        assertTrue(patronInformationResponse.getOverdueItems().isEmpty());
-        assertNotNull(patronInformationResponse.getChargedItems());
-        assertTrue(patronInformationResponse.getChargedItems().isEmpty());
-        assertNotNull(patronInformationResponse.getFineItems());
-        assertTrue(patronInformationResponse.getFineItems().isEmpty());
-        assertNotNull(patronInformationResponse.getRecallItems());
-        assertEquals(Arrays.asList("1990 to 2010"), patronInformationResponse.getRecallItems());
-        assertNotNull(patronInformationResponse.getUnavailableHoldItems());
-        assertTrue(patronInformationResponse.getUnavailableHoldItems().isEmpty());
-        assertEquals(null, patronInformationResponse.getHomeAddress());
-        assertEquals(null, patronInformationResponse.getEmailAddress());
-        assertEquals(null, patronInformationResponse.getHomePhoneNumber());
-        assertNull(patronInformationResponse.getScreenMessage());
-        assertNull(patronInformationResponse.getPrintLine());
+        testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
+          assertNotNull(patronInformationResponse);
+          assertNotNull(patronInformationResponse.getPatronStatus());
+          assertTrue(patronInformationResponse.getPatronStatus().isEmpty());
+          assertEquals(ENGLISH, patronInformationResponse.getLanguage());
+          assertEquals(OffsetDateTime.now(clock), patronInformationResponse.getTransactionDate());
+          assertEquals(2, patronInformationResponse.getHoldItemsCount());
+          assertEquals(1, patronInformationResponse.getOverdueItemsCount());
+          assertNull(patronInformationResponse.getChargedItemsCount());
+          assertNull(patronInformationResponse.getFineItemsCount());
+          assertEquals(1, patronInformationResponse.getRecallItemsCount());
+          assertNull(patronInformationResponse.getUnavailableHoldsCount());
+          assertEquals("diku", patronInformationResponse.getInstitutionId());
+          assertEquals(patronIdentifier, patronInformationResponse.getPatronIdentifier());
+          assertEquals(patronIdentifier, patronInformationResponse.getPersonalName());
+          assertNull(patronInformationResponse.getHoldItemsLimit());
+          assertNull(patronInformationResponse.getOverdueItemsLimit());
+          assertNull(patronInformationResponse.getChargedItemsLimit());
+          assertTrue(patronInformationResponse.getValidPatron());
+          assertNull(patronInformationResponse.getValidPatronPassword());
+          assertNull(patronInformationResponse.getCurrencyType());
+          assertNull(patronInformationResponse.getFeeAmount());
+          assertNull(patronInformationResponse.getFeeLimit());
+          assertNotNull(patronInformationResponse.getHoldItems());
+          assertTrue(patronInformationResponse.getHoldItems().isEmpty());
+          assertNotNull(patronInformationResponse.getOverdueItems());
+          assertTrue(patronInformationResponse.getOverdueItems().isEmpty());
+          assertNotNull(patronInformationResponse.getChargedItems());
+          assertTrue(patronInformationResponse.getChargedItems().isEmpty());
+          assertNotNull(patronInformationResponse.getFineItems());
+          assertTrue(patronInformationResponse.getFineItems().isEmpty());
+          assertNotNull(patronInformationResponse.getRecallItems());
+          assertEquals(Arrays.asList("1990 to 2010"), patronInformationResponse.getRecallItems());
+          assertNotNull(patronInformationResponse.getUnavailableHoldItems());
+          assertTrue(patronInformationResponse.getUnavailableHoldItems().isEmpty());
+          assertEquals(null, patronInformationResponse.getHomeAddress());
+          assertEquals(null, patronInformationResponse.getEmailAddress());
+          assertEquals(null, patronInformationResponse.getHomePhoneNumber());
+          assertNull(patronInformationResponse.getScreenMessage());
+          assertNull(patronInformationResponse.getPrintLine());
 
-        testContext.completeNow();
-      })));
+          testContext.completeNow();
+        })));
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/resources/json/user_response_with_no_personal.json
+++ b/src/test/resources/json/user_response_with_no_personal.json
@@ -1,0 +1,22 @@
+{
+  "username" : "leslie",
+  "id" : "4f0e711c-d583-41e0-9555-b62f1725023f",
+  "barcode" : "997383903573496",
+  "active" : true,
+  "type" : "patron",
+  "patronGroup" : "bdc2b6d4-5ceb-4a12-ab46-249b9a68473e",
+  "proxyFor" : [ ],
+  "enrollmentDate" : "2015-04-30T00:00:00.000+0000",
+  "expirationDate" : "2020-06-19T00:00:00.000+0000",
+  "createdDate" : "2019-04-15T10:23:30.751+0000",
+  "updatedDate" : "2019-04-16T19:08:57.247+0000",
+  "metadata" : {
+    "createdDate" : "2019-04-16T19:08:57.244+0000",
+    "createdByUserId" : "d5402f1c-f64f-5eb9-8176-abacba37c8a9",
+    "updatedDate" : "2019-04-16T19:08:57.244+0000",
+    "updatedByUserId" : "d5402f1c-f64f-5eb9-8176-abacba37c8a9"
+  },
+  "tags" : {
+    "tagList" : [ "urgent" ]
+  }
+}

--- a/src/test/resources/json/user_response_wo_personal_names.json
+++ b/src/test/resources/json/user_response_wo_personal_names.json
@@ -1,0 +1,44 @@
+{
+  "username" : "leslie",
+  "id" : "4f0e711c-d583-41e0-9555-b62f1725023f",
+  "barcode" : "997383903573496",
+  "active" : true,
+  "type" : "patron",
+  "patronGroup" : "bdc2b6d4-5ceb-4a12-ab46-249b9a68473e",
+  "proxyFor" : [ ],
+  "personal" : {
+    "email" : "earnestine@sipes-stokes-and-durgan.so",
+    "phone" : "(916)599-0326",
+    "dateOfBirth" : "1968-08-12T00:00:00.000+0000",
+    "addresses" : [ {
+      "countryId" : "US",
+      "addressLine1" : "2123 Blah Street",
+      "city" : "Boston",
+      "region" : "MA",
+      "postalCode" : "12345-1234",
+      "addressTypeId" : "93d3d88d-499b-45d0-9bc7-ac73c3a19880"
+    }, {
+      "countryId" : "US",
+      "addressLine1" : "00430 Denis Parks",
+      "city" : "Indianapolis",
+      "region" : "FL",
+      "postalCode" : "14654-6001",
+      "addressTypeId" : "93d3d88d-499b-45d0-9bc7-ac73c3a19880",
+      "primaryAddress" : true
+    } ],
+    "preferredContactTypeId" : "005"
+  },
+  "enrollmentDate" : "2015-04-30T00:00:00.000+0000",
+  "expirationDate" : "2020-06-19T00:00:00.000+0000",
+  "createdDate" : "2019-04-15T10:23:30.751+0000",
+  "updatedDate" : "2019-04-16T19:08:57.247+0000",
+  "metadata" : {
+    "createdDate" : "2019-04-16T19:08:57.244+0000",
+    "createdByUserId" : "d5402f1c-f64f-5eb9-8176-abacba37c8a9",
+    "updatedDate" : "2019-04-16T19:08:57.244+0000",
+    "updatedByUserId" : "d5402f1c-f64f-5eb9-8176-abacba37c8a9"
+  },
+  "tags" : {
+    "tagList" : [ "urgent" ]
+  }
+}


### PR DESCRIPTION
Added a simple check for empty user name string and assign the patron identifier if it's empty when building out a valid patron information response. 

Added one new test case for the code change, moved private utility methods to the bottom so all the tests are grouped together. If this proved too much headaches for reviewing I don't mind restoring the previous order. 