### PR TITLE
SIP2-110: Update edge-sip2 to Vert.x 4.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>3.9.2</version>
+        <version>4.2.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -331,7 +331,7 @@
                 <filter>
                   <artifact>*:*</artifact>
                   <excludes>
-                    <exclude>module-info.class</exclude>
+                    <exclude>**/module-info.class</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/src/main/java/org/folio/edge/sip2/handlers/HandlersFactory.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/HandlersFactory.java
@@ -1,7 +1,7 @@
 package org.folio.edge.sip2.handlers;
 
 import freemarker.template.Template;
-import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
 import java.time.Clock;
 import java.util.Objects;
 import org.folio.edge.sip2.handlers.freemarker.FreemarkerRepository;
@@ -33,12 +33,12 @@ public class HandlersFactory {
       Template freeMarkerTemplate,
       Clock clock,
       String okapiUrl,
-      Vertx vertx) {
+      WebClient webClient) {
 
     Objects.requireNonNull(okapiUrl, "okapiUrl is required");
-    Objects.requireNonNull(vertx, "vertx is required");
+    Objects.requireNonNull(webClient, "webClient is required");
 
-    resProvider = getResourceProvider(resProvider, okapiUrl, vertx);
+    resProvider = getResourceProvider(resProvider, okapiUrl, webClient);
 
     if (configRepo == null && clock == null) {
       configRepo = new ConfigurationRepository(resProvider, Clock.systemUTC());
@@ -58,9 +58,9 @@ public class HandlersFactory {
 
   @SuppressWarnings("unchecked")
   private static <T> IResourceProvider<T> getResourceProvider(
-      IResourceProvider<T> resourceProvider, String okapiUrl, Vertx vertx) {
+      IResourceProvider<T> resourceProvider, String okapiUrl, WebClient webClient) {
     if (resourceProvider == null) {
-      return (IResourceProvider<T>) new FolioResourceProvider(okapiUrl, vertx);
+      return (IResourceProvider<T>) new FolioResourceProvider(okapiUrl, webClient);
     }
 
     return resourceProvider;

--- a/src/main/java/org/folio/edge/sip2/modules/FolioResourceProviderModule.java
+++ b/src/main/java/org/folio/edge/sip2/modules/FolioResourceProviderModule.java
@@ -2,7 +2,7 @@ package org.folio.edge.sip2.modules;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.name.Names;
-import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
 
 /**
  * Module for creating a {@code FolioResourceProvider} via Dependency injection.
@@ -12,21 +12,21 @@ import io.vertx.core.Vertx;
  */
 public class FolioResourceProviderModule extends AbstractModule {
   private final String okapiUrl;
-  private final Vertx vertx;
+  private final WebClient webClient;
 
   /**
    * Build a module for dependency injection.
    * @param okapiUrl the okapi url
-   * @param vertx the instance of vertx
+   * @param webClient the instance of WebClient
    */
-  public FolioResourceProviderModule(String okapiUrl, Vertx vertx) {
+  public FolioResourceProviderModule(String okapiUrl, WebClient webClient) {
     this.okapiUrl = okapiUrl;
-    this.vertx = vertx;
+    this.webClient = webClient;
   }
 
   @Override
   protected void configure() {
     bind(String.class).annotatedWith(Names.named("okapiUrl")).toInstance(okapiUrl);
-    bind(Vertx.class).annotatedWith(Names.named("vertx")).toInstance(vertx);
+    bind(WebClient.class).annotatedWith(Names.named("webClient")).toInstance(webClient);
   }
 }

--- a/src/main/java/org/folio/edge/sip2/parser/Parser.java
+++ b/src/main/java/org/folio/edge/sip2/parser/Parser.java
@@ -289,7 +289,7 @@ public final class Parser {
       return this;
     }
 
-    public ParserBuilder errorDetectionEnaled(Boolean errorDetectionEnabled) {
+    public ParserBuilder errorDetectionEnabled(Boolean errorDetectionEnabled) {
       this.errorDetectionEnabled = errorDetectionEnabled;
       return this;
     }

--- a/src/test/java/org/folio/edge/sip2/handlers/CheckinHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/CheckinHandlerTests.java
@@ -67,7 +67,7 @@ public class CheckinHandlerTests {
 
     final SessionData sessionData = TestUtils.getMockedSessionData();
 
-    handler.execute(checkin, sessionData).setHandler(
+    handler.execute(checkin, sessionData).onComplete(
         testContext.succeeding(sipMessage -> testContext.verify(() -> {
           final String expectedString = "101YUN"
               + TestUtils.getFormattedLocalDateTime(OffsetDateTime.now(clock))
@@ -118,7 +118,7 @@ public class CheckinHandlerTests {
 
     final SessionData sessionData = TestUtils.getMockedSessionData();
 
-    handler.execute(checkin, sessionData).setHandler(
+    handler.execute(checkin, sessionData).onComplete(
         testContext.succeeding(sipMessage -> testContext.verify(() -> {
           final String expectedString = "100YUN"
               + TestUtils.getFormattedLocalDateTime(OffsetDateTime.now(clock))

--- a/src/test/java/org/folio/edge/sip2/handlers/CheckoutHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/CheckoutHandlerTests.java
@@ -71,7 +71,7 @@ public class CheckoutHandlerTests {
 
     final SessionData sessionData = TestUtils.getMockedSessionData();
 
-    handler.execute(checkout, sessionData).setHandler(
+    handler.execute(checkout, sessionData).onComplete(
         testContext.succeeding(sipMessage -> testContext.verify(() -> {
           final String expectedString = "121NUY"
               + TestUtils.getFormattedLocalDateTime(OffsetDateTime.now(clock))
@@ -130,7 +130,7 @@ public class CheckoutHandlerTests {
 
     final SessionData sessionData = TestUtils.getMockedSessionData();
 
-    handler.execute(checkout, sessionData).setHandler(
+    handler.execute(checkout, sessionData).onComplete(
         testContext.succeeding(sipMessage -> testContext.verify(() -> {
           final String expectedString = "120NUN"
               + TestUtils.getFormattedLocalDateTime(OffsetDateTime.now(clock))

--- a/src/test/java/org/folio/edge/sip2/handlers/EndPatronSessionHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/EndPatronSessionHandlerTests.java
@@ -66,7 +66,7 @@ public class EndPatronSessionHandlerTests {
     sessionData.setUsername("JoeSmith");
     sessionData.setAuthenticationToken("abcdefghijklmnop");
 
-    handler.execute(endPatronSessionRequest, sessionData).setHandler(
+    handler.execute(endPatronSessionRequest, sessionData).onComplete(
         testContext.succeeding(sipMessage -> testContext.verify(() -> {
           final String expectedString = "36Y"
               + OffsetDateTime.now(clock).format(DateTimeFormatter.ofPattern("yyyyMMdd    HHmmss"))
@@ -123,7 +123,7 @@ public class EndPatronSessionHandlerTests {
     sessionData.setAuthenticationToken("abcdefghijklmnop");
     sessionData.setPatronPasswordVerificationRequired(true);
 
-    handler.execute(endPatronSessionRequest, sessionData).setHandler(
+    handler.execute(endPatronSessionRequest, sessionData).onComplete(
         testContext.succeeding(sipMessage -> testContext.verify(() -> {
           final String expectedString = "36N"
               + OffsetDateTime.now(clock).format(DateTimeFormatter.ofPattern("yyyyMMdd    HHmmss"))

--- a/src/test/java/org/folio/edge/sip2/handlers/HandlersFactoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/HandlersFactoryTests.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import freemarker.template.Template;
 import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.handlers.freemarker.FreemarkerRepository;
 import org.folio.edge.sip2.parser.Command;
@@ -15,10 +16,12 @@ import org.folio.edge.sip2.repositories.IResourceProvider;
 import org.junit.jupiter.api.Test;
 
 public class HandlersFactoryTests {
+  private WebClient webClient = WebClient.create(Vertx.vertx());
+
   @Test
   public void canGetAcsStatusHandlerWithNullArguments() {
     ISip2RequestHandler acsStatusHandler = HandlersFactory
-        .getScStatusHandlerInstance(null, null, null, null, "http://abcdefg.com", Vertx.vertx());
+        .getScStatusHandlerInstance(null, null, null, null, "http://abcdefg.com", webClient);
     assertNotNull(acsStatusHandler);
     assertTrue(acsStatusHandler instanceof SCStatusHandler);
   }
@@ -34,7 +37,7 @@ public class HandlersFactoryTests {
 
     ISip2RequestHandler acsStatusHandler = HandlersFactory
         .getScStatusHandlerInstance(configRepo, resourceProvider,
-            freemarkerTemplate, null, "abcdefg", Vertx.vertx());
+            freemarkerTemplate, null, "abcdefg", webClient);
     assertNotNull(acsStatusHandler);
     assertTrue(acsStatusHandler instanceof SCStatusHandler);
   }

--- a/src/test/java/org/folio/edge/sip2/handlers/LoginHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/LoginHandlerTests.java
@@ -48,7 +48,7 @@ public class LoginHandlerTests {
 
     final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
 
-    handler.execute(login, sessionData).setHandler(
+    handler.execute(login, sessionData).onComplete(
         testContext.succeeding(sipMessage -> testContext.verify(() -> {
           final String expectedString = "941";
 
@@ -79,7 +79,7 @@ public class LoginHandlerTests {
 
     final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
 
-    handler.execute(login, sessionData).setHandler(
+    handler.execute(login, sessionData).onComplete(
         testContext.succeeding(sipMessage -> testContext.verify(() -> {
           final String expectedString = "940";
 

--- a/src/test/java/org/folio/edge/sip2/handlers/PatronInformationHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/PatronInformationHandlerTests.java
@@ -102,7 +102,7 @@ public class PatronInformationHandlerTests {
 
     final SessionData sessionData = TestUtils.getMockedSessionData();
 
-    handler.execute(patronInformation, sessionData).setHandler(
+    handler.execute(patronInformation, sessionData).onComplete(
         testContext.succeeding(sipMessage -> testContext.verify(() -> {
           final String expectedString = "64              001"
               + TestUtils.getFormattedLocalDateTime(OffsetDateTime.now(clock).plusSeconds(5))

--- a/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/SCStatusHandlerTests.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.time.Clock;
@@ -38,12 +39,12 @@ public class SCStatusHandlerTests {
 
     SCStatusHandler handler = ((SCStatusHandler) HandlersFactory
         .getScStatusHandlerInstance(null, defaultConfigurationProvider, null,
-          clock, "abcdefg.com", vertx));
+          clock, "abcdefg.com", WebClient.create(vertx)));
 
     SessionData sessionData = TestUtils.getMockedSessionData();
     sessionData.setScLocation("TL01");
 
-    handler.execute(getMockedSCStatusMessage(), sessionData).setHandler(
+    handler.execute(getMockedSCStatusMessage(), sessionData).onComplete(
         testContext.succeeding(sipMessage -> testContext.verify(() -> {
           // Because the sipMessage has a dateTime component that's supposed
           // to be current, we can't assert on the entirety of the string,
@@ -73,12 +74,12 @@ public class SCStatusHandlerTests {
 
     SCStatusHandler handler = ((SCStatusHandler) HandlersFactory
         .getScStatusHandlerInstance(null, defaultConfigurationProvider, null,
-            clock, "abcdefg.com", vertx));
+            clock, "abcdefg.com", WebClient.create(vertx)));
 
     SessionData sessionData = TestUtils.getMockedSessionData();
     sessionData.setScLocation("TL01");
 
-    handler.execute(getMockedSCStatusMessage(), sessionData).setHandler(
+    handler.execute(getMockedSCStatusMessage(), sessionData).onComplete(
         testContext.succeeding(sipMessage -> testContext.verify(() -> {
           // Because the sipMessage has a dateTime component that's supposed
           // to be current, we can't assert on the entirety of the string,
@@ -109,7 +110,7 @@ public class SCStatusHandlerTests {
     SCStatusHandler handler = new SCStatusHandler(configurationRepository, null);
 
     handler.execute(getMockedSCStatusMessage(),
-                    TestUtils.getMockedSessionData()).setHandler(
+                    TestUtils.getMockedSessionData()).onComplete(
         testContext.failing(throwable -> testContext.verify(() -> {
           assertEquals("", throwable.getMessage());
           testContext.completeNow();
@@ -129,7 +130,7 @@ public class SCStatusHandlerTests {
     SCStatusHandler handler = new SCStatusHandler(configurationRepository, null);
 
     handler.execute(getMockedSCStatusMessage(),
-                    TestUtils.getMockedSessionData()).setHandler(
+                    TestUtils.getMockedSessionData()).onComplete(
         testContext.failing(throwable -> testContext.verify(() -> {
           assertEquals("Unable to find all necessary configuration(s). Found 2 of 3",
               throwable.getMessage());

--- a/src/test/java/org/folio/edge/sip2/parser/ParserTests.java
+++ b/src/test/java/org/folio/edge/sip2/parser/ParserTests.java
@@ -98,7 +98,7 @@ class ParserTests {
 
   @Test
   void testLoginParsingWithErrorDetection() {
-    final Parser parser = Parser.builder().errorDetectionEnaled(TRUE).build();
+    final Parser parser = Parser.builder().errorDetectionEnabled(TRUE).build();
     final Message<?> message = parser.parseMessage(
         "9300CNuser_id|COpassw0rd|AY1AZF594");
 
@@ -116,7 +116,7 @@ class ParserTests {
 
   @Test
   void testLoginParsingWithErrorDetectionAndBadChecksum() {
-    final Parser parser = Parser.builder().errorDetectionEnaled(TRUE).build();
+    final Parser parser = Parser.builder().errorDetectionEnabled(TRUE).build();
     final Message<?> message = parser.parseMessage(
         "9300CNuser_id|COpassw0rd|AY1AZF595");
 
@@ -717,7 +717,7 @@ class ParserTests {
   @Test
   void testRenewAllParsingWithErrorDetection() {
     final Parser parser = Parser.builder()
-        .errorDetectionEnaled(TRUE)
+        .errorDetectionEnabled(TRUE)
         .timezone(TestUtils.UTCTimeZone)
         .build();
     final OffsetDateTime transactionDate =
@@ -747,7 +747,7 @@ class ParserTests {
 
   @Test
   void testRenewAllParsingWithErrorDetectionAndKnownSequenceNumber() {
-    final Parser parser = Parser.builder().errorDetectionEnaled(TRUE).build();
+    final Parser parser = Parser.builder().errorDetectionEnabled(TRUE).build();
 
     final int sequenceNumber = 1;
     final OffsetDateTime transactionDate =

--- a/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
@@ -105,7 +105,7 @@ public class CirculationRepositoryTests {
 
     final CirculationRepository circulationRepository = new CirculationRepository(
         mockFolioProvider, mockPasswordVerifier, clock);
-    circulationRepository.performCheckinCommand(checkin, sessionData).setHandler(
+    circulationRepository.performCheckinCommand(checkin, sessionData).onComplete(
         testContext.succeeding(checkinResponse -> testContext.verify(() -> {
           assertNotNull(checkinResponse);
           assertTrue(checkinResponse.getOk());
@@ -161,7 +161,7 @@ public class CirculationRepositoryTests {
 
     final CirculationRepository circulationRepository = new CirculationRepository(
         mockFolioProvider, mockPasswordVerifier, clock);
-    circulationRepository.performCheckinCommand(checkin, sessionData).setHandler(
+    circulationRepository.performCheckinCommand(checkin, sessionData).onComplete(
         testContext.succeeding(checkinResponse -> testContext.verify(() -> {
           assertNotNull(checkinResponse);
           assertTrue(checkinResponse.getOk());
@@ -212,7 +212,7 @@ public class CirculationRepositoryTests {
 
     final CirculationRepository circulationRepository = new CirculationRepository(
         mockFolioProvider, mockPasswordVerifier, clock);
-    circulationRepository.performCheckinCommand(checkin, sessionData).setHandler(
+    circulationRepository.performCheckinCommand(checkin, sessionData).onComplete(
         testContext.succeeding(checkinResponse -> testContext.verify(() -> {
           assertNotNull(checkinResponse);
           assertFalse(checkinResponse.getOk());
@@ -274,7 +274,7 @@ public class CirculationRepositoryTests {
 
     final CirculationRepository circulationRepository = new CirculationRepository(
         mockFolioProvider, mockPasswordVerifier, clock);
-    circulationRepository.performCheckoutCommand(checkout, sessionData).setHandler(
+    circulationRepository.performCheckoutCommand(checkout, sessionData).onComplete(
         testContext.succeeding(checkoutResponse -> testContext.verify(() -> {
           assertNotNull(checkoutResponse);
           assertTrue(checkoutResponse.getOk());
@@ -346,7 +346,7 @@ public class CirculationRepositoryTests {
 
     final CirculationRepository circulationRepository = new CirculationRepository(
         mockFolioProvider, mockPasswordVerifier, clock);
-    circulationRepository.performCheckoutCommand(checkout, sessionData).setHandler(
+    circulationRepository.performCheckoutCommand(checkout, sessionData).onComplete(
         testContext.succeeding(checkoutResponse -> testContext.verify(() -> {
           assertNotNull(checkoutResponse);
           assertTrue(checkoutResponse.getOk());
@@ -409,7 +409,7 @@ public class CirculationRepositoryTests {
 
     final CirculationRepository circulationRepository = new CirculationRepository(
         mockFolioProvider, mockPasswordVerifier, clock);
-    circulationRepository.performCheckoutCommand(checkout, sessionData).setHandler(
+    circulationRepository.performCheckoutCommand(checkout, sessionData).onComplete(
         testContext.succeeding(checkoutResponse -> testContext.verify(() -> {
           assertNotNull(checkoutResponse);
           assertFalse(checkoutResponse.getOk());
@@ -492,7 +492,7 @@ public class CirculationRepositoryTests {
 
     final CirculationRepository circulationRepository = new CirculationRepository(
         mockFolioProvider, mockPasswordVerifier, clock);
-    circulationRepository.performCheckoutCommand(checkout, sessionData).setHandler(
+    circulationRepository.performCheckoutCommand(checkout, sessionData).onComplete(
         testContext.succeeding(checkoutResponse -> testContext.verify(() -> {
           assertNotNull(checkoutResponse);
           assertFalse(checkoutResponse.getOk());
@@ -549,7 +549,7 @@ public class CirculationRepositoryTests {
 
     final CirculationRepository circulationRepository = new CirculationRepository(
         mockFolioProvider, mockPasswordVerifier, clock);
-    circulationRepository.getLoansByUserId(userId, null, null, sessionData).setHandler(
+    circulationRepository.getLoansByUserId(userId, null, null, sessionData).onComplete(
         testContext.succeeding(loansResponse -> testContext.verify(() -> {
           assertNotNull(loansResponse);
           assertEquals(1, loansResponse.getInteger("totalRecords"));
@@ -579,7 +579,7 @@ public class CirculationRepositoryTests {
 
     final CirculationRepository circulationRepository = new CirculationRepository(
         mockFolioProvider, mockPasswordVerifier, clock);
-    circulationRepository.getLoansByUserId(userId, null, null, sessionData).setHandler(
+    circulationRepository.getLoansByUserId(userId, null, null, sessionData).onComplete(
         testContext.succeeding(loansResponse -> testContext.verify(() -> {
           assertNull(loansResponse);
 
@@ -620,7 +620,7 @@ public class CirculationRepositoryTests {
     final CirculationRepository circulationRepository = new CirculationRepository(
         mockFolioProvider, mockPasswordVerifier, clock);
     circulationRepository.getOverdueLoansByUserId(userId, OffsetDateTime.now(clock), null, null,
-        sessionData).setHandler(testContext.succeeding(loansResponse -> testContext.verify(() -> {
+        sessionData).onComplete(testContext.succeeding(loansResponse -> testContext.verify(() -> {
           assertNotNull(loansResponse);
           assertEquals(1, loansResponse.getInteger("totalRecords"));
           final JsonArray loans = loansResponse.getJsonArray("loans");
@@ -651,7 +651,7 @@ public class CirculationRepositoryTests {
     final CirculationRepository circulationRepository = new CirculationRepository(
         mockFolioProvider, mockPasswordVerifier, clock);
     circulationRepository.getOverdueLoansByUserId(userId, OffsetDateTime.now(clock), null, null,
-        sessionData).setHandler(testContext.succeeding(loansResponse -> testContext.verify(() -> {
+        sessionData).onComplete(testContext.succeeding(loansResponse -> testContext.verify(() -> {
           assertNull(loansResponse);
 
           testContext.completeNow();
@@ -691,7 +691,7 @@ public class CirculationRepositoryTests {
     final CirculationRepository circulationRepository = new CirculationRepository(
         mockFolioProvider, mockPasswordVerifier, clock);
     circulationRepository.getRequestsByItemId(itemId, "Recall", null, null, sessionData)
-        .setHandler(testContext.succeeding(requestsResponse -> testContext.verify(() -> {
+        .onComplete(testContext.succeeding(requestsResponse -> testContext.verify(() -> {
           assertNotNull(requestsResponse);
           assertEquals(1, requestsResponse.getInteger("totalRecords"));
           final JsonArray requests = requestsResponse.getJsonArray("requests");
@@ -721,7 +721,7 @@ public class CirculationRepositoryTests {
     final CirculationRepository circulationRepository = new CirculationRepository(
         mockFolioProvider, mockPasswordVerifier, clock);
     circulationRepository.getRequestsByItemId(itemId, "Recall", null, null,
-        sessionData).setHandler(testContext.succeeding(
+        sessionData).onComplete(testContext.succeeding(
             requestsResponse -> testContext.verify(() -> {
               assertNull(requestsResponse);
 
@@ -756,7 +756,7 @@ public class CirculationRepositoryTests {
     final CirculationRepository circulationRepository = new CirculationRepository(
         mockFolioProvider, mockPasswordVerifier, clock);
     circulationRepository.getRequestsByItemId(itemId, "Hold", null, null, sessionData)
-        .setHandler(testContext.succeeding(requestsResponse -> testContext.verify(() -> {
+        .onComplete(testContext.succeeding(requestsResponse -> testContext.verify(() -> {
           assertNotNull(requestsResponse);
           assertEquals(1, requestsResponse.getInteger("totalRecords"));
           final JsonArray requests = requestsResponse.getJsonArray("requests");
@@ -786,7 +786,7 @@ public class CirculationRepositoryTests {
     final CirculationRepository circulationRepository = new CirculationRepository(
         mockFolioProvider, mockPasswordVerifier, clock);
     circulationRepository.getRequestsByItemId(userId, "Hold", null, null,
-        sessionData).setHandler(testContext.succeeding(
+        sessionData).onComplete(testContext.succeeding(
             requestsResponse -> testContext.verify(() -> {
               assertNull(requestsResponse);
 

--- a/src/test/java/org/folio/edge/sip2/repositories/ConfigurationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/ConfigurationRepositoryTests.java
@@ -92,7 +92,7 @@ public class ConfigurationRepositoryTests {
     SessionData sessionData = TestUtils.getMockedSessionData();
     sessionData.setScLocation("SE10");
 
-    configurationRepository.getACSStatus(sessionData).setHandler(
+    configurationRepository.getACSStatus(sessionData).onComplete(
         testContext.succeeding(status -> testContext.verify(() -> {
 
           assertNotNull(status);
@@ -139,7 +139,7 @@ public class ConfigurationRepositoryTests {
     ConfigurationRepository configRepo = new ConfigurationRepository(resourceProvider, clock);
 
     configRepo.retrieveConfigurations(TestUtils.getMockedSessionData(),
-        configParamsList).setHandler(
+        configParamsList).onComplete(
           testContext.succeeding(testTenantConfig -> testContext.verify(() -> {
             assertNotNull(testTenantConfig);
 

--- a/src/test/java/org/folio/edge/sip2/repositories/DefaultResourceProviderTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/DefaultResourceProviderTests.java
@@ -36,7 +36,7 @@ public class DefaultResourceProviderTests {
 
     DefaultResourceProvider defaultConfigurationProvider =
         new DefaultResourceProvider(DEFAULT_CONFIGURATION_FILE);
-    defaultConfigurationProvider.retrieveResource(mockRequestData).setHandler(
+    defaultConfigurationProvider.retrieveResource(mockRequestData).onComplete(
         testContext.succeeding(resource -> testContext.verify(() -> {
           final JsonObject jsonConfig = resource.getResource();
           assertNotNull(jsonConfig);
@@ -64,7 +64,7 @@ public class DefaultResourceProviderTests {
 
     DefaultResourceProvider defaultConfigurationProvider =
         new DefaultResourceProvider(DEFAULT_CONFIGURATION_FILE);
-    defaultConfigurationProvider.retrieveResource(mockRequestData).setHandler(
+    defaultConfigurationProvider.retrieveResource(mockRequestData).onComplete(
         testContext.succeeding(resource -> testContext.verify(() -> {
           final JsonObject jsonConfig = resource.getResource();
           assertNotNull(jsonConfig);

--- a/src/test/java/org/folio/edge/sip2/repositories/FeeFinesRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/FeeFinesRepositoryTests.java
@@ -66,7 +66,7 @@ public class FeeFinesRepositoryTests {
 
     final FeeFinesRepository feeFinesRepository = new FeeFinesRepository(mockFolioProvider);
     feeFinesRepository.getManualBlocksByUserId(UUID.randomUUID().toString(),
-        sessionData).setHandler(
+        sessionData).onComplete(
             testContext.succeeding(manualBlocks -> testContext.verify(() -> {
               assertNotNull(manualBlocks);
               assertNotNull(manualBlocks.getJsonArray(FIELD_MANUALBLOCKS));
@@ -88,7 +88,7 @@ public class FeeFinesRepositoryTests {
 
     final FeeFinesRepository feeFinesRepository = new FeeFinesRepository(mockFolioProvider);
     feeFinesRepository.getManualBlocksByUserId(UUID.randomUUID().toString(),
-        sessionData).setHandler(
+        sessionData).onComplete(
             testContext.succeeding(manualBlocks -> testContext.verify(() -> {
               assertNull(manualBlocks);
 
@@ -114,7 +114,7 @@ public class FeeFinesRepositoryTests {
     final SessionData sessionData = TestUtils.getMockedSessionData();
 
     final FeeFinesRepository feeFinesRepository = new FeeFinesRepository(mockFolioProvider);
-    feeFinesRepository.getManualBlocksByUserId(userId, sessionData).setHandler(
+    feeFinesRepository.getManualBlocksByUserId(userId, sessionData).onComplete(
         testContext.succeeding(manualBlocks -> testContext.verify(() -> {
           assertNotNull(manualBlocks);
           assertEquals(1, manualBlocks.getInteger(FIELD_TOTAL_RECORDS));

--- a/src/test/java/org/folio/edge/sip2/repositories/LoginRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/LoginRepositoryTests.java
@@ -66,7 +66,7 @@ public class LoginRepositoryTests {
     final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
 
     final LoginRepository loginRepository = new LoginRepository(mockFolioProvider);
-    loginRepository.login(login, sessionData).setHandler(
+    loginRepository.login(login, sessionData).onComplete(
         testContext.succeeding(loginResponse -> testContext.verify(() -> {
           assertNotNull(loginResponse);
           assertTrue(loginResponse.getOk());
@@ -93,7 +93,7 @@ public class LoginRepositoryTests {
     final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
 
     final LoginRepository loginRepository = new LoginRepository(mockFolioProvider);
-    loginRepository.login(login, sessionData).setHandler(
+    loginRepository.login(login, sessionData).onComplete(
         testContext.succeeding(loginResponse -> testContext.verify(() -> {
           assertNotNull(loginResponse);
           assertFalse(loginResponse.getOk());
@@ -116,7 +116,7 @@ public class LoginRepositoryTests {
     final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
 
     final LoginRepository loginRepository = new LoginRepository(mockFolioProvider);
-    loginRepository.patronLogin(username, password, sessionData).setHandler(
+    loginRepository.patronLogin(username, password, sessionData).onComplete(
         testContext.succeeding(loginResponse -> testContext.verify(() -> {
           assertNotNull(loginResponse);
           assertNotNull(loginResponse.getResource());
@@ -138,7 +138,7 @@ public class LoginRepositoryTests {
     final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
 
     final LoginRepository loginRepository = new LoginRepository(mockFolioProvider);
-    loginRepository.patronLogin(username, password, sessionData).setHandler(
+    loginRepository.patronLogin(username, password, sessionData).onComplete(
         testContext.succeeding(loginResponse -> testContext.verify(() -> {
           assertNotNull(loginResponse);
           assertNull(loginResponse.getResource());

--- a/src/test/java/org/folio/edge/sip2/repositories/PasswordVerifierTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/PasswordVerifierTests.java
@@ -49,7 +49,7 @@ class PasswordVerifierTests {
 
     final PasswordVerifier passwordVerifier = new PasswordVerifier(mockUsersRepository,
         mockLoginRepository);
-    passwordVerifier.verifyPatronPassword(patronIdentifier, "0989", sessionData).setHandler(
+    passwordVerifier.verifyPatronPassword(patronIdentifier, "0989", sessionData).onComplete(
         testContext.succeeding(verification -> testContext.verify(() -> {
           assertNotNull(verification);
           assertEquals("997383903573496", verification.getUser().getBarcode());
@@ -77,7 +77,7 @@ class PasswordVerifierTests {
 
     final PasswordVerifier passwordVerifier = new PasswordVerifier(mockUsersRepository,
         mockLoginRepository);
-    passwordVerifier.verifyPatronPassword(patronIdentifier, "0989", sessionData).setHandler(
+    passwordVerifier.verifyPatronPassword(patronIdentifier, "0989", sessionData).onComplete(
         testContext.succeeding(verification -> testContext.verify(() -> {
           assertNotNull(verification);
           assertNull(verification.getUser());
@@ -113,7 +113,7 @@ class PasswordVerifierTests {
 
     final PasswordVerifier passwordVerifier = new PasswordVerifier(mockUsersRepository,
         mockLoginRepository);
-    passwordVerifier.verifyPatronPassword(patronIdentifier, "0989", sessionData).setHandler(
+    passwordVerifier.verifyPatronPassword(patronIdentifier, "0989", sessionData).onComplete(
         testContext.succeeding(verification -> testContext.verify(() -> {
           assertNotNull(verification);
           assertEquals("997383903573496", verification.getUser().getBarcode());
@@ -143,7 +143,7 @@ class PasswordVerifierTests {
 
     final PasswordVerifier passwordVerifier = new PasswordVerifier(mockUsersRepository,
         mockLoginRepository);
-    passwordVerifier.verifyPatronPassword(patronIdentifier,"0989", sessionData).setHandler(
+    passwordVerifier.verifyPatronPassword(patronIdentifier,"0989", sessionData).onComplete(
         testContext.succeeding(verification -> testContext.verify(() -> {
           assertNotNull(verification);
           assertNotNull(verification.getUser());
@@ -167,7 +167,7 @@ class PasswordVerifierTests {
         .thenReturn(Future.succeededFuture(null));
     final PasswordVerifier passwordVerifier = new PasswordVerifier(mockUsersRepository,
         mockLoginRepository);
-    passwordVerifier.verifyPatronPassword(patronIdentifier, "0989", sessionData).setHandler(
+    passwordVerifier.verifyPatronPassword(patronIdentifier, "0989", sessionData).onComplete(
         testContext.succeeding(verification -> testContext.verify(() -> {
           assertNotNull(verification);
           assertNull(verification.getUser());

--- a/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
@@ -175,7 +175,7 @@ public class PatronRepositoryTests {
 
     final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
         mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
-    patronRepository.performPatronInformationCommand(patronInformation, sessionData).setHandler(
+    patronRepository.performPatronInformationCommand(patronInformation, sessionData).onComplete(
         testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
           assertNotNull(patronInformationResponse);
           assertNotNull(patronInformationResponse.getPatronStatus());
@@ -278,7 +278,7 @@ public class PatronRepositoryTests {
 
     final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
         mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
-    patronRepository.performPatronInformationCommand(patronInformation, sessionData).setHandler(
+    patronRepository.performPatronInformationCommand(patronInformation, sessionData).onComplete(
         testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
           assertNotNull(patronInformationResponse);
           assertNotNull(patronInformationResponse.getPatronStatus());
@@ -381,7 +381,7 @@ public class PatronRepositoryTests {
 
     final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
         mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
-    patronRepository.performPatronInformationCommand(patronInformation, sessionData).setHandler(
+    patronRepository.performPatronInformationCommand(patronInformation, sessionData).onComplete(
         testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
           assertNotNull(patronInformationResponse);
           assertNotNull(patronInformationResponse.getPatronStatus());
@@ -485,7 +485,7 @@ public class PatronRepositoryTests {
 
     final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
         mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
-    patronRepository.performPatronInformationCommand(patronInformation, sessionData).setHandler(
+    patronRepository.performPatronInformationCommand(patronInformation, sessionData).onComplete(
         testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
           assertNotNull(patronInformationResponse);
           assertNotNull(patronInformationResponse.getPatronStatus());
@@ -615,7 +615,7 @@ public class PatronRepositoryTests {
 
     final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
         mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
-    patronRepository.performPatronInformationCommand(patronInformation, sessionData).setHandler(
+    patronRepository.performPatronInformationCommand(patronInformation, sessionData).onComplete(
         testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
           assertNotNull(patronInformationResponse);
           assertNotNull(patronInformationResponse.getPatronStatus());
@@ -726,7 +726,7 @@ public class PatronRepositoryTests {
 
     final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
         mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
-    patronRepository.performPatronInformationCommand(patronInformation, sessionData).setHandler(
+    patronRepository.performPatronInformationCommand(patronInformation, sessionData).onComplete(
         testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
           assertNotNull(patronInformationResponse);
           assertNotNull(patronInformationResponse.getPatronStatus());
@@ -800,7 +800,7 @@ public class PatronRepositoryTests {
 
     final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
         mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
-    patronRepository.performPatronInformationCommand(patronInformation, sessionData).setHandler(
+    patronRepository.performPatronInformationCommand(patronInformation, sessionData).onComplete(
         testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
           assertNotNull(patronInformationResponse);
           assertEquals(EnumSet.allOf(PatronStatus.class),
@@ -873,7 +873,7 @@ public class PatronRepositoryTests {
 
     final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
         mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
-    patronRepository.performPatronInformationCommand(patronInformation, sessionData).setHandler(
+    patronRepository.performPatronInformationCommand(patronInformation, sessionData).onComplete(
         testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
           assertNotNull(patronInformationResponse);
           assertEquals(EnumSet.allOf(PatronStatus.class),
@@ -946,7 +946,7 @@ public class PatronRepositoryTests {
 
     final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
         mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
-    patronRepository.performPatronInformationCommand(patronInformation, sessionData).setHandler(
+    patronRepository.performPatronInformationCommand(patronInformation, sessionData).onComplete(
         testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
           assertNotNull(patronInformationResponse);
           assertEquals(EnumSet.allOf(PatronStatus.class),
@@ -1032,7 +1032,7 @@ public class PatronRepositoryTests {
 
     final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
         mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
-    patronRepository.performPatronInformationCommand(patronInformation, sessionData).setHandler(
+    patronRepository.performPatronInformationCommand(patronInformation, sessionData).onComplete(
         testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
           assertNotNull(patronInformationResponse);
           assertEquals(EnumSet.noneOf(PatronStatus.class),
@@ -1124,7 +1124,7 @@ public class PatronRepositoryTests {
 
     final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
         mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
-    patronRepository.performPatronInformationCommand(patronInformation, sessionData).setHandler(
+    patronRepository.performPatronInformationCommand(patronInformation, sessionData).onComplete(
         testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
           assertNotNull(patronInformationResponse);
           assertEquals(EnumSet.noneOf(PatronStatus.class),
@@ -1212,7 +1212,7 @@ public class PatronRepositoryTests {
 
     final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
         mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
-    patronRepository.performPatronInformationCommand(patronInformation, sessionData).setHandler(
+    patronRepository.performPatronInformationCommand(patronInformation, sessionData).onComplete(
         testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
           assertNotNull(patronInformationResponse);
           assertEquals(expectedPatronStatus,
@@ -1282,7 +1282,7 @@ public class PatronRepositoryTests {
 
     final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
         mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
-    patronRepository.performEndPatronSessionCommand(endPatronSession, sessionData).setHandler(
+    patronRepository.performEndPatronSessionCommand(endPatronSession, sessionData).onComplete(
         testContext.succeeding(endSessionResponse -> testContext.verify(() -> {
           assertNotNull(endSessionResponse);
           assertTrue(endSessionResponse.getEndSession());
@@ -1323,7 +1323,7 @@ public class PatronRepositoryTests {
 
     final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
         mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
-    patronRepository.performEndPatronSessionCommand(endPatronSession, sessionData).setHandler(
+    patronRepository.performEndPatronSessionCommand(endPatronSession, sessionData).onComplete(
         testContext.succeeding(endSessionResponse -> testContext.verify(() -> {
           assertNotNull(endSessionResponse);
           assertTrue(endSessionResponse.getEndSession());
@@ -1367,7 +1367,7 @@ public class PatronRepositoryTests {
 
     final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
         mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
-    patronRepository.performEndPatronSessionCommand(endPatronSession, sessionData).setHandler(
+    patronRepository.performEndPatronSessionCommand(endPatronSession, sessionData).onComplete(
         testContext.succeeding(endSessionResponse -> testContext.verify(() -> {
           assertNotNull(endSessionResponse);
           assertFalse(endSessionResponse.getEndSession());

--- a/src/test/java/org/folio/edge/sip2/repositories/UsersRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/UsersRepositoryTests.java
@@ -59,7 +59,7 @@ public class UsersRepositoryTests {
     final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
 
     final UsersRepository usersRepository = new UsersRepository(mockFolioProvider);
-    usersRepository.getUserById("997383903573496", sessionData).setHandler(
+    usersRepository.getUserById("997383903573496", sessionData).onComplete(
         testContext.succeeding(user -> testContext.verify(() -> {
           assertNotNull(user);
           assertEquals("997383903573496", user.getBarcode());
@@ -83,7 +83,7 @@ public class UsersRepositoryTests {
     final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
 
     final UsersRepository usersRepository = new UsersRepository(mockFolioProvider);
-    usersRepository.getUserById("leslie", sessionData).setHandler(
+    usersRepository.getUserById("leslie", sessionData).onComplete(
         testContext.succeeding(user -> testContext.verify(() -> {
           assertNotNull(user);
           assertEquals("leslie", user.getUsername());
@@ -120,7 +120,7 @@ public class UsersRepositoryTests {
     final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
 
     final UsersRepository usersRepository = new UsersRepository(mockFolioProvider);
-    usersRepository.getUserById(extSystemId, sessionData).setHandler(
+    usersRepository.getUserById(extSystemId, sessionData).onComplete(
         testContext.succeeding(user -> testContext.verify(() -> {
           assertNotNull(user);
           assertEquals(extSystemId, user.getExtSystemId());
@@ -139,7 +139,7 @@ public class UsersRepositoryTests {
     final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
 
     final UsersRepository usersRepository = new UsersRepository(mockFolioProvider);
-    usersRepository.getUserById("1234667", sessionData).setHandler(
+    usersRepository.getUserById("1234667", sessionData).onComplete(
         testContext.succeeding(user -> testContext.verify(() -> {
           assertNull(user);
 


### PR DESCRIPTION
Update Vert.x from 3.9.* to 4.2.5.

Replace Vertx by WebClient for better re-use enabling
HTTP pooling and HTTP pipe-lining.

Use existing methods for random port.