### PR TITLE
Sip2 115

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -22,6 +22,10 @@
     {
       "id": "feesfines",
       "version": "15.0 16.0 17.0"
+    },
+    {
+      "id": "search",
+      "version": "0.6"
     }
   ],
   "permissionSets": [],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -25,7 +25,7 @@
     },
     {
       "id": "search",
-      "version": "0.6"
+      "version": "0.7"
     }
   ],
   "permissionSets": [],

--- a/pom.xml
+++ b/pom.xml
@@ -356,24 +356,24 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.1</version>
-        <configuration>
-          <configLocation>checkstyle.xml</configLocation>
-          <linkXRef>false</linkXRef>
-          <violationSeverity>warning</violationSeverity>
-          <includeTestSourceDirectory>true</includeTestSourceDirectory>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+<!--      <plugin>-->
+<!--        <groupId>org.apache.maven.plugins</groupId>-->
+<!--        <artifactId>maven-checkstyle-plugin</artifactId>-->
+<!--        <version>3.1.1</version>-->
+<!--        <configuration>-->
+<!--          <configLocation>checkstyle.xml</configLocation>-->
+<!--          <linkXRef>false</linkXRef>-->
+<!--          <violationSeverity>warning</violationSeverity>-->
+<!--          <includeTestSourceDirectory>true</includeTestSourceDirectory>-->
+<!--        </configuration>-->
+<!--        <executions>-->
+<!--          <execution>-->
+<!--            <goals>-->
+<!--              <goal>check</goal>-->
+<!--            </goals>-->
+<!--          </execution>-->
+<!--        </executions>-->
+<!--      </plugin>-->
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -356,24 +356,6 @@
           </execution>
         </executions>
       </plugin>
-<!--      <plugin>-->
-<!--        <groupId>org.apache.maven.plugins</groupId>-->
-<!--        <artifactId>maven-checkstyle-plugin</artifactId>-->
-<!--        <version>3.1.1</version>-->
-<!--        <configuration>-->
-<!--          <configLocation>checkstyle.xml</configLocation>-->
-<!--          <linkXRef>false</linkXRef>-->
-<!--          <violationSeverity>warning</violationSeverity>-->
-<!--          <includeTestSourceDirectory>true</includeTestSourceDirectory>-->
-<!--        </configuration>-->
-<!--        <executions>-->
-<!--          <execution>-->
-<!--            <goals>-->
-<!--              <goal>check</goal>-->
-<!--            </goals>-->
-<!--          </execution>-->
-<!--        </executions>-->
-<!--      </plugin>-->
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,24 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>3.1.1</version>
+        <configuration>
+          <configLocation>checkstyle.xml</configLocation>
+          <linkXRef>false</linkXRef>
+          <violationSeverity>warning</violationSeverity>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>com.coderplus.maven.plugins</groupId>
         <artifactId>copy-rename-maven-plugin</artifactId>
         <version>1.0</version>

--- a/src/main/java/org/folio/edge/sip2/handlers/ISip2RequestHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/ISip2RequestHandler.java
@@ -22,7 +22,9 @@ public interface ISip2RequestHandler {
    */
   default void writeHistory(SessionData sessionData, Message<Object> request, String response) {
     /* added one check in default method as none of the implementation implementing it */
-    if(request!=null && (request.getSequenceNumber()!=null && request.getChecksumsString()!=null) )
-    sessionData.setPreviousMessage(new PreviousMessage(request, response));
+    if ((request != null) &&
+      (request.getSequenceNumber() != null) && request.getChecksumsString() != null) {
+      sessionData.setPreviousMessage(new PreviousMessage(request, response));
+    }
   }
 }

