### PR TITLE
SIP2-110: Update dependencies (CVE-2020-25649)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,28 +49,35 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>3.9.2</version>
+        <version>3.9.12</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-bom</artifactId>
+        <version>1.8.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.7.0</version>
+        <version>5.8.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.17.0</version>
+        <version>2.17.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>2.10.2</version>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-bom</artifactId>
+        <version>4.3.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -115,13 +122,12 @@
     <dependency>
       <groupId>org.freemarker</groupId>
       <artifactId>freemarker</artifactId>
-      <version>2.3.28</version>
+      <version>2.3.31</version>
     </dependency>
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>4.2.3</version>
-      <classifier>no_aop</classifier>
+      <version>5.1.0</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>
@@ -131,7 +137,6 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
-      <version>1.1.5</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -166,13 +171,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.28.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>2.28.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -212,7 +215,6 @@
         <dependency>
           <groupId>io.micrometer</groupId>
           <artifactId>micrometer-registry-prometheus</artifactId>
-          <version>1.1.5</version>
           <scope>runtime</scope>
         </dependency>
       </dependencies>
@@ -226,7 +228,6 @@
         <dependency>
           <groupId>io.micrometer</groupId>
           <artifactId>micrometer-registry-influx</artifactId>
-          <version>1.1.5</version>
           <scope>runtime</scope>
         </dependency>
       </dependencies>


### PR DESCRIPTION
PR #78 has updated vertx-stack-depchain from 3.9.2 to 4.2.5, this has indirectly bumped netty from 4.1.49 to 4.1.72 fixing HTTP request smuggling: https://nvd.nist.gov/vuln/detail/CVE-2021-21295 and denial of service (DoS): https://nvd.nist.gov/vuln/detail/CVE-2021-37136 , https://nvd.nist.gov/vuln/detail/CVE-2021-37137

Update jackson from 2.10.2 to 2.11.4 by using the version from vertx-stack-depchain. This fixes an XML external entity (XXE) Injection: https://nvd.nist.gov/vuln/detail/CVE-2020-25649

Update freemarker from 2.3.28 to 2.3.31 fixing server-side template injection (SSTI): https://security.snyk.io/vuln/SNYK-JAVA-ORGFREEMARKER-1076795

Update guice from 4.2.3 to 5.1.0 fixing temp directory creation vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2020-8908

Update micrometer from 1.1.5 to 1.8.3.

Update log4j from 2.17.0 to 2.17.2.

Update junit from 5.7.0 to 5.8.2.

Update mockito from 2.28.2 to 4.3.1.