### PR TITLE
SIP2-108

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,26 @@ $ java -jar edge-sip2-fat.jar -conf '{"port":1234,"okapiUrl":"https://folio-snap
 |`path`|string|File system path to JKS key store|
 |`password`|string|The password for the JKS key store|
 
+## Permissions
+All permission associated with edge-sip2
+```
+    circulation.check-in-by-barcode.post
+    circulation.check-out-by-barcode.post
+    circulation.requests.collection.get
+    search.instances.collection.get
+    search.instances.ids.collection.get
+    circulation.loans.collection.get
+    configuration.entries.collection.get
+    configuration.entries.item.get
+    manualblocks.collection.get
+    manualblocks.item.get
+    accounts.collection.get
+    accounts.item.get
+    users.collection.get
+    users.item.get
+    
+```
+
 #### Security concerns for developers
 
 For local development, there is no requirement to encrypt communications from a SIP2 client to edge-sip2. Unencrypted TCP sockets are the default when launching edge-sip2 as described in the [Configuration](#configuration) section. Encrypted communication from a SIP2 client is only required when explicitly configured via the [above options](#security) and is up to the developer to provide that secure connection for edge-sip2.

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -28,7 +28,29 @@
       "version": "0.7"
     }
   ],
-  "permissionSets": [],
+  "permissionSets": [
+    {
+      "permissionName" : "edge-sip.all",
+      "displayName" : "All permission associated with edge-sip2",
+      "description" : "All permissions edge-sip scope",
+      "subPermissions" : [
+        "circulation.check-in-by-barcode.post",
+        "circulation.check-out-by-barcode.post",
+        "circulation.requests.collection.get",
+        "search.instances.collection.get",
+        "search.instances.ids.collection.get",
+        "circulation.loans.collection.get",
+        "configuration.entries.collection.get",
+        "configuration.entries.item.get",
+        "manualblocks.collection.get",
+        "manualblocks.item.get",
+        "accounts.collection.get",
+        "accounts.item.get",
+        "users.collection.get",
+        "users.item.get"
+      ]
+    }
+  ],
   "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",
     "dockerPull": false,


### PR DESCRIPTION
[SIP2-108] ( https://issues.folio.org/browse/SIP2-108 )

## Purpose : 

- Add edge-sip2 related permissions in descriptor &  readme file

## Approach :

- Updated module-descriptor & Readme file 


## Verification : 

- Created user in snapshot with the following permissions 

- API used to add permission : 

```
curl --location --request PUT 'https://folio-snapshot-okapi.dev.folio.org/perms/users/901529f0-bf72-42eb-a21d-d95399b12750' \
--header 'X-Okapi-Tenant: diku' \
--header 'Content-Type: application/json' \
--header 'X-Okapi-Token: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJkaWt1X2FkbWluIiwidHlwZSI6ImxlZ2FjeS1hY2Nlc3MiLCJ1c2VyX2lkIjoiMDgxYTdiZDctZmI5ZC01NGY3LWIxZWUtNWE0MWFmM2JjOThmIiwiaWF0IjoxNjY0MzQyNzIwLCJ0ZW5hbnQiOiJkaWt1In0.0IQAYyvtAvE4W1OViKrKsvxpbQ4rnxczardlMWSxMGA' \
--data-raw '{
            "id": "901529f0-bf72-42eb-a21d-d95399b12750",
            "userId": "e2534c16-734b-4083-ae02-a763e65a4e36",
            "permissions": [
                    "circulation.check-in-by-barcode.post",
                    "circulation.check-out-by-barcode.post",
                    "circulation.requests.collection.get",
                    "search.instances.collection.get",
                    "search.instances.ids.collection.get",
                    "circulation.loans.collection.get",
                    "configuration.entries.collection.get",
                    "configuration.entries.item.get",
                    "manualblocks.collection.get",
                    "manualblocks.item.get",
                    "accounts.collection.get",
                    "accounts.item.get",
                    "users.collection.get",
                    "users.item.get"
            ],
            "metadata": {
                "createdDate": "2022-09-27T06:28:47.876+00:00",
                "updatedDate": "2022-03-25T04:55:26.255+00:00"
            }
        }'
```

- Test against the API used in sip2 module ( see collection attachment in jira ) 
