### PR TITLE
SIP2-80: Fix checkstyle security vulnerability, upgrade to 8.29 + 3.1.1

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
           "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
           "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
     Checkstyle configuration that checks the Google coding conventions from Google Java Style
-    that can be found at https://google.github.io/styleguide/javaguide.html.
+    that can be found at https://google.github.io/styleguide/javaguide.html
 
     Checkstyle is very configurable. Be sure to read the documentation at
-    http://checkstyle.sf.net (or in your downloaded distribution).
+    http://checkstyle.org (or in your downloaded distribution).
 
     To completely disable a check, just comment it out or delete it from the file.
+    To suppress certain violations please review suppression filters.
 
     Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
-
-    Modifications: mreno-EBSCO
  -->
 
 <module name = "Checker">
@@ -28,10 +27,23 @@
     <module name="BeforeExecutionExclusionFileFilter">
         <property name="fileNamePattern" value="module\-info\.java$"/>
     </module>
+    <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
+    <module name="SuppressionFilter">
+        <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
+                  default="checkstyle-suppressions.xml" />
+        <property name="optional" value="true"/>
+    </module>
+
     <!-- Checks for whitespace                               -->
-    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+    <!-- See http://checkstyle.org/config_whitespace.html -->
     <module name="FileTabCharacter">
         <property name="eachLine" value="true"/>
+    </module>
+
+    <module name="LineLength">
+        <property name="fileExtensions" value="java"/>
+        <property name="max" value="100"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
     </module>
 
     <module name="TreeWalker">
@@ -48,20 +60,28 @@
             <property name="allowByTailComment" value="true"/>
             <property name="allowNonPrintableEscapes" value="true"/>
         </module>
-        <module name="LineLength">
-            <property name="max" value="100"/>
-            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
-        </module>
         <module name="AvoidStarImport"/>
         <module name="OneTopLevelClass"/>
-        <module name="NoLineWrap"/>
+        <module name="NoLineWrap">
+            <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT"/>
+        </module>
         <module name="EmptyBlock">
             <property name="option" value="TEXT"/>
             <property name="tokens"
              value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
         </module>
-        <module name="NeedBraces"/>
-        <module name="LeftCurly"/>
+        <module name="NeedBraces">
+            <property name="tokens"
+             value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE"/>
+        </module>
+        <module name="LeftCurly">
+            <property name="tokens"
+             value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
+                    INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, LITERAL_DEFAULT,
+                    LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF,
+                    OBJBLOCK, STATIC_INIT"/>
+        </module>
         <module name="RightCurly">
             <property name="id" value="RightCurlySame"/>
             <property name="tokens"
@@ -73,7 +93,13 @@
             <property name="option" value="alone"/>
             <property name="tokens"
              value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
-                    INSTANCE_INIT"/>
+                    INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF"/>
+        </module>
+        <module name="SuppressionXpathSingleFilter">
+          <!-- suppresion is required till https://github.com/checkstyle/checkstyle/issues/7541 -->
+          <property name="id" value="RightCurlyAlone"/>
+          <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1]
+                                                 or preceding-sibling::*[last()][self::LCURLY]]"/>
         </module>
         <module name="WhitespaceAround">
             <property name="allowEmptyConstructors" value="true"/>
@@ -81,6 +107,14 @@
             <property name="allowEmptyMethods" value="true"/>
             <property name="allowEmptyTypes" value="true"/>
             <property name="allowEmptyLoops" value="true"/>
+            <property name="tokens"
+             value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR,
+                    BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND,
+                    LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY,
+                    LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH, LITERAL_SYNCHRONIZED,
+                     LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN,
+                     NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR,
+                     SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND"/>
             <message key="ws.notFollowed"
              value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
             <message key="ws.notPreceded"
@@ -94,6 +128,9 @@
         <module name="UpperEll"/>
         <module name="ModifierOrder"/>
         <module name="EmptyLineSeparator">
+            <property name="tokens"
+             value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                    STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
             <property name="allowNoEmptyLineBetweenFields" value="true"/>
         </module>
         <module name="SeparatorWrap">
@@ -129,6 +166,7 @@
              value="Package name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="TypeName">
+            <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF"/>
             <message key="name.invalidPattern"
              value="Type name ''{0}'' must match pattern ''{1}''."/>
         </module>
@@ -153,7 +191,6 @@
              value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="LocalVariableName">
-            <property name="tokens" value="VARIABLE_DEF"/>
             <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
             <message key="name.invalidPattern"
              value="Local variable name ''{0}'' must match pattern ''{1}''."/>
@@ -195,9 +232,12 @@
         <module name="AbbreviationAsWordInName">
             <property name="ignoreFinal" value="false"/>
             <property name="allowedAbbreviationLength" value="1"/>
-            <!-- Begin modification mreno-EBSCO -->
+            <!-- Begin FOLIO modification -->
             <property name="allowedAbbreviations" value="PWD,UID,ACS,SC,TLS,UTC"/>
-            <!-- End modification mreno-EBSCO -->
+            <!-- End FOLIO modification -->
+            <property name="tokens"
+             value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
+                    PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF"/>
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>
@@ -205,14 +245,25 @@
             <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="separateLineBetweenGroups" value="true"/>
             <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+            <property name="tokens" value="IMPORT, STATIC_IMPORT, PACKAGE_DEF"/>
         </module>
-        <module name="MethodParamPad"/>
+        <module name="MethodParamPad">
+            <property name="tokens"
+             value="CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF,
+                    SUPER_CTOR_CALL, ENUM_CONSTANT_DEF"/>
+        </module>
         <module name="NoWhitespaceBefore">
             <property name="tokens"
              value="COMMA, SEMI, POST_INC, POST_DEC, DOT, ELLIPSIS, METHOD_REF"/>
             <property name="allowLineBreaks" value="true"/>
         </module>