--- a/src/main/java/org/folio/edge/sip2/handlers/ISip2RequestHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/ISip2RequestHandler.java
@@ -22,8 +22,9 @@ public interface ISip2RequestHandler {
    */
   default void writeHistory(SessionData sessionData, Message<Object> request, String response) {
     /* added one check in default method as none of the implementation implementing it */
-    if ((request != null) &&
-      (request.getSequenceNumber() != null) && request.getChecksumsString() != null) {
+    if ((request != null)
+        && (request.getSequenceNumber() != null)
+        && request.getChecksumsString() != null) {
       sessionData.setPreviousMessage(new PreviousMessage(request, response));
     }
   }

--- a/src/main/java/org/folio/edge/sip2/handlers/ISip2RequestHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/ISip2RequestHandler.java
@@ -21,6 +21,8 @@ public interface ISip2RequestHandler {
    * @param response SIP response for the passed in request
    */
   default void writeHistory(SessionData sessionData, Message<Object> request, String response) {
+    /* added one check in default method as none of the implementation implementing it */
+    if(request!=null && (request.getSequenceNumber()!=null && request.getChecksumsString()!=null) )
     sessionData.setPreviousMessage(new PreviousMessage(request, response));
   }
 }

--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -39,6 +39,7 @@ public class CirculationRepository {
   // Should consider letting the template take care of required fields with missing values
   private static final String UNKNOWN = "";
   public static final String TITLE_NOT_FOUND = "TITLE NOT FOUND";
+  public static final String TITLE = "title";
   private final IResourceProvider<IRequestData> resourceProvider;
   private final PasswordVerifier passwordVerifier;
   private final Clock clock;
@@ -97,7 +98,7 @@ public class CirculationRepository {
               // this allows the kiosk to show something related to the item that could be used
               // by the patron to identify which item this checkin response applies to.
               .titleIdentifier(resource.getResource() == null ? itemIdentifier
-                  : getChildString(resource.getResource(), "item", "title", itemIdentifier))
+                  : getChildString(resource.getResource(), "item", TITLE, itemIdentifier))
               // this is probably not the permanent location
               // this might require a call to inventory
               .permanentLocation(
@@ -172,7 +173,7 @@ public class CirculationRepository {
               .patronIdentifier(patronIdentifier)
               .itemIdentifier(itemIdentifier)
               .titleIdentifier(response.map(
-                  v -> getChildString(v, "item", "title", UNKNOWN))
+                  v -> getChildString(v, "item", TITLE, UNKNOWN))
                 .orElse(resource.getTitle()))
               .dueDate(dueDate)
               .screenMessage(Optional.of(resource.getErrorMessages())
@@ -247,7 +248,7 @@ public class CirculationRepository {
     final String instances = "instances";
     JsonArray instanceArray = response.get().getJsonArray(instances);
     if (instanceArray.size() > 0) {
-      title = instanceArray.getJsonObject(0).getString("title");
+      title = instanceArray.getJsonObject(0).getString(TITLE);
       return getiResourceFromTitle(title, circErrorMessages);
     } else
       return getiResourceFromTitle(title, circErrorMessages);
@@ -515,7 +516,7 @@ public class CirculationRepository {
   }
 
   private class ItemRequestData extends SearchRequestData {
-    private final String basePath = "/search/instances?limit=1&query=";
+    private static final String basePath = "/search/instances?limit=1&query=";
 
     private String itemBarcode;
 
@@ -572,24 +573,6 @@ public class CirculationRepository {
       return sessionData;
     }
 
-    protected StringBuilder appendLimits(StringBuilder sb) {
-      final int offset;
-      if (startItem != null) {
-        offset = startItem.intValue() - 1; // expects a 1-based count, FOLIO is 0
-        sb.append("&offset=").append(offset);
-      } else {
-        offset = 0;
-      }
-
-      if (endItem != null) {
-        final int limit = endItem.intValue() - offset;
-        sb.append("&limit=").append(limit);
-      }
-
-      return sb;
-    }
   }
-
-  //end
 
 }

--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -12,7 +12,14 @@ import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import javax.inject.Inject;
 import org.folio.edge.sip2.domain.messages.requests.Checkin;
 import org.folio.edge.sip2.domain.messages.requests.Checkout;
@@ -507,7 +514,6 @@ public class CirculationRepository {
     }
   }
 
-  //SIP2 changes
   private class ItemRequestData extends SearchRequestData {
     private final String basePath = "/search/instances?limit=1&query=";
 

--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -12,11 +12,11 @@ import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -141,14 +141,14 @@ public class CirculationRepository {
 
         final User user = verification.getUser();
         final JsonObject body = new JsonObject()
-          .put("itemBarcode", itemIdentifier)
-          .put("userBarcode", user != null ? user.getBarcode() : patronIdentifier)
-          .put("servicePointId", sessionData.getScLocation());
+            .put("itemBarcode", itemIdentifier)
+            .put("userBarcode", user != null ? user.getBarcode() : patronIdentifier)
+            .put("servicePointId", sessionData.getScLocation());
 
         final Map<String, String> headers = getBaseHeaders();
 
         final CheckoutRequestData checkoutRequestData =
-          new CheckoutRequestData(body, headers, sessionData);
+            new CheckoutRequestData(body, headers, sessionData);
 
         final Future<IResource> result = resourceProvider.createResource(checkoutRequestData);
 
@@ -159,9 +159,9 @@ public class CirculationRepository {
             final Optional<JsonObject> response = Optional.ofNullable(resource.getResource());
 
             final OffsetDateTime dueDate = response
-              .map(v -> v.getString("dueDate"))
-              .map(v -> OffsetDateTime.from(Utils.getFolioDateTimeFormatter().parse(v)))
-              .orElse(OffsetDateTime.now(clock));
+                .map(v -> v.getString("dueDate"))
+                .map(v -> OffsetDateTime.from(Utils.getFolioDateTimeFormatter().parse(v)))
+                .orElse(OffsetDateTime.now(clock));
 
             return CheckoutResponse.builder()
               .ok(Boolean.valueOf(response.isPresent()))
@@ -209,8 +209,7 @@ public class CirculationRepository {
       @Override
       public List<String> getErrorMessages() {
         List<String> tempError = new ArrayList<>(circErrorMessages);
-        if(TITLE_NOT_FOUND.equals(title))
-        {
+        if (TITLE_NOT_FOUND.equals(title)) {
           tempError.add("Title Not Found");
           return tempError;
         }
@@ -220,11 +219,12 @@ public class CirculationRepository {
     return res;
   }
 
-  private Future<IResource> getTitle(String itemIdentifier, SessionData sessionData, List<String> circErrorMessages) {
+  private Future<IResource> getTitle(String itemIdentifier, SessionData sessionData,
+                                     List<String> circErrorMessages) {
 
     final Map<String, String> headers = getBaseHeaders();
     final ItemRequestData itemRequestData =
-      new ItemRequestData(null, headers, sessionData, itemIdentifier);
+        new ItemRequestData(null, headers, sessionData, itemIdentifier);
 
     final Future<IResource> result = resourceProvider.retrieveResource(itemRequestData);
 
@@ -235,8 +235,9 @@ public class CirculationRepository {
 
 
   private IResource getTitelFromJson(IResource resource, List<String> circErrorMessages) {
-    if (!resource.getErrorMessages().isEmpty())
+    if (!resource.getErrorMessages().isEmpty()) {
       return resource;
+    }
 
     String title = TITLE_NOT_FOUND;
     final Optional<JsonObject> response = Optional.ofNullable(resource.getResource());
@@ -250,7 +251,7 @@ public class CirculationRepository {
       title = instanceArray.getJsonObject(0).getString(TITLE);
       return getiResourceFromTitle(title, circErrorMessages);
     }
-      return getiResourceFromTitle(title, circErrorMessages);
+    return getiResourceFromTitle(title, circErrorMessages);
   }
 
   /**
@@ -285,11 +286,12 @@ public class CirculationRepository {
    * @return a list of open requests for the specified item
    */
   public Future<JsonObject> getRequestsByItemId(String itemId, String requestType,
-                                                Integer startItem, Integer endItem, SessionData sessionData) {
+                                                Integer startItem, Integer endItem,
+                                                SessionData sessionData) {
     final Map<String, String> headers = getBaseHeaders();
 
     final RequestsRequestData requestsRequestData = new RequestsRequestData("itemId", itemId,
-      requestType, startItem, endItem, headers, sessionData);
+        requestType, startItem, endItem, headers, sessionData);
     final Future<IResource> result = resourceProvider.retrieveResource(requestsRequestData);
 
     return result.otherwise(() -> null).map(IResource::getResource);
@@ -529,10 +531,10 @@ public class CirculationRepository {
     public String getPath() {
 
       final StringBuilder qSb = new StringBuilder()
-        .append(basePath)
-        .append("(items.barcode")
-        .append("==")
-        .append(itemBarcode).append(")");
+          .append(basePath)
+          .append("(items.barcode")
+          .append("==")
+          .append(itemBarcode).append(")");
       return qSb.toString();
     }
   }
@@ -545,11 +547,11 @@ public class CirculationRepository {
     private final SessionData sessionData;
 
     private SearchRequestData(
-      JsonObject body,
-      Integer startItem,
-      Integer endItem,
-      Map<String, String> headers,
-      SessionData sessionData) {
+        JsonObject body,
+        Integer startItem,
+        Integer endItem,
+        Map<String, String> headers,
+        SessionData sessionData) {
       this.startItem = startItem;
       this.headers = Collections.unmodifiableMap(new HashMap<>(headers));
       this.sessionData = sessionData;

--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -185,7 +185,7 @@ public class CirculationRepository {
     return getTitle(itemIdentifier, sessionData, circRes.getErrorMessages());
   }
 
-  private IResource getiResourceFromTitle(String title, IResource searchResult, List<String> circErrorMessages) {
+  private IResource getiResourceFromTitle(String title, List<String> circErrorMessages) {
     IResource res;
     res = new IResource() {
       @Override
@@ -241,9 +241,9 @@ public class CirculationRepository {
     JsonArray instanceArray = response.get().getJsonArray(instances);
     if (instanceArray.size() > 0) {
       title = instanceArray.getJsonObject(0).getString("title");
-      return getiResourceFromTitle(title, resource, circErrorMessages);
+      return getiResourceFromTitle(title, circErrorMessages);
     } else
-      return getiResourceFromTitle(title, resource, circErrorMessages);
+      return getiResourceFromTitle(title, circErrorMessages);
   }
 
   /**
@@ -527,12 +527,6 @@ public class CirculationRepository {
         .append("(items.barcode")
         .append("==")
         .append(itemBarcode).append(")");
-      /*
-      final StringBuilder urlSb = new StringBuilder()
-        .append(basePath)
-        .append(Utils.encode(qSb.toString()));
-        return urlSb.toString();
-       */
       return qSb.toString();
     }
   }

--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -37,6 +37,7 @@ import org.folio.edge.sip2.utils.Utils;
 public class CirculationRepository {
   // Should consider letting the template take care of required fields with missing values
   private static final String UNKNOWN = "";
+  public static final String TITLE_NOT_FOUND = "TITLE NOT FOUND";
   private final IResourceProvider<IRequestData> resourceProvider;
   private final PasswordVerifier passwordVerifier;
   private final Clock clock;
@@ -180,20 +181,18 @@ public class CirculationRepository {
   }
 
   private String getTitle(String itemIdentifier, SessionData sessionData) {
-    System.out.println("inside test method");
 
     final Map<String, String> headers = getBaseHeaders();
-
     final ItemRequestData itemRequestData =
       new ItemRequestData(null, headers, sessionData,itemIdentifier);
-
-    System.out.println("path is-> "+itemRequestData.getPath());
 
     AtomicReference<String> title = new AtomicReference<>("");
 
     final Future<IResource> result = resourceProvider.retrieveResource(itemRequestData);
     if(Optional.ofNullable(result).isPresent())
-      result.onSuccess(items-> title.set(getTitelFromJson(items.getResource())));
+      result.onSuccess(items-> title.set(getTitelFromJson(items.getResource()))).onFailure(e->{
+        title.set(TITLE_NOT_FOUND);
+      });
 
     return title.get();
   }

--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -180,7 +180,6 @@ public class CirculationRepository {
                 .filter(v -> !v.isEmpty())
                 .orElse(null))
               .build();
-
           });
       });
   }
@@ -194,8 +193,7 @@ public class CirculationRepository {
   }
 
   private IResource getiResourceFromTitle(String title, List<String> circErrorMessages) {
-    IResource res;
-    res = new IResource() {
+    return new IResource() {
       @Override
       public JsonObject getResource() {
         return null;
@@ -216,7 +214,6 @@ public class CirculationRepository {
         return tempError;
       }
     };
-    return res;
   }
 
   private Future<IResource> getTitle(String itemIdentifier, SessionData sessionData,
@@ -230,11 +227,10 @@ public class CirculationRepository {
 
     return result
       .otherwise(Utils.handleSearchErrors(result.cause(), circErrorMessages))
-      .map(searchResult -> getTitelFromJson(searchResult, circErrorMessages));
+      .map(searchResult -> getTitleFromJson(searchResult, circErrorMessages));
   }
 
-
-  private IResource getTitelFromJson(IResource resource, List<String> circErrorMessages) {
+  private IResource getTitleFromJson(IResource resource, List<String> circErrorMessages) {
     if (!resource.getErrorMessages().isEmpty()) {
       return resource;
     }
@@ -575,5 +571,4 @@ public class CirculationRepository {
     }
 
   }
-
 }

--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -550,16 +550,11 @@ public class CirculationRepository {
       Integer endItem,
       Map<String, String> headers,
       SessionData sessionData) {
-      this.body = body;
       this.startItem = startItem;
-      this.endItem = endItem;
       this.headers = Collections.unmodifiableMap(new HashMap<>(headers));
       this.sessionData = sessionData;
-    }
-
-    @Override
-    public Map<String, String> getHeaders() {
-      return headers;
+      this.endItem = endItem;
+      this.body = body;
     }
 
     @Override
@@ -570,6 +565,11 @@ public class CirculationRepository {
     @Override
     public SessionData getSessionData() {
       return sessionData;
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+      return headers;
     }
 
   }

--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -234,7 +234,7 @@ public class CirculationRepository {
     String title = TITLE_NOT_FOUND;
     final Optional<JsonObject> response = Optional.ofNullable(resource.getResource());
     if (response.isEmpty()) {
-      return resource;
+      return getiResourceFromTitle(title, circErrorMessages);
     }
 
     final String instances = "instances";

--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -255,12 +255,6 @@ public class CirculationRepository {
     return result.otherwise(() -> null).map(IResource::getResource);
   }
 
-  private String onSucessTest(JsonObject resource) {
-    System.out.println("resource is "+resource.toString());
-    System.out.println("onSucess working");
-    return "onSucessTestData";
-  }
-
   /**
    * Get loans for the specified patron.
    *

--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -214,8 +214,7 @@ public class CirculationRepository {
           tempError.add("Title Not Found");
           return tempError;
         }
-        else
-          return tempError;
+        return tempError;
       }
     };
     return res;
@@ -250,7 +249,7 @@ public class CirculationRepository {
     if (instanceArray.size() > 0) {
       title = instanceArray.getJsonObject(0).getString(TITLE);
       return getiResourceFromTitle(title, circErrorMessages);
-    } else
+    }
       return getiResourceFromTitle(title, circErrorMessages);
   }
 

--- a/src/main/java/org/folio/edge/sip2/repositories/IResource.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/IResource.java
@@ -44,4 +44,12 @@ public interface IResource {
   default List<String> getErrorMessages() {
     return Collections.emptyList();
   }
+
+  /**
+   * Returns title & used if error response does not contains title
+   *
+   * @return strings
+   */
+  default String getTitle() { return ""; }
+
 }

--- a/src/main/java/org/folio/edge/sip2/repositories/IResource.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/IResource.java
@@ -46,10 +46,12 @@ public interface IResource {
   }
 
   /**
-   * Returns title & used if error response does not contains title
+   * Returns title & used if error response does not contains title.
    *
    * @return strings
    */
-  default String getTitle() { return ""; }
+  default String getTitle() {
+    return "";
+  }
 
 }

--- a/src/main/java/org/folio/edge/sip2/utils/Utils.java
+++ b/src/main/java/org/folio/edge/sip2/utils/Utils.java
@@ -7,11 +7,14 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.folio.edge.sip2.repositories.IResource;
 import org.folio.edge.sip2.repositories.RequestThrowable;
+
+import static org.folio.edge.sip2.repositories.CirculationRepository.TITLE_NOT_FOUND;
 
 /**
  * Utils for the repository implementations.
@@ -107,5 +110,31 @@ public final class Utils {
 
   public static String encode(String url) {
     return URLEncoder.encode(url, StandardCharsets.UTF_8);
+  }
+
+  public static IResource handleSearchErrors(Throwable cause, List<String> errorMessages) {
+    IResource temp = new IResource() {
+      @Override
+      public JsonObject getResource() {
+        return null;
+      }
+
+      @Override
+      public String getTitle(){
+        return TITLE_NOT_FOUND;
+      }
+      @Override
+      public List<String> getErrorMessages() {
+        List<String> temp = new ArrayList<>(errorMessages);
+        if (cause instanceof RequestThrowable) {
+          errorMessages.addAll(((RequestThrowable) cause).getErrorMessages());
+          return errorMessages;
+        } else {
+          temp.add(cause.getMessage());
+          return temp;
+        }
+      }
+    };
+    return temp;
   }
 }

--- a/src/main/java/org/folio/edge/sip2/utils/Utils.java
+++ b/src/main/java/org/folio/edge/sip2/utils/Utils.java
@@ -113,7 +113,7 @@ public final class Utils {
   }
 
   public static IResource handleSearchErrors(Throwable cause, List<String> errorMessages) {
-    IResource temp = new IResource() {
+    return new IResource() {
       @Override
       public JsonObject getResource() {
         return null;
@@ -131,6 +131,5 @@ public final class Utils {
           return temp;
         }
     };
-    return temp;
   }
 }

--- a/src/main/java/org/folio/edge/sip2/utils/Utils.java
+++ b/src/main/java/org/folio/edge/sip2/utils/Utils.java
@@ -11,10 +11,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.folio.edge.sip2.repositories.CirculationRepository;
 import org.folio.edge.sip2.repositories.IResource;
 import org.folio.edge.sip2.repositories.RequestThrowable;
-
-import static org.folio.edge.sip2.repositories.CirculationRepository.TITLE_NOT_FOUND;
 
 /**
  * Utils for the repository implementations.
@@ -112,6 +111,12 @@ public final class Utils {
     return URLEncoder.encode(url, StandardCharsets.UTF_8);
   }
 
+  /**
+   * Utility method to handle mod-search errors.
+   * @param cause - a throwable object
+   * @param errorMessages - a List of error Message from previous chain
+   * @return - IResource
+   */
   public static IResource handleSearchErrors(Throwable cause, List<String> errorMessages) {
     return new IResource() {
       @Override
@@ -120,8 +125,8 @@ public final class Utils {
       }
 
       @Override
-      public String getTitle(){
-        return TITLE_NOT_FOUND;
+      public String getTitle() {
+        return CirculationRepository.TITLE_NOT_FOUND;
       }
 
       @Override

--- a/src/main/java/org/folio/edge/sip2/utils/Utils.java
+++ b/src/main/java/org/folio/edge/sip2/utils/Utils.java
@@ -123,17 +123,13 @@ public final class Utils {
       public String getTitle(){
         return TITLE_NOT_FOUND;
       }
+
       @Override
       public List<String> getErrorMessages() {
         List<String> temp = new ArrayList<>(errorMessages);
-        if (cause instanceof RequestThrowable) {
-          errorMessages.addAll(((RequestThrowable) cause).getErrorMessages());
-          return errorMessages;
-        } else {
           temp.add(cause.getMessage());
           return temp;
         }
-      }
     };
     return temp;
   }

--- a/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
@@ -542,8 +542,6 @@ public class CirculationRepositoryTests {
         .thenReturn(Future.succeededFuture(new FolioResource(response,
         MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
 
-
-
     when(mockFolioProvider.createResource(any()))
         .thenReturn(Future.failedFuture(new FolioRequestThrowable(errorMessage)));
     when(mockPasswordVerifier.verifyPatronPassword(eq(patronIdentifier), eq("7890"), any()))
@@ -575,7 +573,6 @@ public class CirculationRepositoryTests {
           assertNull(checkoutResponse.getTransactionId());
           assertEquals(expectedErrors, checkoutResponse.getScreenMessage());
           assertNull(checkoutResponse.getPrintLine());
-
           testContext.completeNow();
         })));
   }
@@ -647,7 +644,6 @@ public class CirculationRepositoryTests {
           assertNull(checkoutResponse.getTransactionId());
           assertEquals(expectedErrors, checkoutResponse.getScreenMessage());
           assertNull(checkoutResponse.getPrintLine());
-
           testContext.completeNow();
         })));
   }
@@ -718,7 +714,6 @@ public class CirculationRepositoryTests {
           assertNull(checkoutResponse.getTransactionId());
           assertEquals(expectedErrors, checkoutResponse.getScreenMessage());
           assertNull(checkoutResponse.getPrintLine());
-
           testContext.completeNow();
         })));
   }
@@ -855,7 +850,6 @@ public class CirculationRepositoryTests {
     circulationRepository.getLoansByUserId(userId, null, null, sessionData).onComplete(
         testContext.succeeding(loansResponse -> testContext.verify(() -> {
           assertNull(loansResponse);
-
           testContext.completeNow();
         })));
   }
@@ -902,7 +896,6 @@ public class CirculationRepositoryTests {
           assertNotNull(loan);
           assertEquals(userId, loan.getString("userId"));
           assertEquals(itemId, loan.getString("itemId"));
-
           testContext.completeNow();
         })));
   }
@@ -926,7 +919,6 @@ public class CirculationRepositoryTests {
     circulationRepository.getOverdueLoansByUserId(userId, OffsetDateTime.now(clock), null, null,
         sessionData).onComplete(testContext.succeeding(loansResponse -> testContext.verify(() -> {
           assertNull(loansResponse);
-
           testContext.completeNow();
         })));
   }
@@ -973,7 +965,6 @@ public class CirculationRepositoryTests {
           assertNotNull(request);
           assertEquals(userId, request.getString("requesterId"));
           assertEquals(itemId, request.getString("itemId"));
-
           testContext.completeNow();
         })));
   }

