### PR TITLE
SIP2-76: Fix unit test that uses fixed hours adjustment

### DIFF
--- a/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
@@ -21,6 +21,7 @@ import org.folio.edge.sip2.repositories.DefaultResourceProvider;
 import org.folio.edge.sip2.repositories.IRequestData;
 import org.folio.edge.sip2.repositories.IResourceProvider;
 import org.folio.edge.sip2.session.SessionData;
+import org.folio.edge.sip2.utils.Utils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -86,7 +87,7 @@ public class SCStatusHandlerTests {
 
           String expectedDateTimeString =
               TestUtils.getFormattedLocalDateTime(
-                OffsetDateTime.now(clock).plusHours(2)); //Europe/Stockholm is 2 hours ahead of UTC
+                  Utils.convertDateTime(OffsetDateTime.now(clock),"Europe/Stockholm"));
 
           String expectedSipResponse = "98YYNYNN005003"
               + expectedDateTimeString


### PR DESCRIPTION
A unit test started failing when daylight saving time ended in the
timezone used for a test since we were manually adjusting the clock by a
fixed offset to determine the expected date and time returned in a SIP
response. The offset is now 1 instead of 2, so the test will fail until
DST begins again in the timezone.

To correct this, since a master build shouldn't remain broken for
months, we'll just use java.time to compute the expected date and time
based on the test's timezone. This will handle DST shifts automatically.