-        <module name="ParenPad"/>
+        <module name="ParenPad">
+            <property name="tokens"
+             value="ANNOTATION, ANNOTATION_FIELD_DEF, CTOR_CALL, CTOR_DEF, DOT, ENUM_CONSTANT_DEF,
+                    EXPR, LITERAL_CATCH, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_NEW,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_WHILE, METHOD_CALL,
+                    METHOD_DEF, QUESTION, RESOURCE_SPECIFICATION, SUPER_CTOR_CALL, LAMBDA"/>
+        </module>
         <module name="OperatorWrap">
             <property name="option" value="NL"/>
             <property name="tokens"
@@ -230,6 +281,7 @@
             <property name="allowSamelineMultipleAnnotations" value="true"/>
         </module>
         <module name="NonEmptyAtclauseDescription"/>
+        <module name="InvalidJavadocPosition"/>
         <module name="JavadocTagContinuationIndentation"/>
         <module name="SummaryJavadoc">
             <property name="forbiddenSummaryFragments"
@@ -244,11 +296,15 @@
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
+            <property name="allowedAnnotations" value="Override, Test"/>
+            <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF"/>
+        </module>
+        <module name="MissingJavadocMethod">
+            <property name="scope" value="public"/>
             <property name="minLineCount" value="2"/>
             <property name="allowedAnnotations" value="Override, Test"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
+            <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF"/>
         </module>
         <module name="MethodName">
             <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
@@ -261,6 +317,14 @@
         <module name="EmptyCatchBlock">
             <property name="exceptionVariableName" value="expected"/>
         </module>
-        <module name="CommentsIndentation"/>
+        <module name="CommentsIndentation">
+            <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN"/>
+        </module>
+        <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
+        <module name="SuppressionXpathFilter">
+            <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
+                      default="checkstyle-xpath-suppressions.xml" />
+            <property name="optional" value="true"/>
+        </module>
     </module>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -320,20 +320,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.1</version>
         <configuration>
           <configLocation>checkstyle.xml</configLocation>
           <linkXRef>false</linkXRef>
           <violationSeverity>warning</violationSeverity>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>com.puppycrawl.tools</groupId>
-            <artifactId>checkstyle</artifactId>
-            <version>8.18</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <goals>

--- a/src/main/java/org/folio/edge/sip2/domain/messages/requests/FeePaid.java
+++ b/src/main/java/org/folio/edge/sip2/domain/messages/requests/FeePaid.java
@@ -2,7 +2,6 @@ package org.folio.edge.sip2.domain.messages.requests;
 
 import java.time.OffsetDateTime;
 import java.util.Objects;
-
 import org.folio.edge.sip2.domain.messages.enumerations.CurrencyType;
 import org.folio.edge.sip2.domain.messages.enumerations.FeeType;
 import org.folio.edge.sip2.domain.messages.enumerations.PaymentType;

--- a/src/main/java/org/folio/edge/sip2/domain/messages/requests/Hold.java
+++ b/src/main/java/org/folio/edge/sip2/domain/messages/requests/Hold.java
@@ -2,7 +2,6 @@ package org.folio.edge.sip2.domain.messages.requests;
 
 import java.time.OffsetDateTime;
 import java.util.Objects;
-
 import org.folio.edge.sip2.domain.messages.enumerations.HoldMode;
 import org.folio.edge.sip2.domain.messages.enumerations.HoldType;
 

--- a/src/main/java/org/folio/edge/sip2/domain/messages/requests/Login.java
+++ b/src/main/java/org/folio/edge/sip2/domain/messages/requests/Login.java
@@ -1,7 +1,6 @@
 package org.folio.edge.sip2.domain.messages.requests;
 
 import java.util.Objects;
-
 import org.folio.edge.sip2.domain.messages.enumerations.PWDAlgorithm;
 import org.folio.edge.sip2.domain.messages.enumerations.UIDAlgorithm;
 

--- a/src/main/java/org/folio/edge/sip2/domain/messages/requests/PatronInformation.java
+++ b/src/main/java/org/folio/edge/sip2/domain/messages/requests/PatronInformation.java
@@ -2,7 +2,6 @@ package org.folio.edge.sip2.domain.messages.requests;
 
 import java.time.OffsetDateTime;
 import java.util.Objects;
-
 import org.folio.edge.sip2.domain.messages.enumerations.Language;
 import org.folio.edge.sip2.domain.messages.enumerations.Summary;
 

--- a/src/main/java/org/folio/edge/sip2/domain/messages/requests/PatronStatusRequest.java
+++ b/src/main/java/org/folio/edge/sip2/domain/messages/requests/PatronStatusRequest.java
@@ -2,7 +2,6 @@ package org.folio.edge.sip2.domain.messages.requests;
 
 import java.time.OffsetDateTime;
 import java.util.Objects;
-
 import org.folio.edge.sip2.domain.messages.enumerations.Language;
 
 /**

--- a/src/main/java/org/folio/edge/sip2/domain/messages/requests/SCStatus.java
+++ b/src/main/java/org/folio/edge/sip2/domain/messages/requests/SCStatus.java
@@ -1,7 +1,6 @@
 package org.folio.edge.sip2.domain.messages.requests;
 
 import java.util.Objects;
-
 import org.folio.edge.sip2.domain.messages.enumerations.StatusCode;
 
 /**

--- a/src/main/java/org/folio/edge/sip2/domain/messages/responses/ACSStatus.java
+++ b/src/main/java/org/folio/edge/sip2/domain/messages/responses/ACSStatus.java
@@ -7,7 +7,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-
 import org.folio.edge.sip2.domain.messages.enumerations.Messages;
 
 /**

--- a/src/main/java/org/folio/edge/sip2/domain/messages/responses/BaseCheckoutRenewResponse.java
+++ b/src/main/java/org/folio/edge/sip2/domain/messages/responses/BaseCheckoutRenewResponse.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-
 import org.folio.edge.sip2.domain.messages.enumerations.CurrencyType;
 import org.folio.edge.sip2.domain.messages.enumerations.FeeType;
 import org.folio.edge.sip2.domain.messages.enumerations.MediaType;
@@ -40,7 +39,7 @@ public abstract class BaseCheckoutRenewResponse {
   /**
    * {@code TRUE} if the SC should desensitize the article. {@code FALSE} if
    * the SC should not desensitize the article, e.g. a closed reserve book or
-   * the checkout was refused. 
+   * the checkout was refused.
    */
   private final Boolean desensitize;
   /** The date and time the patron checked out the item at the SC. */