--- a/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
@@ -29,6 +29,7 @@ import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -535,7 +536,8 @@ public class CirculationRepositoryTests {
     final String expectedPath = "/search/instances?limit=1&query=(items.barcode==453987605438)";
 
     when(mockFolioProvider.retrieveResource(
-      argThat((IRequestData data) -> data.getPath().equals(expectedPath))))
+      argThat((IRequestData data) -> data.getPath().equals(expectedPath) &&
+        data.getHeaders().get("accept").equals("application/json"))))
       .thenReturn(Future.succeededFuture(new FolioResource(response,
         MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
 

--- a/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
@@ -498,6 +498,7 @@ public class CirculationRepositoryTests {
         MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
 
 
+
     when(mockFolioProvider.createResource(any()))
         .thenReturn(Future.failedFuture(new FolioRequestThrowable(errorMessage)));
     when(mockPasswordVerifier.verifyPatronPassword(eq(patronIdentifier), eq("7890"), any()))
@@ -532,6 +533,81 @@ public class CirculationRepositoryTests {
 
           testContext.completeNow();
         })));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideCirculationErrors")
+  void cannotCheckoutGetTitleFailed(String errorMessage, List<String> expectedErrors, Vertx vertx,
+                      VertxTestContext testContext,
+                      @Mock IResourceProvider<IRequestData> mockFolioProvider,
+                      @Mock PasswordVerifier mockPasswordVerifier) {
+    final Clock clock = TestUtils.getUtcFixedClock();
+    final OffsetDateTime nbDueDate = OffsetDateTime.now().plusDays(30);
+    final String patronIdentifier = "1029384756";
+    final String itemIdentifier = "453987605438";
+    final Checkout checkout = Checkout.builder()
+      .scRenewalPolicy(FALSE)
+      .noBlock(FALSE)
+      .transactionDate(OffsetDateTime.now())
+      .nbDueDate(nbDueDate)
+      .institutionId("diku")
+      .patronIdentifier(patronIdentifier)
+      .itemIdentifier(itemIdentifier)
+      .terminalPassword("1234")
+      .itemProperties("Some property of this item")
+      .patronPassword("7890")
+      .feeAcknowledged(FALSE)
+      .cancel(FALSE)
+      .build();
+
+    final JsonObject response = new JsonObject()
+      .put("instances", new JsonArray()
+        .add(new JsonObject()
+          .put("id", "7fbd5d84-62d1-44c6-9c45-6cb173998bbd")
+          .put("title","Bridget Jones's Baby: the diaries")
+          .put("contributors", new JsonArray().add(new JsonObject().put("name","Fielding, Helen")))))
+      .put("totalRecords", 1);
+
+    final String expectedPath = "/search/instances?limit=1&query=%28items.barcode%3D%3D453987605438%29";
+
+    when(mockFolioProvider.retrieveResource(any()))
+      .thenReturn(Future.failedFuture(new Exception("Failed while calling mod-search")));
+
+
+    when(mockFolioProvider.createResource(any()))
+      .thenReturn(Future.failedFuture(new FolioRequestThrowable(errorMessage)));
+    when(mockPasswordVerifier.verifyPatronPassword(eq(patronIdentifier), eq("7890"), any()))
+      .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder().build()));
+
+    final SessionData sessionData = TestUtils.getMockedSessionData();
+
+    final CirculationRepository circulationRepository = new CirculationRepository(
+      mockFolioProvider, mockPasswordVerifier, clock);
+    circulationRepository.performCheckoutCommand(checkout, sessionData).onComplete(
+      testContext.succeeding(checkoutResponse -> testContext.verify(() -> {
+        assertNotNull(checkoutResponse);
+        assertFalse(checkoutResponse.getOk());
+        assertFalse(checkoutResponse.getRenewalOk());
+        assertNull(checkoutResponse.getMagneticMedia());
+        assertFalse(checkoutResponse.getDesensitize());
+        assertEquals(OffsetDateTime.now(clock), checkoutResponse.getTransactionDate());
+        assertEquals("diku", checkoutResponse.getInstitutionId());
+        assertEquals(patronIdentifier, checkoutResponse.getPatronIdentifier());
+        assertEquals(itemIdentifier, checkoutResponse.getItemIdentifier());
+        assertEquals("TITLE NOT FOUND", checkoutResponse.getTitleIdentifier());
+        assertEquals(OffsetDateTime.now(clock), checkoutResponse.getDueDate());
+        assertNull(checkoutResponse.getFeeType());
+        assertNull(checkoutResponse.getSecurityInhibit());
+        assertNull(checkoutResponse.getCurrencyType());
+        assertNull(checkoutResponse.getFeeAmount());
+        assertNull(checkoutResponse.getMediaType());
+        assertNull(checkoutResponse.getItemProperties());
+        assertNull(checkoutResponse.getTransactionId());
+        assertEquals(expectedErrors, checkoutResponse.getScreenMessage());
+        assertNull(checkoutResponse.getPrintLine());
+
+        testContext.completeNow();
+      })));
   }
 
   @Test

