### PR TITLE
SIP2-91 Update circulation interface dependency

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -9,7 +9,7 @@
     },
     {
       "id": "circulation",
-      "version": "7.0 8.0 9.0"
+      "version": "7.0 8.0 9.0 10.0"
     },
     {
       "id": "users",


### PR DESCRIPTION
Resolves [SIP2-91](https://issues.folio.org/browse/SIP2-91)

Update `circulation` interface dependency to support version 10.0