--- a/src/main/java/org/folio/edge/sip2/domain/messages/responses/CheckinResponse.java
+++ b/src/main/java/org/folio/edge/sip2/domain/messages/responses/CheckinResponse.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-
 import org.folio.edge.sip2.domain.messages.enumerations.MediaType;
 
 /**
@@ -28,7 +27,7 @@ public final class CheckinResponse {
   /**
    * {@code TRUE} if the SC should resensitize the article. {@code FALSE} if
    * the SC should not resensitize the article, e.g. a closed reserve book or
-   * the checkin was refused. 
+   * the checkin was refused.
    */
   private final Boolean resensitize;
   /**

--- a/src/main/java/org/folio/edge/sip2/domain/messages/responses/ItemInformationResponse.java
+++ b/src/main/java/org/folio/edge/sip2/domain/messages/responses/ItemInformationResponse.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-
 import org.folio.edge.sip2.domain.messages.enumerations.CirculationStatus;
 import org.folio.edge.sip2.domain.messages.enumerations.CurrencyType;
 import org.folio.edge.sip2.domain.messages.enumerations.FeeType;

--- a/src/main/java/org/folio/edge/sip2/domain/messages/responses/PatronEnableResponse.java
+++ b/src/main/java/org/folio/edge/sip2/domain/messages/responses/PatronEnableResponse.java
@@ -7,7 +7,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-
 import org.folio.edge.sip2.domain.messages.enumerations.Language;
 import org.folio.edge.sip2.domain.messages.enumerations.PatronStatus;
 

--- a/src/main/java/org/folio/edge/sip2/domain/messages/responses/PatronInformationResponse.java
+++ b/src/main/java/org/folio/edge/sip2/domain/messages/responses/PatronInformationResponse.java
@@ -11,7 +11,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-
 import org.folio.edge.sip2.domain.messages.enumerations.CurrencyType;
 import org.folio.edge.sip2.domain.messages.enumerations.Language;
 import org.folio.edge.sip2.domain.messages.enumerations.PatronStatus;

--- a/src/main/java/org/folio/edge/sip2/domain/messages/responses/PatronStatusResponse.java
+++ b/src/main/java/org/folio/edge/sip2/domain/messages/responses/PatronStatusResponse.java
@@ -7,7 +7,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-
 import org.folio.edge.sip2.domain.messages.enumerations.CurrencyType;
 import org.folio.edge.sip2.domain.messages.enumerations.Language;
 import org.folio.edge.sip2.domain.messages.enumerations.PatronStatus;

--- a/src/main/java/org/folio/edge/sip2/handlers/ACSResendHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/ACSResendHandler.java
@@ -1,7 +1,6 @@
 package org.folio.edge.sip2.handlers;
 
 import io.vertx.core.Future;
-
 import org.folio.edge.sip2.domain.PreviousMessage;
 import org.folio.edge.sip2.parser.Message;
 import org.folio.edge.sip2.session.SessionData;

--- a/src/main/java/org/folio/edge/sip2/handlers/EndPatronSessionHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/EndPatronSessionHandler.java
@@ -1,15 +1,12 @@
 package org.folio.edge.sip2.handlers;
 
 import com.google.inject.Inject;
-
 import freemarker.template.Template;
 import io.vertx.core.Future;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import javax.inject.Named;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.domain.messages.requests.EndPatronSession;

--- a/src/main/java/org/folio/edge/sip2/handlers/HandlersFactory.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/HandlersFactory.java
@@ -2,10 +2,8 @@ package org.folio.edge.sip2.handlers;
 
 import freemarker.template.Template;
 import io.vertx.core.Vertx;
-
 import java.time.Clock;
 import java.util.Objects;
-
 import org.folio.edge.sip2.handlers.freemarker.FreemarkerRepository;
 import org.folio.edge.sip2.parser.Command;
 import org.folio.edge.sip2.repositories.ConfigurationRepository;

--- a/src/main/java/org/folio/edge/sip2/handlers/ISip2RequestHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/ISip2RequestHandler.java
@@ -1,7 +1,6 @@
 package org.folio.edge.sip2.handlers;
 
 import io.vertx.core.Future;
-
 import org.folio.edge.sip2.domain.PreviousMessage;
 import org.folio.edge.sip2.parser.Message;
 import org.folio.edge.sip2.session.SessionData;

--- a/src/main/java/org/folio/edge/sip2/handlers/SCStatusHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/SCStatusHandler.java
@@ -8,7 +8,6 @@ import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.domain.messages.enumerations.Messages;

--- a/src/main/java/org/folio/edge/sip2/handlers/freemarker/FormatDateTimeMethodModel.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/freemarker/FormatDateTimeMethodModel.java
@@ -4,11 +4,9 @@ import freemarker.ext.beans.StringModel;
 import freemarker.template.SimpleScalar;
 import freemarker.template.TemplateMethodModelEx;
 import freemarker.template.TemplateModelException;
-
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-
 import org.folio.edge.sip2.utils.Utils;
 
 public class FormatDateTimeMethodModel implements TemplateMethodModelEx {

--- a/src/main/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerRepository.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerRepository.java
@@ -11,11 +11,9 @@ import static org.folio.edge.sip2.parser.Command.REQUEST_SC_RESEND;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateExceptionHandler;
-
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.EnumMap;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.parser.Command;

--- a/src/main/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerUtils.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerUtils.java
@@ -2,11 +2,9 @@ package org.folio.edge.sip2.handlers.freemarker;
 
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
-
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/src/main/java/org/folio/edge/sip2/parser/BlockPatronMessageParser.java
+++ b/src/main/java/org/folio/edge/sip2/parser/BlockPatronMessageParser.java
@@ -3,7 +3,6 @@ package org.folio.edge.sip2.parser;
 import static org.folio.edge.sip2.domain.messages.requests.BlockPatron.builder;
 
 import java.time.OffsetDateTime;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.domain.messages.requests.BlockPatron;

--- a/src/main/java/org/folio/edge/sip2/parser/CheckinMessageParser.java
+++ b/src/main/java/org/folio/edge/sip2/parser/CheckinMessageParser.java
@@ -3,7 +3,6 @@ package org.folio.edge.sip2.parser;
 import static org.folio.edge.sip2.domain.messages.requests.Checkin.builder;
 
 import java.time.OffsetDateTime;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.domain.messages.requests.Checkin;

--- a/src/main/java/org/folio/edge/sip2/parser/CheckoutMessageParser.java
+++ b/src/main/java/org/folio/edge/sip2/parser/CheckoutMessageParser.java
@@ -3,7 +3,6 @@ package org.folio.edge.sip2.parser;
 import static org.folio.edge.sip2.domain.messages.requests.Checkout.builder;
 
 import java.time.OffsetDateTime;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.domain.messages.requests.Checkout;

--- a/src/main/java/org/folio/edge/sip2/parser/EndPatronSessionMessageParser.java
+++ b/src/main/java/org/folio/edge/sip2/parser/EndPatronSessionMessageParser.java
@@ -3,7 +3,6 @@ package org.folio.edge.sip2.parser;
 import static org.folio.edge.sip2.domain.messages.requests.EndPatronSession.builder;
 
 import java.time.OffsetDateTime;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.domain.messages.requests.EndPatronSession;

--- a/src/main/java/org/folio/edge/sip2/parser/FeePaidMessageParser.java
+++ b/src/main/java/org/folio/edge/sip2/parser/FeePaidMessageParser.java
@@ -23,7 +23,6 @@ import static org.folio.edge.sip2.domain.messages.enumerations.PaymentType.VISA;
 import static org.folio.edge.sip2.domain.messages.requests.FeePaid.builder;
 
 import java.time.OffsetDateTime;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.domain.messages.enumerations.CurrencyType;

--- a/src/main/java/org/folio/edge/sip2/parser/HoldMessageParser.java
+++ b/src/main/java/org/folio/edge/sip2/parser/HoldMessageParser.java
@@ -10,7 +10,6 @@ import static org.folio.edge.sip2.domain.messages.enumerations.HoldType.SPECIFIC
 import static org.folio.edge.sip2.domain.messages.requests.Hold.builder;
 
 import java.time.OffsetDateTime;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.domain.messages.enumerations.HoldMode;

--- a/src/main/java/org/folio/edge/sip2/parser/ItemInformationMessageParser.java
+++ b/src/main/java/org/folio/edge/sip2/parser/ItemInformationMessageParser.java
@@ -3,7 +3,6 @@ package org.folio.edge.sip2.parser;
 import static org.folio.edge.sip2.domain.messages.requests.ItemInformation.builder;
 
 import java.time.OffsetDateTime;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.domain.messages.requests.ItemInformation;

--- a/src/main/java/org/folio/edge/sip2/parser/ItemStatusUpdateMessageParser.java
+++ b/src/main/java/org/folio/edge/sip2/parser/ItemStatusUpdateMessageParser.java
@@ -3,7 +3,6 @@ package org.folio.edge.sip2.parser;
 import static org.folio.edge.sip2.domain.messages.requests.ItemStatusUpdate.builder;
 
 import java.time.OffsetDateTime;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.domain.messages.requests.ItemStatusUpdate;

--- a/src/main/java/org/folio/edge/sip2/parser/LanguageMapper.java
+++ b/src/main/java/org/folio/edge/sip2/parser/LanguageMapper.java
@@ -1,7 +1,6 @@
 package org.folio.edge.sip2.parser;
 
 import java.util.Arrays;
-
 import org.folio.edge.sip2.domain.messages.enumerations.Language;
 
 /**

--- a/src/main/java/org/folio/edge/sip2/parser/MessageParser.java
+++ b/src/main/java/org/folio/edge/sip2/parser/MessageParser.java
@@ -8,7 +8,6 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Objects;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.parser.exceptions.MissingDelimiterException;

--- a/src/main/java/org/folio/edge/sip2/parser/PatronEnableMessageParser.java
+++ b/src/main/java/org/folio/edge/sip2/parser/PatronEnableMessageParser.java
@@ -3,7 +3,6 @@ package org.folio.edge.sip2.parser;
 import static org.folio.edge.sip2.domain.messages.requests.PatronEnable.builder;
 
 import java.time.OffsetDateTime;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.domain.messages.requests.PatronEnable;

--- a/src/main/java/org/folio/edge/sip2/parser/PatronInformationMessageParser.java
+++ b/src/main/java/org/folio/edge/sip2/parser/PatronInformationMessageParser.java
@@ -11,7 +11,6 @@ import static org.folio.edge.sip2.parser.Field.BP;
 import static org.folio.edge.sip2.parser.Field.BQ;
 
 import java.time.OffsetDateTime;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.domain.messages.enumerations.Summary;

--- a/src/main/java/org/folio/edge/sip2/parser/PatronStatusRequestMessageParser.java
+++ b/src/main/java/org/folio/edge/sip2/parser/PatronStatusRequestMessageParser.java
@@ -3,7 +3,6 @@ package org.folio.edge.sip2.parser;
 import static org.folio.edge.sip2.domain.messages.requests.PatronStatusRequest.builder;
 
 import java.time.OffsetDateTime;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.domain.messages.requests.PatronStatusRequest;

--- a/src/main/java/org/folio/edge/sip2/parser/RenewAllMessageParser.java
+++ b/src/main/java/org/folio/edge/sip2/parser/RenewAllMessageParser.java
@@ -3,7 +3,6 @@ package org.folio.edge.sip2.parser;
 import static org.folio.edge.sip2.domain.messages.requests.RenewAll.builder;
 
 import java.time.OffsetDateTime;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.domain.messages.requests.RenewAll;

--- a/src/main/java/org/folio/edge/sip2/parser/RenewMessageParser.java
+++ b/src/main/java/org/folio/edge/sip2/parser/RenewMessageParser.java
@@ -3,7 +3,6 @@ package org.folio.edge.sip2.parser;
 import static org.folio.edge.sip2.domain.messages.requests.Renew.builder;
 
 import java.time.OffsetDateTime;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.domain.messages.requests.Renew;

--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -308,16 +308,14 @@ public class CirculationRepository {
       final int offset;
       if (startItem != null) {
         offset = startItem.intValue() - 1; // expects a 1-based count, FOLIO is 0
-        sb.append("&offset=")
-          .append(offset);
+        sb.append("&offset=").append(offset);
       } else {
         offset = 0;
       }
 
       if (endItem != null) {
         final int limit = endItem.intValue() - offset;
-        sb.append("&limit=")
-          .append(limit);
+        sb.append("&limit=").append(limit);
       }
 
       return sb;
@@ -376,8 +374,7 @@ public class CirculationRepository {
           .append(idValue)
           .append(" and status=Open");
       if (requestType != null) {
-        sb.append(" and requestType==")
-          .append(requestType);
+        sb.append(" and requestType==").append(requestType);
       }
       sb.append(')');
 

--- a/src/main/java/org/folio/edge/sip2/repositories/ConfigurationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/ConfigurationRepository.java
@@ -3,7 +3,6 @@ package org.folio.edge.sip2.repositories;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-
 import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -15,7 +14,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.domain.messages.enumerations.Messages;
@@ -166,7 +164,7 @@ public class ConfigurationRepository {
     }
   }
 
-  private void addTenantConfig(JsonObject config, SessionData sessionData, 
+  private void addTenantConfig(JsonObject config, SessionData sessionData,
       ACSStatusBuilder builder) {
     if (config != null) {
       builder.onLineStatus(true);

--- a/src/main/java/org/folio/edge/sip2/repositories/DefaultResourceProvider.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/DefaultResourceProvider.java
@@ -2,14 +2,12 @@ package org.folio.edge.sip2.repositories;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
-
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.invoke.MethodHandles;
 import java.net.URL;
 import java.util.stream.Collectors;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/src/main/java/org/folio/edge/sip2/utils/Utils.java
+++ b/src/main/java/org/folio/edge/sip2/utils/Utils.java
@@ -1,7 +1,6 @@
 package org.folio.edge.sip2.utils;
 
 import io.vertx.core.json.JsonObject;
-
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -9,7 +8,6 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
 import org.folio.edge.sip2.repositories.IResource;
 import org.folio.edge.sip2.repositories.RequestThrowable;
 

--- a/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
+++ b/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
@@ -12,7 +12,6 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.TimeZone;
-
 import org.folio.edge.sip2.api.support.BaseTest;
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.junit.jupiter.api.Disabled;

--- a/src/test/java/org/folio/edge/sip2/api/support/BaseTest.java
+++ b/src/test/java/org/folio/edge/sip2/api/support/BaseTest.java
@@ -16,7 +16,6 @@ import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SelfSignedCertificate;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.EnumMap;

--- a/src/test/java/org/folio/edge/sip2/api/support/TestUtils.java
+++ b/src/test/java/org/folio/edge/sip2/api/support/TestUtils.java
@@ -10,7 +10,6 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-
 import org.folio.edge.sip2.session.SessionData;
 
 public class TestUtils {

--- a/src/test/java/org/folio/edge/sip2/domain/messages/requests/BlockPatronTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/requests/BlockPatronTests.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
-
 import org.junit.jupiter.api.Test;
 
 class BlockPatronTests {

--- a/src/test/java/org/folio/edge/sip2/domain/messages/requests/CheckinTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/requests/CheckinTests.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
-
 import org.junit.jupiter.api.Test;
 
 class CheckinTests {

--- a/src/test/java/org/folio/edge/sip2/domain/messages/requests/CheckoutTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/requests/CheckoutTests.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
-
 import org.junit.jupiter.api.Test;
 
 class CheckoutTests {

--- a/src/test/java/org/folio/edge/sip2/domain/messages/requests/EndPatronSessionTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/requests/EndPatronSessionTests.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
-
 import org.junit.jupiter.api.Test;
 
 class EndPatronSessionTests {

--- a/src/test/java/org/folio/edge/sip2/domain/messages/requests/FeePaidTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/requests/FeePaidTests.java
@@ -14,7 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
-
 import org.folio.edge.sip2.domain.messages.enumerations.CurrencyType;
 import org.folio.edge.sip2.domain.messages.enumerations.FeeType;
 import org.folio.edge.sip2.domain.messages.enumerations.PaymentType;

--- a/src/test/java/org/folio/edge/sip2/domain/messages/requests/HoldTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/requests/HoldTests.java
@@ -14,7 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
-
 import org.folio.edge.sip2.domain.messages.enumerations.HoldMode;
 import org.folio.edge.sip2.domain.messages.enumerations.HoldType;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/folio/edge/sip2/domain/messages/requests/ItemInformationTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/requests/ItemInformationTests.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
-
 import org.junit.jupiter.api.Test;
 
 class ItemInformationTests {

--- a/src/test/java/org/folio/edge/sip2/domain/messages/requests/ItemStatusUpdateTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/requests/ItemStatusUpdateTests.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
-
 import org.junit.jupiter.api.Test;
 
 class ItemStatusUpdateTests {

--- a/src/test/java/org/folio/edge/sip2/domain/messages/requests/PatronEnableTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/requests/PatronEnableTests.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
-
 import org.junit.jupiter.api.Test;
 
 class PatronEnableTests {

--- a/src/test/java/org/folio/edge/sip2/domain/messages/requests/PatronInformationTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/requests/PatronInformationTests.java
@@ -12,7 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
-
 import org.folio.edge.sip2.domain.messages.enumerations.Language;
 import org.folio.edge.sip2.domain.messages.enumerations.Summary;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/folio/edge/sip2/domain/messages/requests/PatronStatusRequestTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/requests/PatronStatusRequestTests.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
-
 import org.folio.edge.sip2.domain.messages.enumerations.Language;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/org/folio/edge/sip2/domain/messages/requests/RenewAllTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/requests/RenewAllTests.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
-
 import org.junit.jupiter.api.Test;
 
 class RenewAllTests {

--- a/src/test/java/org/folio/edge/sip2/domain/messages/requests/RenewTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/requests/RenewTests.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
-
 import org.junit.jupiter.api.Test;
 
 class RenewTests {

--- a/src/test/java/org/folio/edge/sip2/domain/messages/responses/ACSStatusTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/responses/ACSStatusTests.java
@@ -19,7 +19,6 @@ import java.time.OffsetDateTime;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
-
 import org.folio.edge.sip2.domain.messages.enumerations.Messages;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/org/folio/edge/sip2/domain/messages/responses/PatronEnableResponseTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/responses/PatronEnableResponseTests.java
@@ -21,7 +21,6 @@ import java.time.OffsetDateTime;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
-
 import org.folio.edge.sip2.domain.messages.enumerations.Language;
 import org.folio.edge.sip2.domain.messages.enumerations.PatronStatus;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/folio/edge/sip2/domain/messages/responses/PatronInformationResponseTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/responses/PatronInformationResponseTests.java
@@ -23,7 +23,6 @@ import java.time.OffsetDateTime;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
-
 import org.folio.edge.sip2.domain.messages.enumerations.CurrencyType;
 import org.folio.edge.sip2.domain.messages.enumerations.Language;
 import org.folio.edge.sip2.domain.messages.enumerations.PatronStatus;

--- a/src/test/java/org/folio/edge/sip2/domain/messages/responses/PatronStatusResponseTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/responses/PatronStatusResponseTests.java
@@ -23,7 +23,6 @@ import java.time.OffsetDateTime;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
-
 import org.folio.edge.sip2.domain.messages.enumerations.CurrencyType;
 import org.folio.edge.sip2.domain.messages.enumerations.Language;
 import org.folio.edge.sip2.domain.messages.enumerations.PatronStatus;

--- a/src/test/java/org/folio/edge/sip2/domain/messages/responses/RenewAllResponseTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/responses/RenewAllResponseTests.java
@@ -12,7 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
 import java.util.List;
-
 import org.junit.jupiter.api.Test;
 
 class RenewAllResponseTests {

--- a/src/test/java/org/folio/edge/sip2/handlers/CheckinHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/CheckinHandlerTests.java
@@ -15,7 +15,6 @@ import io.vertx.junit5.VertxTestContext;
 import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.util.UUID;
-
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.requests.Checkin;
 import org.folio.edge.sip2.domain.messages.responses.CheckinResponse;

--- a/src/test/java/org/folio/edge/sip2/handlers/CheckoutHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/CheckoutHandlerTests.java
@@ -14,7 +14,6 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.time.Clock;
 import java.time.OffsetDateTime;
-
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.requests.Checkout;
 import org.folio.edge.sip2.domain.messages.responses.CheckoutResponse;

--- a/src/test/java/org/folio/edge/sip2/handlers/EndPatronSessionHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/EndPatronSessionHandlerTests.java
@@ -15,7 +15,6 @@ import io.vertx.junit5.VertxTestContext;
 import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
-
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.requests.EndPatronSession;
 import org.folio.edge.sip2.domain.messages.responses.EndSessionResponse;

--- a/src/test/java/org/folio/edge/sip2/handlers/HandlersFactoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/HandlersFactoryTests.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import freemarker.template.Template;
 import io.vertx.core.Vertx;
-
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.handlers.freemarker.FreemarkerRepository;
 import org.folio.edge.sip2.parser.Command;

--- a/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
@@ -11,7 +11,6 @@ import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.util.HashSet;
 import java.util.Set;
-
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.enumerations.Messages;
 import org.folio.edge.sip2.domain.messages.enumerations.StatusCode;

--- a/src/test/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerRepositoryTests.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import freemarker.template.Template;
-
 import org.folio.edge.sip2.parser.Command;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerUtilsTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerUtilsTests.java
@@ -3,11 +3,8 @@ package org.folio.edge.sip2.handlers.freemarker;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import freemarker.template.Template;
-
 import java.util.Date;
-
 import org.folio.edge.sip2.parser.Command;
-
 import org.junit.jupiter.api.Test;
 
 

--- a/src/test/java/org/folio/edge/sip2/parser/BlockPatronMessageParserTests.java
+++ b/src/test/java/org/folio/edge/sip2/parser/BlockPatronMessageParserTests.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
-
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.requests.BlockPatron;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/folio/edge/sip2/parser/CheckinMessageParserTests.java
+++ b/src/test/java/org/folio/edge/sip2/parser/CheckinMessageParserTests.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
-
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.requests.Checkin;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/folio/edge/sip2/parser/CheckoutMessageParserTests.java
+++ b/src/test/java/org/folio/edge/sip2/parser/CheckoutMessageParserTests.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
-
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.requests.Checkout;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/folio/edge/sip2/parser/EndPatronSessionMessageParserTests.java
+++ b/src/test/java/org/folio/edge/sip2/parser/EndPatronSessionMessageParserTests.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
-
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.requests.EndPatronSession;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/folio/edge/sip2/parser/FeePaidMessageParserTests.java
+++ b/src/test/java/org/folio/edge/sip2/parser/FeePaidMessageParserTests.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
-
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.requests.FeePaid;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/folio/edge/sip2/parser/HoldMessageParserTests.java
+++ b/src/test/java/org/folio/edge/sip2/parser/HoldMessageParserTests.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
-
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.requests.Hold;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/folio/edge/sip2/parser/ItemInformationMessageParserTests.java
+++ b/src/test/java/org/folio/edge/sip2/parser/ItemInformationMessageParserTests.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
-
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.requests.ItemInformation;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/folio/edge/sip2/parser/ItemStatusUpdateMessageParserTests.java
+++ b/src/test/java/org/folio/edge/sip2/parser/ItemStatusUpdateMessageParserTests.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
-
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.requests.ItemStatusUpdate;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/folio/edge/sip2/parser/ParserTests.java
+++ b/src/test/java/org/folio/edge/sip2/parser/ParserTests.java
@@ -41,7 +41,6 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Random;
-
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.enumerations.PWDAlgorithm;
 import org.folio.edge.sip2.domain.messages.enumerations.UIDAlgorithm;

--- a/src/test/java/org/folio/edge/sip2/parser/PatronEnableMessageParserTests.java
+++ b/src/test/java/org/folio/edge/sip2/parser/PatronEnableMessageParserTests.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
-
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.requests.PatronEnable;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/folio/edge/sip2/parser/PatronInformationMessageParserTests.java
+++ b/src/test/java/org/folio/edge/sip2/parser/PatronInformationMessageParserTests.java
@@ -15,7 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.stream.Stream;
-
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.enumerations.Summary;
 import org.folio.edge.sip2.domain.messages.requests.PatronInformation;

--- a/src/test/java/org/folio/edge/sip2/parser/RenewAllMessageParserTests.java
+++ b/src/test/java/org/folio/edge/sip2/parser/RenewAllMessageParserTests.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
-
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.requests.RenewAll;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/folio/edge/sip2/parser/RenewMessageParserTests.java
+++ b/src/test/java/org/folio/edge/sip2/parser/RenewMessageParserTests.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
-
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.requests.Renew;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/folio/edge/sip2/repositories/ConfigurationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/ConfigurationRepositoryTests.java
@@ -12,13 +12,11 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-
 import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
-
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.enumerations.Messages;
 import org.folio.edge.sip2.session.SessionData;
@@ -84,7 +82,7 @@ public class ConfigurationRepositoryTests {
     resultsWrapper.put("configs", configsArray);
 
     when(mockFolioProvider.retrieveResource(any()))
-      .thenReturn(succeededFuture(() -> resultsWrapper));
+        .thenReturn(succeededFuture(() -> resultsWrapper));
 
     Clock clock = TestUtils.getUtcFixedClock();
 

--- a/src/test/java/org/folio/edge/sip2/repositories/FolioResourceProviderTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/FolioResourceProviderTests.java
@@ -28,23 +28,23 @@ public class FolioResourceProviderTests {
       .requestHandler(req -> {
         if (req.path().equals("/test_retrieve")) {
           req.response()
-            .setStatusCode(200)
-            .putHeader("content-type", "application/json")
-            .putHeader("x-okapi-token", "token-value")
-            .end("{\"test\":\"value\"}");
+              .setStatusCode(200)
+              .putHeader("content-type", "application/json")
+              .putHeader("x-okapi-token", "token-value")
+              .end("{\"test\":\"value\"}");
         } else if (req.path().equals("/test_create")) {
           req.response()
-            .setStatusCode(201)
-            .putHeader("content-type", "application/json")
-            .putHeader("x-okapi-token", "token-value")
-            .end("{\"test\":\"value\"}");
+              .setStatusCode(201)
+              .putHeader("content-type", "application/json")
+              .putHeader("x-okapi-token", "token-value")
+              .end("{\"test\":\"value\"}");
         } else {
           req.response()
-            .setStatusCode(500)
-            .end("Unexpected call: " + req.path());
+              .setStatusCode(500)
+              .end("Unexpected call: " + req.path());
         }
       })
-      .listen(port, testContext.completing());
+        .listen(port, testContext.completing());
 
     assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
 

--- a/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
@@ -38,7 +38,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
-
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.enumerations.PatronStatus;
 import org.folio.edge.sip2.domain.messages.enumerations.Summary;
@@ -267,23 +266,23 @@ public class PatronRepositoryTests {
     final String recallsResponseJson = getJsonFromFile("json/recall_requests_response.json");
     final JsonObject recallsResponse = new JsonObject(recallsResponseJson);
     when(mockUsersRepository.getUserById(eq(patronIdentifier), any()))
-      .thenReturn(Future.succeededFuture(userResponse));
+        .thenReturn(Future.succeededFuture(userResponse));
     when(mockFeeFinesRepository.getManualBlocksByUserId(any(), any()))
-      .thenReturn(Future.succeededFuture(manualBlocksResponse));
+        .thenReturn(Future.succeededFuture(manualBlocksResponse));
     when(mockCirculationRepository.getOverdueLoansByUserId(any(), any(), any(), any(), any()))
-      .thenReturn(Future.succeededFuture(overdueResponse));
+        .thenReturn(Future.succeededFuture(overdueResponse));
     when(mockCirculationRepository.getRequestsByUserId(
       any(), eq("Hold"), any(), any(), any()))
-      .thenReturn(Future.succeededFuture(holdsResponse));
+        .thenReturn(Future.succeededFuture(holdsResponse));
     when(mockCirculationRepository.getLoansByUserId(any(), any(), any(), any()))
-      .thenReturn(Future.succeededFuture(openLoansResponse));
+        .thenReturn(Future.succeededFuture(openLoansResponse));
     when(mockCirculationRepository.getRequestsByItemId(
         any(), eq("Recall"), any(), any(), any()))
           .thenReturn(Future.succeededFuture(recallsResponse),
             Future.succeededFuture(new JsonObject().put("requests", new JsonArray())),
             Future.succeededFuture(new JsonObject().put("requests", new JsonArray())));
     when(mockPasswordVerifier.verifyPatronPassword(eq(patronIdentifier), eq("0989"), any()))
-      .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder().build()));
+        .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder().build()));
 
     final SessionData sessionData = TestUtils.getMockedSessionData();
 
@@ -370,23 +369,23 @@ public class PatronRepositoryTests {
     final String recallsResponseJson = getJsonFromFile("json/recall_requests_response.json");
     final JsonObject recallsResponse = new JsonObject(recallsResponseJson);
     when(mockUsersRepository.getUserById(eq(patronIdentifier), any()))
-      .thenReturn(Future.succeededFuture(userResponse));
+        .thenReturn(Future.succeededFuture(userResponse));
     when(mockFeeFinesRepository.getManualBlocksByUserId(any(), any()))
-      .thenReturn(Future.succeededFuture(manualBlocksResponse));
+        .thenReturn(Future.succeededFuture(manualBlocksResponse));
     when(mockCirculationRepository.getOverdueLoansByUserId(any(), any(), any(), any(), any()))
-      .thenReturn(Future.succeededFuture(overdueResponse));
+        .thenReturn(Future.succeededFuture(overdueResponse));
     when(mockCirculationRepository.getRequestsByUserId(
       any(), eq("Hold"), any(), any(), any()))
-      .thenReturn(Future.succeededFuture(holdsResponse));
+        .thenReturn(Future.succeededFuture(holdsResponse));
     when(mockCirculationRepository.getLoansByUserId(any(), any(), any(), any()))
-      .thenReturn(Future.succeededFuture(openLoansResponse));
+        .thenReturn(Future.succeededFuture(openLoansResponse));
     when(mockCirculationRepository.getRequestsByItemId(
         any(), eq("Recall"), any(), any(), any()))
           .thenReturn(Future.succeededFuture(recallsResponse),
             Future.succeededFuture(new JsonObject().put("requests", new JsonArray())),
             Future.succeededFuture(new JsonObject().put("requests", new JsonArray())));
     when(mockPasswordVerifier.verifyPatronPassword(eq(patronIdentifier), eq("0989"), any()))
-      .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder().build()));
+        .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder().build()));
 
     final SessionData sessionData = TestUtils.getMockedSessionData();
 
@@ -1214,14 +1213,14 @@ public class PatronRepositoryTests {
     final String userResponseJson = getJsonFromFile("json/user_response2.json");
     final User userResponse = Json.decodeValue(userResponseJson, User.class);
     when(mockUsersRepository.getUserById(eq(patronIdentifier), any()))
-      .thenReturn(Future.succeededFuture(userResponse));
+        .thenReturn(Future.succeededFuture(userResponse));
     when(mockFeeFinesRepository.getManualBlocksByUserId(any(), any()))
-      .thenReturn(Future.succeededFuture(manualBlocksResponse));
+        .thenReturn(Future.succeededFuture(manualBlocksResponse));
     when(mockCirculationRepository.getOverdueLoansByUserId(any(), any(), any(), any(), any()))
-      .thenReturn(Future.succeededFuture(null));
+        .thenReturn(Future.succeededFuture(null));
     when(mockCirculationRepository.getRequestsByUserId(
       any(), eq("Hold"), any(), any(), any()))
-      .thenReturn(Future.succeededFuture(null));
+        .thenReturn(Future.succeededFuture(null));
     when(mockCirculationRepository.getLoansByUserId(any(), any(), any(), any()))
         .thenReturn(Future.succeededFuture(null));
     when(mockPasswordVerifier.verifyPatronPassword(eq(patronIdentifier), eq("0989"), any()))

--- a/src/test/java/org/folio/edge/sip2/utils/UtilsTests.java
+++ b/src/test/java/org/folio/edge/sip2/utils/UtilsTests.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
 public class UtilsTests {


### PR DESCRIPTION
* Upgrade maven-checkstyle-plugin from 3.0.0 to 3.1.1

* Upgrade com.puppycrawl.tools:checkstyle from 8.18 to 8.29
  by using the default shipped with maven-checkstyle-plugin:3.1.1

* Upgrade checkstyle.xml from
  https://github.com/checkstyle/checkstyle/blob/checkstyle-8.18/src/main/resources/google_checks.xml
  to
  https://github.com/checkstyle/checkstyle/blob/checkstyle-8.31/src/main/resources/google_checks.xml

* Fix these whitespace violations reported after upgrading google_checks.xml
  from 8.18 to 8.31:
  * (imports) CustomImportOrder: Extra separation in import group before …
  * (indentation) Indentation: 'method call' child has incorrect indentation level