### PR TITLE
SIP2-86: upgrade to Java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM folioci/alpine-jre-openjdk8:latest
+FROM folioci/alpine-jre-openjdk11:latest
 
 ENV VERTICLE_FILE edge-sip2-fat.jar
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ buildMvn {
   mvnDeploy = true
   publishAPI = false
   runLintRamlCop = false
-
+  buildNode = 'jenkins-agent-java11'
   doDocker = {
     buildJavaDocker {
       publishMaster = true

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,6 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
     <exec.mainClass>org.folio.edge.sip2.MainVerticle</exec.mainClass>
   </properties>
 
@@ -58,7 +56,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.7.0-RC1</version>
+        <version>5.7.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -72,7 +70,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.9.8</version>
+        <version>2.10.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -137,6 +135,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <version>4.2.3</version>
+      <classifier>no_aop</classifier>
     </dependency>
     <!-- Test dependencies -->
     <dependency>
@@ -298,6 +302,14 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>module-info.class</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,8 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>4.2.2</version>
+      <version>4.2.3</version>
+      <classifier>no_aop</classifier>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>
@@ -135,12 +136,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.inject</groupId>
-      <artifactId>guice</artifactId>
-      <version>4.2.3</version>
-      <classifier>no_aop</classifier>
     </dependency>
     <!-- Test dependencies -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -51,14 +51,14 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>3.7.0</version>
+        <version>3.9.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.4.2</version>
+        <version>5.7.0-RC1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -230,14 +230,13 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>${maven.compiler.source}</source>
-          <target>${maven.compiler.target}</target>
+          <release>11</release>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>3.0.0-M5</version>
       </plugin>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
@@ -371,7 +370,7 @@
       <plugins>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.1.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
Upgrade Edge-sip2 to use Java 11
I followed the pattern here on mod-rtac: https://github.com/folio-org/mod-rtac/commit/49d8a368baa96fce8876af90018145a09182049e. 