### PR TITLE
[SIP2-88] Update version of interface "feesfines" to v16.0

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -21,7 +21,7 @@
     },
     {
       "id": "feesfines",
-      "version": "15.0"
+      "version": "15.0 16.0"
     }
   ],
   "permissionSets": [],


### PR DESCRIPTION
As a result of breaking changes introduced in scope of [MODFEE-88](https://issues.folio.org/browse/MODFEE-88) major version of interface "feesfines" was updated from 15.6 to 16.0. Since SIP2 depends on this interface, it needs to adopt this change as well.

Endpoint `/manualblocks` used by SIP2 was not affected by changes in mod-feesfines.