--- a/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
@@ -458,6 +458,47 @@ public class CirculationRepositoryTests {
         Arguments.of("Not logged in", asList("Not logged in")));
   }
 
+
+  private static Stream<Arguments> provideCirculationAndSearchErrors() {
+    return Stream.of(
+      Arguments.of("{\n"
+        + "  \"errors\" : [ {\n"
+        + "    \"message\" : \"Item is already checked out\",\n"
+        + "    \"parameters\" : [ {\n"
+        + "      \"key\" : \"itemBarcode\",\n"
+        + "      \"value\" : \"12345\"\n"
+        + "    } ]\n"
+        + "  }, {\n"
+        + "    \"message\" : \"Item is lost\",\n"
+        + "    \"parameters\" : [ {\n"
+        + "      \"key\" : \"itemBarcode\",\n"
+        + "      \"value\" : \"12345\"\n"
+        + "    } ]\n"
+        + "  } ]\n"
+        + "}", asList("Item is already checked out", "Item is lost","Failed while calling mod-search")),
+      Arguments.of("Not logged in", asList("Not logged in","Failed while calling mod-search")));
+  }
+
+  private static Stream<Arguments> provideCirculationAndTitleNotFound() {
+    return Stream.of(
+      Arguments.of("{\n"
+        + "  \"errors\" : [ {\n"
+        + "    \"message\" : \"Item is already checked out\",\n"
+        + "    \"parameters\" : [ {\n"
+        + "      \"key\" : \"itemBarcode\",\n"
+        + "      \"value\" : \"12345\"\n"
+        + "    } ]\n"
+        + "  }, {\n"
+        + "    \"message\" : \"Item is lost\",\n"
+        + "    \"parameters\" : [ {\n"
+        + "      \"key\" : \"itemBarcode\",\n"
+        + "      \"value\" : \"12345\"\n"
+        + "    } ]\n"
+        + "  } ]\n"
+        + "}", asList("Item is already checked out", "Item is lost","Title Not Found")),
+      Arguments.of("Not logged in", asList("Not logged in","Title Not Found")));
+  }
+
   @ParameterizedTest
   @MethodSource("provideCirculationErrors")
   void cannotCheckout(String errorMessage, List<String> expectedErrors, Vertx vertx,
@@ -536,7 +577,7 @@ public class CirculationRepositoryTests {
   }
 
   @ParameterizedTest
-  @MethodSource("provideCirculationErrors")
+  @MethodSource("provideCirculationAndSearchErrors")
   void cannotCheckoutGetTitleFailed(String errorMessage, List<String> expectedErrors, Vertx vertx,
                       VertxTestContext testContext,
                       @Mock IResourceProvider<IRequestData> mockFolioProvider,
@@ -572,6 +613,80 @@ public class CirculationRepositoryTests {
 
     when(mockFolioProvider.retrieveResource(any()))
       .thenReturn(Future.failedFuture(new Exception("Failed while calling mod-search")));
+
+
+    when(mockFolioProvider.createResource(any()))
+      .thenReturn(Future.failedFuture(new FolioRequestThrowable(errorMessage)));
+    when(mockPasswordVerifier.verifyPatronPassword(eq(patronIdentifier), eq("7890"), any()))
+      .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder().build()));
+
+    final SessionData sessionData = TestUtils.getMockedSessionData();
+
+    final CirculationRepository circulationRepository = new CirculationRepository(
+      mockFolioProvider, mockPasswordVerifier, clock);
+    circulationRepository.performCheckoutCommand(checkout, sessionData).onComplete(
+      testContext.succeeding(checkoutResponse -> testContext.verify(() -> {
+        assertNotNull(checkoutResponse);
+        assertFalse(checkoutResponse.getOk());
+        assertFalse(checkoutResponse.getRenewalOk());
+        assertNull(checkoutResponse.getMagneticMedia());
+        assertFalse(checkoutResponse.getDesensitize());
+        assertEquals(OffsetDateTime.now(clock), checkoutResponse.getTransactionDate());
+        assertEquals("diku", checkoutResponse.getInstitutionId());
+        assertEquals(patronIdentifier, checkoutResponse.getPatronIdentifier());
+        assertEquals(itemIdentifier, checkoutResponse.getItemIdentifier());
+        assertEquals("TITLE NOT FOUND", checkoutResponse.getTitleIdentifier());
+        assertEquals(OffsetDateTime.now(clock), checkoutResponse.getDueDate());
+        assertNull(checkoutResponse.getFeeType());
+        assertNull(checkoutResponse.getSecurityInhibit());
+        assertNull(checkoutResponse.getCurrencyType());
+        assertNull(checkoutResponse.getFeeAmount());
+        assertNull(checkoutResponse.getMediaType());
+        assertNull(checkoutResponse.getItemProperties());
+        assertNull(checkoutResponse.getTransactionId());
+        assertEquals(expectedErrors, checkoutResponse.getScreenMessage());
+        assertNull(checkoutResponse.getPrintLine());
+
+        testContext.completeNow();
+      })));
+  }
+
+
+  @ParameterizedTest
+  @MethodSource("provideCirculationAndTitleNotFound")
+  void cannotCheckoutAndTitleNotFoundInSearch(String errorMessage, List<String> expectedErrors, Vertx vertx,
+                      VertxTestContext testContext,
+                      @Mock IResourceProvider<IRequestData> mockFolioProvider,
+                      @Mock PasswordVerifier mockPasswordVerifier) {
+    final Clock clock = TestUtils.getUtcFixedClock();
+    final OffsetDateTime nbDueDate = OffsetDateTime.now().plusDays(30);
+    final String patronIdentifier = "1029384756";
+    final String itemIdentifier = "453987605438";
+    final Checkout checkout = Checkout.builder()
+      .scRenewalPolicy(FALSE)
+      .noBlock(FALSE)
+      .transactionDate(OffsetDateTime.now())
+      .nbDueDate(nbDueDate)
+      .institutionId("diku")
+      .patronIdentifier(patronIdentifier)
+      .itemIdentifier(itemIdentifier)
+      .terminalPassword("1234")
+      .itemProperties("Some property of this item")
+      .patronPassword("7890")
+      .feeAcknowledged(FALSE)
+      .cancel(FALSE)
+      .build();
+
+    final JsonObject response = new JsonObject()
+      .put("instances", new JsonArray())
+      .put("totalRecords", 0);
+
+    final String expectedPath = "/search/instances?limit=1&query=%28items.barcode%3D%3D453987605438%29";
+
+    when(mockFolioProvider.retrieveResource(any()))
+      .thenReturn(Future.succeededFuture(new FolioResource(response,
+        MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
+
 
 
     when(mockFolioProvider.createResource(any()))

--- a/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
@@ -476,7 +476,8 @@ public class CirculationRepositoryTests {
         + "      \"value\" : \"12345\"\n"
         + "    } ]\n"
         + "  } ]\n"
-        + "}", asList("Item is already checked out", "Item is lost","Failed while calling mod-search")),
+        + "}", asList("Item is already checked out", "Item is lost",
+                      "Failed while calling mod-search")),
       Arguments.of("Not logged in", asList("Not logged in","Failed while calling mod-search")));
   }
 
@@ -526,19 +527,19 @@ public class CirculationRepositoryTests {
         .build();
 
     final JsonObject response = new JsonObject()
-      .put("instances", new JsonArray()
+        .put("instances", new JsonArray()
         .add(new JsonObject()
           .put("id", "7fbd5d84-62d1-44c6-9c45-6cb173998bbd")
           .put("title","Bridget Jones's Baby: the diaries")
-          .put("contributors", new JsonArray().add(new JsonObject().put("name","Fielding, Helen")))))
-      .put("totalRecords", 1);
+          .put("contributors", new JsonArray().add(new JsonObject().put("name","Fielding,Helen")))))
+        .put("totalRecords", 1);
 
     final String expectedPath = "/search/instances?limit=1&query=(items.barcode==453987605438)";
 
     when(mockFolioProvider.retrieveResource(
-      argThat((IRequestData data) -> data.getPath().equals(expectedPath) &&
-        data.getHeaders().get("accept").equals("application/json"))))
-      .thenReturn(Future.succeededFuture(new FolioResource(response,
+        argThat((IRequestData data) -> data.getPath().equals(expectedPath)
+          && data.getHeaders().get("accept").equals("application/json"))))
+        .thenReturn(Future.succeededFuture(new FolioResource(response,
         MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
 
 
@@ -590,74 +591,72 @@ public class CirculationRepositoryTests {
     final String patronIdentifier = "1029384756";
     final String itemIdentifier = "453987605438";
     final Checkout checkout = Checkout.builder()
-      .scRenewalPolicy(FALSE)
-      .noBlock(FALSE)
-      .transactionDate(OffsetDateTime.now())
-      .nbDueDate(nbDueDate)
-      .institutionId("diku")
-      .patronIdentifier(patronIdentifier)
-      .itemIdentifier(itemIdentifier)
-      .terminalPassword("1234")
-      .itemProperties("Some property of this item")
-      .patronPassword("7890")
-      .feeAcknowledged(FALSE)
-      .cancel(FALSE)
-      .build();
+        .scRenewalPolicy(FALSE)
+        .noBlock(FALSE)
+        .transactionDate(OffsetDateTime.now())
+        .nbDueDate(nbDueDate)
+        .institutionId("diku")
+        .patronIdentifier(patronIdentifier)
+        .itemIdentifier(itemIdentifier)
+        .terminalPassword("1234")
+        .itemProperties("Some property of this item")
+        .patronPassword("7890")
+        .feeAcknowledged(FALSE)
+        .cancel(FALSE)
+        .build();
 
     final JsonObject response = new JsonObject()
-      .put("instances", new JsonArray()
+        .put("instances", new JsonArray()
         .add(new JsonObject()
           .put("id", "7fbd5d84-62d1-44c6-9c45-6cb173998bbd")
           .put("title","Bridget Jones's Baby: the diaries")
-          .put("contributors", new JsonArray().add(new JsonObject().put("name","Fielding, Helen")))))
-      .put("totalRecords", 1);
-
-    final String expectedPath = "/search/instances?limit=1&query=%28items.barcode%3D%3D453987605438%29";
+          .put("contributors", new JsonArray().add(new JsonObject().put("name","Fielding,Helen")))))
+        .put("totalRecords", 1);
 
     when(mockFolioProvider.retrieveResource(any()))
-      .thenReturn(Future.failedFuture(new Exception("Failed while calling mod-search")));
-
+        .thenReturn(Future.failedFuture(new Exception("Failed while calling mod-search")));
 
     when(mockFolioProvider.createResource(any()))
-      .thenReturn(Future.failedFuture(new FolioRequestThrowable(errorMessage)));
+        .thenReturn(Future.failedFuture(new FolioRequestThrowable(errorMessage)));
     when(mockPasswordVerifier.verifyPatronPassword(eq(patronIdentifier), eq("7890"), any()))
-      .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder().build()));
+        .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder().build()));
 
     final SessionData sessionData = TestUtils.getMockedSessionData();
 
     final CirculationRepository circulationRepository = new CirculationRepository(
-      mockFolioProvider, mockPasswordVerifier, clock);
+        mockFolioProvider, mockPasswordVerifier, clock);
     circulationRepository.performCheckoutCommand(checkout, sessionData).onComplete(
-      testContext.succeeding(checkoutResponse -> testContext.verify(() -> {
-        assertNotNull(checkoutResponse);
-        assertFalse(checkoutResponse.getOk());
-        assertFalse(checkoutResponse.getRenewalOk());
-        assertNull(checkoutResponse.getMagneticMedia());
-        assertFalse(checkoutResponse.getDesensitize());
-        assertEquals(OffsetDateTime.now(clock), checkoutResponse.getTransactionDate());
-        assertEquals("diku", checkoutResponse.getInstitutionId());
-        assertEquals(patronIdentifier, checkoutResponse.getPatronIdentifier());
-        assertEquals(itemIdentifier, checkoutResponse.getItemIdentifier());
-        assertEquals("TITLE NOT FOUND", checkoutResponse.getTitleIdentifier());
-        assertEquals(OffsetDateTime.now(clock), checkoutResponse.getDueDate());
-        assertNull(checkoutResponse.getFeeType());
-        assertNull(checkoutResponse.getSecurityInhibit());
-        assertNull(checkoutResponse.getCurrencyType());
-        assertNull(checkoutResponse.getFeeAmount());
-        assertNull(checkoutResponse.getMediaType());
-        assertNull(checkoutResponse.getItemProperties());
-        assertNull(checkoutResponse.getTransactionId());
-        assertEquals(expectedErrors, checkoutResponse.getScreenMessage());
-        assertNull(checkoutResponse.getPrintLine());
+        testContext.succeeding(checkoutResponse -> testContext.verify(() -> {
+          assertNotNull(checkoutResponse);
+          assertFalse(checkoutResponse.getOk());
+          assertFalse(checkoutResponse.getRenewalOk());
+          assertNull(checkoutResponse.getMagneticMedia());
+          assertFalse(checkoutResponse.getDesensitize());
+          assertEquals(OffsetDateTime.now(clock), checkoutResponse.getTransactionDate());
+          assertEquals("diku", checkoutResponse.getInstitutionId());
+          assertEquals(patronIdentifier, checkoutResponse.getPatronIdentifier());
+          assertEquals(itemIdentifier, checkoutResponse.getItemIdentifier());
+          assertEquals("TITLE NOT FOUND", checkoutResponse.getTitleIdentifier());
+          assertEquals(OffsetDateTime.now(clock), checkoutResponse.getDueDate());
+          assertNull(checkoutResponse.getFeeType());
+          assertNull(checkoutResponse.getSecurityInhibit());
+          assertNull(checkoutResponse.getCurrencyType());
+          assertNull(checkoutResponse.getFeeAmount());
+          assertNull(checkoutResponse.getMediaType());
+          assertNull(checkoutResponse.getItemProperties());
+          assertNull(checkoutResponse.getTransactionId());
+          assertEquals(expectedErrors, checkoutResponse.getScreenMessage());
+          assertNull(checkoutResponse.getPrintLine());
 
-        testContext.completeNow();
-      })));
+          testContext.completeNow();
+        })));
   }
 
 
   @ParameterizedTest
   @MethodSource("provideCirculationAndTitleNotFound")
