### PR TITLE
SIP2-84 - compatible with login 7.0

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -5,7 +5,7 @@
   "requires": [
     {
       "id": "login",
-      "version": "5.0 6.0"
+      "version": "5.0 6.0 7.0"
     },
     {
       "id": "circulation",


### PR DESCRIPTION
Update dependencies due to new login interface version.

See https://issues.folio.org/browse/SIP2-84.

For additional context see https://issues.folio.org/browse/MODLOGIN-128 and related issues.

The breaking changes in mod-login were related to credential management, not the /authn/login API, so I think we can safely add 7.0 to the list of supported versions for the login interface.
