### PR TITLE
SIP2-90: URL Encode Query Strings

### DIFF
--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -7,6 +7,7 @@ import static org.folio.edge.sip2.utils.JsonUtils.getSubChildString;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
+
 import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -367,18 +368,21 @@ public class CirculationRepository {
 
     @Override
     public String getPath() {
-      final StringBuilder sb = new StringBuilder()
-          .append("/circulation/requests?query=(")
+      final StringBuilder qSb = new StringBuilder()
+          .append("(")
           .append(idField)
           .append("==")
           .append(idValue)
           .append(" and status=Open");
       if (requestType != null) {
-        sb.append(" and requestType==").append(requestType);
+        qSb.append(" and requestType==").append(requestType);
       }
-      sb.append(')');
+      qSb.append(')');
+      final StringBuilder urlSb = new StringBuilder()
+          .append("/circulation/requests?query=")
+          .append(Utils.encode(qSb.toString()));
 
-      return appendLimits(sb).toString();
+      return appendLimits(urlSb).toString();
     }
   }
 
@@ -397,8 +401,8 @@ public class CirculationRepository {
 
     @Override
     public String getPath() {
-      return "/circulation/loans?query=(userId==" + userId
-          + " and status.name=Open)";
+      String query = Utils.encode("(userId==" + userId + " and status.name=Open)");
+      return "/circulation/loans?query=" + query;
     }
   }
 
@@ -420,13 +424,17 @@ public class CirculationRepository {
 
     @Override
     public String getPath() {
-      final StringBuilder sb = new StringBuilder()
-          .append("/circulation/loans?query=(userId==")
+      final StringBuilder qSb = new StringBuilder()
+          .append("(userId==")
           .append(userId)
           .append(" and status.name=Open and dueDate<")
           .append(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(dueDate))
           .append(')');
-      return appendLimits(sb).toString();
+      final StringBuilder path = new StringBuilder()
+          .append("/circulation/loans?query=")
+          .append(Utils.encode(qSb.toString()));
+
+      return appendLimits(path).toString();
     }
   }
 }

--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -7,7 +7,6 @@ import static org.folio.edge.sip2.utils.JsonUtils.getSubChildString;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
-
 import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;