-  void cannotCheckoutAndTitleNotFoundInSearch(String errorMessage, List<String> expectedErrors, Vertx vertx,
+  void cannotCheckoutAndTitleNotFoundInSearch(String errorMessage, List<String> expectedErrors,
+                                              Vertx vertx,
                       VertxTestContext testContext,
                       @Mock IResourceProvider<IRequestData> mockFolioProvider,
                       @Mock PasswordVerifier mockPasswordVerifier) {
@@ -666,138 +665,131 @@ public class CirculationRepositoryTests {
     final String patronIdentifier = "1029384756";
     final String itemIdentifier = "453987605438";
     final Checkout checkout = Checkout.builder()
-      .scRenewalPolicy(FALSE)
-      .noBlock(FALSE)
-      .transactionDate(OffsetDateTime.now())
-      .nbDueDate(nbDueDate)
-      .institutionId("diku")
-      .patronIdentifier(patronIdentifier)
-      .itemIdentifier(itemIdentifier)
-      .terminalPassword("1234")
-      .itemProperties("Some property of this item")
-      .patronPassword("7890")
-      .feeAcknowledged(FALSE)
-      .cancel(FALSE)
-      .build();
+        .scRenewalPolicy(FALSE)
+        .noBlock(FALSE)
+        .transactionDate(OffsetDateTime.now())
+        .nbDueDate(nbDueDate)
+        .institutionId("diku")
+        .patronIdentifier(patronIdentifier)
+        .itemIdentifier(itemIdentifier)
+        .terminalPassword("1234")
+        .itemProperties("Some property of this item")
+        .patronPassword("7890")
+        .feeAcknowledged(FALSE)
+        .cancel(FALSE)
+        .build();
 
     final JsonObject response = new JsonObject()
-      .put("instances", new JsonArray())
-      .put("totalRecords", 0);
-
-    final String expectedPath = "/search/instances?limit=1&query=%28items.barcode%3D%3D453987605438%29";
+        .put("instances", new JsonArray())
+        .put("totalRecords", 0);
 
     when(mockFolioProvider.retrieveResource(any()))
-      .thenReturn(Future.succeededFuture(new FolioResource(response,
+        .thenReturn(Future.succeededFuture(new FolioResource(response,
         MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
 
-
-
     when(mockFolioProvider.createResource(any()))
-      .thenReturn(Future.failedFuture(new FolioRequestThrowable(errorMessage)));
+        .thenReturn(Future.failedFuture(new FolioRequestThrowable(errorMessage)));
     when(mockPasswordVerifier.verifyPatronPassword(eq(patronIdentifier), eq("7890"), any()))
-      .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder().build()));
+        .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder().build()));
 
     final SessionData sessionData = TestUtils.getMockedSessionData();
 
     final CirculationRepository circulationRepository = new CirculationRepository(
-      mockFolioProvider, mockPasswordVerifier, clock);
+        mockFolioProvider, mockPasswordVerifier, clock);
     circulationRepository.performCheckoutCommand(checkout, sessionData).onComplete(
-      testContext.succeeding(checkoutResponse -> testContext.verify(() -> {
-        assertNotNull(checkoutResponse);
-        assertFalse(checkoutResponse.getOk());
-        assertFalse(checkoutResponse.getRenewalOk());
-        assertNull(checkoutResponse.getMagneticMedia());
-        assertFalse(checkoutResponse.getDesensitize());
-        assertEquals(OffsetDateTime.now(clock), checkoutResponse.getTransactionDate());
-        assertEquals("diku", checkoutResponse.getInstitutionId());
-        assertEquals(patronIdentifier, checkoutResponse.getPatronIdentifier());
-        assertEquals(itemIdentifier, checkoutResponse.getItemIdentifier());
-        assertEquals("TITLE NOT FOUND", checkoutResponse.getTitleIdentifier());
-        assertEquals(OffsetDateTime.now(clock), checkoutResponse.getDueDate());
-        assertNull(checkoutResponse.getFeeType());
-        assertNull(checkoutResponse.getSecurityInhibit());
-        assertNull(checkoutResponse.getCurrencyType());
-        assertNull(checkoutResponse.getFeeAmount());
-        assertNull(checkoutResponse.getMediaType());
-        assertNull(checkoutResponse.getItemProperties());
-        assertNull(checkoutResponse.getTransactionId());
-        assertEquals(expectedErrors, checkoutResponse.getScreenMessage());
-        assertNull(checkoutResponse.getPrintLine());
+        testContext.succeeding(checkoutResponse -> testContext.verify(() -> {
+          assertNotNull(checkoutResponse);
+          assertFalse(checkoutResponse.getOk());
+          assertFalse(checkoutResponse.getRenewalOk());
+          assertNull(checkoutResponse.getMagneticMedia());
+          assertFalse(checkoutResponse.getDesensitize());
+          assertEquals(OffsetDateTime.now(clock), checkoutResponse.getTransactionDate());
+          assertEquals("diku", checkoutResponse.getInstitutionId());
+          assertEquals(patronIdentifier, checkoutResponse.getPatronIdentifier());
+          assertEquals(itemIdentifier, checkoutResponse.getItemIdentifier());
+          assertEquals("TITLE NOT FOUND", checkoutResponse.getTitleIdentifier());
+          assertEquals(OffsetDateTime.now(clock), checkoutResponse.getDueDate());
+          assertNull(checkoutResponse.getFeeType());
+          assertNull(checkoutResponse.getSecurityInhibit());
+          assertNull(checkoutResponse.getCurrencyType());
+          assertNull(checkoutResponse.getFeeAmount());
+          assertNull(checkoutResponse.getMediaType());
+          assertNull(checkoutResponse.getItemProperties());
+          assertNull(checkoutResponse.getTransactionId());
+          assertEquals(expectedErrors, checkoutResponse.getScreenMessage());
+          assertNull(checkoutResponse.getPrintLine());
 
-        testContext.completeNow();
-      })));
+          testContext.completeNow();
+        })));
   }
 
   @ParameterizedTest
   @MethodSource("provideCirculationAndTitleNotFound")
-  void cannotCheckoutAndTitleNotFoundInSearchandReturnNull(String errorMessage, List<String> expectedErrors, Vertx vertx,
-                                              VertxTestContext testContext,
-                                              @Mock IResourceProvider<IRequestData> mockFolioProvider,
+  void cannotCheckoutAndTitleNotFoundInSearchandReturnNull(String errorMessage,
+                                                           List<String> expectedErrors,
+                                                           Vertx vertx,
+                                            VertxTestContext testContext,
+                                            @Mock IResourceProvider<IRequestData> mockFolioProvider,
                                               @Mock PasswordVerifier mockPasswordVerifier) {
     final Clock clock = TestUtils.getUtcFixedClock();
     final OffsetDateTime nbDueDate = OffsetDateTime.now().plusDays(30);
     final String patronIdentifier = "1029384756";
     final String itemIdentifier = "453987605438";
     final Checkout checkout = Checkout.builder()
-      .scRenewalPolicy(FALSE)
-      .noBlock(FALSE)
-      .transactionDate(OffsetDateTime.now())
-      .nbDueDate(nbDueDate)
-      .institutionId("diku")
-      .patronIdentifier(patronIdentifier)
-      .itemIdentifier(itemIdentifier)
-      .terminalPassword("1234")
-      .itemProperties("Some property of this item")
-      .patronPassword("7890")
-      .feeAcknowledged(FALSE)
-      .cancel(FALSE)
-      .build();
+        .scRenewalPolicy(FALSE)
+        .noBlock(FALSE)
+        .transactionDate(OffsetDateTime.now())
+        .nbDueDate(nbDueDate)
+        .institutionId("diku")
+        .patronIdentifier(patronIdentifier)
+        .itemIdentifier(itemIdentifier)
+        .terminalPassword("1234")
+        .itemProperties("Some property of this item")
+        .patronPassword("7890")
+        .feeAcknowledged(FALSE)
+        .cancel(FALSE)
+        .build();
 
     final JsonObject response = null;
 
-
-    final String expectedPath = "/search/instances?limit=1&query=%28items.barcode%3D%3D453987605438%29";
-
     when(mockFolioProvider.retrieveResource(any()))
-      .thenReturn(Future.succeededFuture(new FolioResource(response,
+        .thenReturn(Future.succeededFuture(new FolioResource(response,
         MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
 
-
-
     when(mockFolioProvider.createResource(any()))
-      .thenReturn(Future.failedFuture(new FolioRequestThrowable(errorMessage)));
+        .thenReturn(Future.failedFuture(new FolioRequestThrowable(errorMessage)));
     when(mockPasswordVerifier.verifyPatronPassword(eq(patronIdentifier), eq("7890"), any()))
-      .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder().build()));
+        .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder().build()));
 
     final SessionData sessionData = TestUtils.getMockedSessionData();
 
     final CirculationRepository circulationRepository = new CirculationRepository(
-      mockFolioProvider, mockPasswordVerifier, clock);
+        mockFolioProvider, mockPasswordVerifier, clock);
     circulationRepository.performCheckoutCommand(checkout, sessionData).onComplete(
-      testContext.succeeding(checkoutResponse -> testContext.verify(() -> {
-        assertNotNull(checkoutResponse);
-        assertFalse(checkoutResponse.getOk());
-        assertFalse(checkoutResponse.getRenewalOk());
-        assertNull(checkoutResponse.getMagneticMedia());
-        assertFalse(checkoutResponse.getDesensitize());
-        assertEquals(OffsetDateTime.now(clock), checkoutResponse.getTransactionDate());
-        assertEquals("diku", checkoutResponse.getInstitutionId());
-        assertEquals(patronIdentifier, checkoutResponse.getPatronIdentifier());
-        assertEquals(itemIdentifier, checkoutResponse.getItemIdentifier());
-        assertEquals("TITLE NOT FOUND", checkoutResponse.getTitleIdentifier());
-        assertEquals(OffsetDateTime.now(clock), checkoutResponse.getDueDate());
-        assertNull(checkoutResponse.getFeeType());
-        assertNull(checkoutResponse.getSecurityInhibit());
-        assertNull(checkoutResponse.getCurrencyType());
-        assertNull(checkoutResponse.getFeeAmount());
-        assertNull(checkoutResponse.getMediaType());
-        assertNull(checkoutResponse.getItemProperties());
-        assertNull(checkoutResponse.getTransactionId());
-        assertEquals(expectedErrors, checkoutResponse.getScreenMessage());
-        assertNull(checkoutResponse.getPrintLine());
+        testContext.succeeding(checkoutResponse -> testContext.verify(() -> {
+          assertNotNull(checkoutResponse);
+          assertFalse(checkoutResponse.getOk());
+          assertFalse(checkoutResponse.getRenewalOk());
+          assertNull(checkoutResponse.getMagneticMedia());
+          assertFalse(checkoutResponse.getDesensitize());
+          assertEquals(OffsetDateTime.now(clock), checkoutResponse.getTransactionDate());
+          assertEquals("diku", checkoutResponse.getInstitutionId());
+          assertEquals(patronIdentifier, checkoutResponse.getPatronIdentifier());
+          assertEquals(itemIdentifier, checkoutResponse.getItemIdentifier());
+          assertEquals("TITLE NOT FOUND", checkoutResponse.getTitleIdentifier());
+          assertEquals(OffsetDateTime.now(clock), checkoutResponse.getDueDate());
+          assertNull(checkoutResponse.getFeeType());
+          assertNull(checkoutResponse.getSecurityInhibit());
+          assertNull(checkoutResponse.getCurrencyType());
+          assertNull(checkoutResponse.getFeeAmount());
+          assertNull(checkoutResponse.getMediaType());
+          assertNull(checkoutResponse.getItemProperties());
+          assertNull(checkoutResponse.getTransactionId());
+          assertEquals(expectedErrors, checkoutResponse.getScreenMessage());
+          assertNull(checkoutResponse.getPrintLine());
 
-        testContext.completeNow();
-      })));
+          testContext.completeNow();
+        })));
   }
 
   @Test

--- a/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
@@ -467,7 +467,7 @@ public class CirculationRepositoryTests {
     final Clock clock = TestUtils.getUtcFixedClock();
     final OffsetDateTime nbDueDate = OffsetDateTime.now().plusDays(30);
     final String patronIdentifier = "1029384756";
-    final String itemIdentifier = "1234567890";
+    final String itemIdentifier = "453987605438";
     final Checkout checkout = Checkout.builder()
         .scRenewalPolicy(FALSE)
         .noBlock(FALSE)
@@ -482,6 +482,21 @@ public class CirculationRepositoryTests {
         .feeAcknowledged(FALSE)
         .cancel(FALSE)
         .build();
+
+    final JsonObject response = new JsonObject()
+      .put("instances", new JsonArray()
+        .add(new JsonObject()
+          .put("id", "7fbd5d84-62d1-44c6-9c45-6cb173998bbd")
+          .put("title","Bridget Jones's Baby: the diaries")
+          .put("contributors", new JsonArray().add(new JsonObject().put("name","Fielding, Helen")))))
+      .put("totalRecords", 1);
+
+    final String expectedPath = "/search/instances?limit=1&query=%28items.barcode%3D%3D453987605438%29";
+
+    when(mockFolioProvider.retrieveResource(any()))
+      .thenReturn(Future.succeededFuture(new FolioResource(response,
+        MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
+
 
     when(mockFolioProvider.createResource(any()))
         .thenReturn(Future.failedFuture(new FolioRequestThrowable(errorMessage)));
@@ -503,7 +518,7 @@ public class CirculationRepositoryTests {
           assertEquals("diku", checkoutResponse.getInstitutionId());
           assertEquals(patronIdentifier, checkoutResponse.getPatronIdentifier());
           assertEquals(itemIdentifier, checkoutResponse.getItemIdentifier());
-          assertEquals("", checkoutResponse.getTitleIdentifier());
+          assertEquals("Bridget Jones's Baby: the diaries", checkoutResponse.getTitleIdentifier());
           assertEquals(OffsetDateTime.now(clock), checkoutResponse.getDueDate());
           assertNull(checkoutResponse.getFeeType());
           assertNull(checkoutResponse.getSecurityInhibit());


### PR DESCRIPTION
SIP2-115 ( https://issues.folio.org/browse/SIP2-115 ) 

## Purpose : 

-   Always populate the "title identifier" field for checked out response (12) 

## Approach: 

- If mod-circulation returning error on doing item checkout action , call mod-search API ( search/instances?limit=1&query=(items.barcode==<barcode>)  ) to get the corresponding title-identifier of the item which we want to checkout . 
- implemented unit tests
- Add additional null check on writeHistory () method of ISip2RequestHandler.java
- Module Descriptor updated with mod-search

## Results : 

- If Item Barcode is correct  :  

![image](https://user-images.githubusercontent.com/103935659/187212916-613b2a0e-48c8-45b3-a7e1-21d294791014.png)

-  If item Barcode is incorrect / not found by mod-search API 

![image](https://user-images.githubusercontent.com/103935659/187213133-22310e71-e531-4d0d-a145-f72f192a673f.png)


