### PR TITLE
SIP2-77: Add the circulation interface 8.0 version

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -9,7 +9,7 @@
     },
     {
       "id": "circulation",
-      "version": "7.0"
+      "version": "7.0 8.0"
     },
     {
       "id": "users",


### PR DESCRIPTION
The `circulation` interface needs to be updated to `8.0` in order to
deploy Edelweiss.