--- a/src/main/java/org/folio/edge/sip2/repositories/ConfigurationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/ConfigurationRepository.java
@@ -235,8 +235,6 @@ public class ConfigurationRepository {
     public String getPath() {
 
       StringBuilder pathStringBuilder = new StringBuilder();
-      pathStringBuilder.append("/configurations/entries?query=");
-
       for (int i = 0; i < configQueryParams.size(); i++) {
         if (i > 0) {
           pathStringBuilder.append(" OR ");
@@ -245,8 +243,7 @@ public class ConfigurationRepository {
         pathStringBuilder.append(Utils.buildQueryString(configQueryParams.get(i), " AND ", "=="));
         pathStringBuilder.append(")");
       }
-
-      String path =  pathStringBuilder.toString();
+      String path =  "/configurations/entries?query=" + Utils.encode(pathStringBuilder.toString());
 
       log.debug("Parsed mod-config path: {}", path);
 

--- a/src/main/java/org/folio/edge/sip2/repositories/FeeFinesRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/FeeFinesRepository.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Objects;
 import javax.inject.Inject;
 import org.folio.edge.sip2.session.SessionData;
+import org.folio.edge.sip2.utils.Utils;
 
 /**
  * Provides interaction with the feefines service.
@@ -64,7 +65,7 @@ public class FeeFinesRepository {
 
     @Override
     public String getPath() {
-      return "/manualblocks?query=userId==" + userId;
+      return "/manualblocks?query=" + Utils.encode("userId==" + userId);
     }
 
     @Override

--- a/src/main/java/org/folio/edge/sip2/repositories/UsersRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/UsersRepository.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import javax.inject.Inject;
 import org.folio.edge.sip2.repositories.domain.User;
 import org.folio.edge.sip2.session.SessionData;
+import org.folio.edge.sip2.utils.Utils;
 
 /**
  * Provides interaction with the users service.
@@ -85,9 +86,15 @@ public class UsersRepository {
 
     @Override
     public String getPath() {
-      return "/users?limit=1&query=(barcode==" + identifier
-                    + " or externalSystemId==" + identifier
-                    + " or username==" + identifier + ')';
+      StringBuilder query = new StringBuilder()
+          .append("(barcode==")
+          .append(identifier)
+          .append(" or externalSystemId==")
+          .append(identifier)
+          .append(" or username==")
+          .append(identifier)
+          .append(')');
+      return "/users?limit=1&query=" + Utils.encode(query.toString());
     }
 
     @Override

--- a/src/main/java/org/folio/edge/sip2/utils/Utils.java
+++ b/src/main/java/org/folio/edge/sip2/utils/Utils.java
@@ -1,6 +1,9 @@
 package org.folio.edge.sip2.utils;
 
 import io.vertx.core.json.JsonObject;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -101,5 +104,9 @@ public final class Utils {
       }
     }
     return stringBuilder.toString();
+  }
+
+  public static String encode(String url){
+    return URLEncoder.encode(url, StandardCharsets.UTF_8);
   }
 }

--- a/src/main/java/org/folio/edge/sip2/utils/Utils.java
+++ b/src/main/java/org/folio/edge/sip2/utils/Utils.java
@@ -1,7 +1,6 @@
 package org.folio.edge.sip2.utils;
 
 import io.vertx.core.json.JsonObject;
-
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
@@ -106,7 +105,7 @@ public final class Utils {
     return stringBuilder.toString();
   }
 
-  public static String encode(String url){
+  public static String encode(String url) {
     return URLEncoder.encode(url, StandardCharsets.UTF_8);
   }
 }

--- a/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
@@ -540,7 +540,8 @@ public class CirculationRepositoryTests {
     String expectedPath = "/circulation/loans?query="
         + Utils.encode("(userId==" + userId + " and status.name=Open)");
 
-    when(mockFolioProvider.retrieveResource(argThat((IRequestData data) -> data.getPath().equals(expectedPath))))
+    when(mockFolioProvider.retrieveResource(
+        argThat((IRequestData data) -> data.getPath().equals(expectedPath))))
         .thenReturn(Future.succeededFuture(new FolioResource(response,
             MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
 
@@ -607,9 +608,10 @@ public class CirculationRepositoryTests {
 
     String expectedPath = "/circulation/loans?query="
         + Utils.encode("(userId==" + userId + " and status.name=Open and dueDate<"
-        + dueDate +")");
+        + dueDate + ")");
 
-    when(mockFolioProvider.retrieveResource(argThat((IRequestData data) -> data.getPath().equals(expectedPath))))
+    when(mockFolioProvider.retrieveResource(
+        argThat((IRequestData data) -> data.getPath().equals(expectedPath))))
         .thenReturn(Future.succeededFuture(new FolioResource(response,
             MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
 
@@ -675,11 +677,12 @@ public class CirculationRepositoryTests {
                 .put("fulfilmentPreference", "Hold Shelf")))
         .put("totalRecords", 1);
 
-    String expectedPath ="/circulation/requests?query="
+    String expectedPath = "/circulation/requests?query="
         + Utils.encode("(itemId==" + itemId
         + " and status=Open and requestType==Recall)");
 
-    when(mockFolioProvider.retrieveResource(argThat((IRequestData data) -> data.getPath().equals(expectedPath))))
+    when(mockFolioProvider.retrieveResource(
+        argThat((IRequestData data) -> data.getPath().equals(expectedPath))))
         .thenReturn(Future.succeededFuture(new FolioResource(response,
             MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
 

--- a/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -37,6 +38,7 @@ import org.folio.edge.sip2.domain.messages.requests.Checkout;
 import org.folio.edge.sip2.repositories.domain.PatronPasswordVerificationRecords;
 import org.folio.edge.sip2.repositories.domain.User;
 import org.folio.edge.sip2.session.SessionData;
+import org.folio.edge.sip2.utils.Utils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -534,7 +536,11 @@ public class CirculationRepositoryTests {
                 .put("loanDate", OffsetDateTime.now(clock).format(ISO_OFFSET_DATE_TIME))
                 .put("action", "checkedout")))
         .put("totalRecords", 1);
-    when(mockFolioProvider.retrieveResource(any()))
+
+    String expectedPath = "/circulation/loans?query="
+        + Utils.encode("(userId==" + userId + " and status.name=Open)");
+
+    when(mockFolioProvider.retrieveResource(argThat((IRequestData data) -> data.getPath().equals(expectedPath))))
         .thenReturn(Future.succeededFuture(new FolioResource(response,
             MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
 
@@ -588,16 +594,22 @@ public class CirculationRepositoryTests {
     final Clock clock = TestUtils.getUtcFixedClock();
     final String userId = UUID.randomUUID().toString();
     final String itemId = UUID.randomUUID().toString();
+    final String dueDate = OffsetDateTime.now(clock).format(ISO_OFFSET_DATE_TIME);
 
     final JsonObject response = new JsonObject()
         .put("loans", new JsonArray()
             .add(new JsonObject()
                 .put("userId", userId)
                 .put("itemId", itemId)
-                .put("loanDate", OffsetDateTime.now(clock).format(ISO_OFFSET_DATE_TIME))
+                .put("loanDate", dueDate)
                 .put("action", "checkedout")))
         .put("totalRecords", 1);
-    when(mockFolioProvider.retrieveResource(any()))
+
+    String expectedPath = "/circulation/loans?query="
+        + Utils.encode("(userId==" + userId + " and status.name=Open and dueDate<"
+        + dueDate +")");
+
+    when(mockFolioProvider.retrieveResource(argThat((IRequestData data) -> data.getPath().equals(expectedPath))))
         .thenReturn(Future.succeededFuture(new FolioResource(response,
             MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
 
@@ -662,7 +674,12 @@ public class CirculationRepositoryTests {
                 .put("requestDate", OffsetDateTime.now(clock).format(ISO_OFFSET_DATE_TIME))
                 .put("fulfilmentPreference", "Hold Shelf")))
         .put("totalRecords", 1);
-    when(mockFolioProvider.retrieveResource(any()))
+
+    String expectedPath ="/circulation/requests?query="
+        + Utils.encode("(itemId==" + itemId
+        + " and status=Open and requestType==Recall)");
+
+    when(mockFolioProvider.retrieveResource(argThat((IRequestData data) -> data.getPath().equals(expectedPath))))
         .thenReturn(Future.succeededFuture(new FolioResource(response,
             MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
 

--- a/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
@@ -537,7 +537,7 @@ public class CirculationRepositoryTests {
                 .put("action", "checkedout")))
         .put("totalRecords", 1);
 
-    String expectedPath = "/circulation/loans?query="
+    final String expectedPath = "/circulation/loans?query="
         + Utils.encode("(userId==" + userId + " and status.name=Open)");
 
     when(mockFolioProvider.retrieveResource(
@@ -606,7 +606,7 @@ public class CirculationRepositoryTests {
                 .put("action", "checkedout")))
         .put("totalRecords", 1);
 
-    String expectedPath = "/circulation/loans?query="
+    final String expectedPath = "/circulation/loans?query="
         + Utils.encode("(userId==" + userId + " and status.name=Open and dueDate<"
         + dueDate + ")");
 
@@ -677,7 +677,7 @@ public class CirculationRepositoryTests {
                 .put("fulfilmentPreference", "Hold Shelf")))
         .put("totalRecords", 1);
 
-    String expectedPath = "/circulation/requests?query="
+    final String expectedPath = "/circulation/requests?query="
         + Utils.encode("(itemId==" + itemId
         + " and status=Open and requestType==Recall)");
 

--- a/src/test/java/org/folio/edge/sip2/repositories/FeeFinesRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/FeeFinesRepositoryTests.java
@@ -21,6 +21,7 @@ import io.vertx.junit5.VertxTestContext;
 import java.util.UUID;
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.session.SessionData;
+import org.folio.edge.sip2.utils.Utils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -106,7 +107,7 @@ public class FeeFinesRepositoryTests {
     final String userId = "a23eac4b-955e-451c-b4ff-6ec2f5e63e23";
 
     when(mockFolioProvider.retrieveResource(
-        argThat(arg -> arg.getPath().endsWith("userId==" + userId))))
+        argThat(arg -> arg.getPath().endsWith(Utils.encode("userId==" + userId)))))
         .thenReturn(Future.succeededFuture(new FolioResource(manualBlocksResponse,
             MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
 

--- a/src/test/java/org/folio/edge/sip2/repositories/UsersRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/UsersRepositoryTests.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
@@ -16,6 +17,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.folio.edge.sip2.session.SessionData;
+import org.folio.edge.sip2.utils.Utils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -105,8 +107,13 @@ public class UsersRepositoryTests {
     final JsonObject userResponse = new JsonObject(userResponseJson);
 
     final String extSystemId = "4f0e711c-d583-41e0-9555-b62f1725023f";
+    final String expectedPath = "/users?limit=1&query="
+        + Utils.encode("(barcode==" + extSystemId
+        + " or externalSystemId==" + extSystemId
+        + " or username==" + extSystemId + ')');
 
-    when(mockFolioProvider.retrieveResource(any()))
+    when(mockFolioProvider.retrieveResource(
+        argThat((IRequestData data) -> data.getPath().equals(expectedPath))))
         .thenReturn(Future.succeededFuture(new FolioResource(userResponse,
         MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
 

--- a/src/test/java/org/folio/edge/sip2/utils/UtilsTests.java
+++ b/src/test/java/org/folio/edge/sip2/utils/UtilsTests.java
@@ -54,7 +54,7 @@ public class UtilsTests {
   }
 
   @Test
-  public void testEncode(){
+  public void testEncode() {
     String url = "item = ab39%3183-194&bp23909&item2 == 23ab3;";
     assertEquals(URLEncoder.encode(url, StandardCharsets.UTF_8), Utils.encode(url));
   }

--- a/src/test/java/org/folio/edge/sip2/utils/UtilsTests.java
+++ b/src/test/java/org/folio/edge/sip2/utils/UtilsTests.java
@@ -54,7 +54,7 @@ public class UtilsTests {
   }
 
   @Test
-  public void testEncode() {
+  void testEncode() {
     String url = "item = ab39%3183-194&bp23909&item2 == 23ab3;";
     assertEquals(URLEncoder.encode(url, StandardCharsets.UTF_8), Utils.encode(url));
   }

--- a/src/test/java/org/folio/edge/sip2/utils/UtilsTests.java
+++ b/src/test/java/org/folio/edge/sip2/utils/UtilsTests.java
@@ -3,6 +3,8 @@ package org.folio.edge.sip2.utils;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -49,5 +51,11 @@ public class UtilsTests {
   @Test
   public void testIsStringNullOrEmpty() {
     assertTrue(Utils.isStringNullOrEmpty(""));
+  }
+
+  @Test
+  public void testEncode(){
+    String url = "item = ab39%3183-194&bp23909&item2 == 23ab3;";
+    assertEquals(URLEncoder.encode(url, StandardCharsets.UTF_8), Utils.encode(url));
   }
 }


### PR DESCRIPTION
URL encode the query strings for known API calls because Vert.x does not automatically encode them anymore. 