### PR TITLE
SIP2-92 Update circulation interface dependency

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -9,7 +9,7 @@
     },
     {
       "id": "circulation",
-      "version": "7.0 8.0 9.0 10.0"
+      "version": "7.0 8.0 9.0 10.0 11.0"
     },
     {
       "id": "users",


### PR DESCRIPTION
Resolves [SIP2-92](https://issues.folio.org/browse/SIP2-92).

### Purpose
There is a breaking change in `mod-circulaion` that will be merge soon. Modules that have a dependency on `circulation` interface need to be updated to support version `11.0`.

### Warning
There are multiple PRs with `circulation` interface version update, they all should be merged on the same day. 
**DO NOT MERGE** this PR until then.