### PR TITLE
SIP2-79: Migrate to circulation v10.0.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -9,7 +9,7 @@
     },
     {
       "id": "circulation",
-      "version": "7.0 8.0"
+      "version": "7.0 8.0 9.0"
     },
     {
       "id": "users",


### PR DESCRIPTION
https://issues.folio.org/browse/SIP2-79: Migrate to new major version of item-storage, inventory, circulation.

Migrate to circulation v10. Changes:
### Item-storage:8.0, item-storage-batch-sync:0.2, inventory:10.0
Changes:
1. {{item.status.name}} has restricted to the following values:
* Available
* Awaiting pickup
* Awaiting delivery
* Checked out
* In process
* In transit
* Missing
* On order
* Paged
* Withdrawn
* Declared lost

2. *Item.status* and *item.status.name* are required now, no defaulting available anymore;
3. Array *item.copyNumbers* converted to a single value *copyNumber*;
4. Item.status.date is read-only field now and has date-time formatting now ("yyyy-MM-dd'T'HH:mm:ss.SSS+0000").

### circulation:9.0, requests-reports:0.6, request-move:0.6
1. Array *request.item.copyNumbers* has converted to a single value - *copyNumber*;
2. *request/loan.item.status.date* has date-time formatting.

**Have to be merged with** https://github.com/folio-org/mod-circulation/pull/443 and https://github.com/folio-org/mod-inventory-storage/pull/382