### PR TITLE
[SIP2-124] Logging improvement

### DIFF
--- a/src/main/java/org/folio/edge/sip2/domain/messages/requests/Checkin.java
+++ b/src/main/java/org/folio/edge/sip2/domain/messages/requests/Checkin.java
@@ -60,6 +60,7 @@ public final class Checkin {
     this.cancel = builder.cancel;
   }
 
+
   /**
    * Returns a builder used to construct a {@code Checkin}.
    * @return A checkin builder.
@@ -147,6 +148,23 @@ public final class Checkin {
         .append(", itemProperties=").append(itemProperties)
         .append(", cancel=").append(cancel)
         .append(']').toString();
+  }
+
+  /**
+   * Returns Formatted Log Message.
+   * @return String.
+   */
+  public String getCheckInLogInfo() {
+    return new StringBuilder()
+      .append("Checkin [noBlock=").append(noBlock)
+      .append(", transactionDate=").append(transactionDate)
+      .append(", returnDate=").append(returnDate)
+      .append(", currentLocation=").append(currentLocation)
+      .append(", institutionId=").append(institutionId)
+      .append(", itemIdentifier=").append(itemIdentifier)
+      .append(", itemProperties=").append(itemProperties)
+      .append(", cancel=").append(cancel)
+      .append(']').toString();
   }
 
   /**

--- a/src/main/java/org/folio/edge/sip2/domain/messages/requests/Checkout.java
+++ b/src/main/java/org/folio/edge/sip2/domain/messages/requests/Checkout.java
@@ -187,6 +187,25 @@ public final class Checkout {
   }
 
   /**
+   * Returns Formatted Log Message.
+   * @return String.
+   */
+  public String getCheckOutLogInfo() {
+    return new StringBuilder()
+      .append("Checkout [scRenewalPolicy=").append(scRenewalPolicy)
+      .append(", noBlock=").append(noBlock)
+      .append(", transactionDate=").append(transactionDate)
+      .append(", nbDueDate=").append(nbDueDate)
+      .append(", institutionId=").append(institutionId)
+      .append(", itemIdentifier=").append(itemIdentifier)
+      .append(", patronIdentifier=").append(patronIdentifier)
+      .append(", itemProperties=").append(itemProperties)
+      .append(", feeAcknowledged=").append(feeAcknowledged)
+      .append(", cancel=").append(cancel)
+      .append(']').toString();
+  }
+
+  /**
    * Builder for {@code Checkout}.
    */
   public static class CheckoutBuilder {

--- a/src/main/java/org/folio/edge/sip2/domain/messages/requests/EndPatronSession.java
+++ b/src/main/java/org/folio/edge/sip2/domain/messages/requests/EndPatronSession.java
@@ -107,6 +107,18 @@ public final class EndPatronSession {
   }
 
   /**
+   * Returns Formatted Log Message.
+   * @return String.
+   */
+  public String getPatronSessionLogInfo() {
+    return new StringBuilder()
+      .append("EndPatronSession [transactionDate=").append(transactionDate)
+      .append(", institutionId=").append(institutionId)
+      .append(", patronIdentifier=").append(patronIdentifier)
+      .append(']').toString();
+  }
+
+  /**
    * Builder for {@code EndPatronSession}.
    */
   public static class EndPatronSessionBuilder {

--- a/src/main/java/org/folio/edge/sip2/domain/messages/requests/Login.java
+++ b/src/main/java/org/folio/edge/sip2/domain/messages/requests/Login.java
@@ -107,6 +107,19 @@ public final class Login {
   }
 
   /**
+   * Returns Formatted Log Message.
+   * @return String.
+   */
+  public String getLoginLogInfo() {
+    return new StringBuilder()
+      .append("Login [uidAlgorithm=").append(uidAlgorithm)
+      .append(", pwdAlgorithm=").append(pwdAlgorithm)
+      .append(", loginUserId=").append(loginUserId)
+      .append(", locationCode=").append(locationCode)
+      .append(']').toString();
+  }
+
+  /**
    * Builder for {@code Login}.
    */
   public static class LoginBuilder {

--- a/src/main/java/org/folio/edge/sip2/domain/messages/requests/PatronInformation.java
+++ b/src/main/java/org/folio/edge/sip2/domain/messages/requests/PatronInformation.java
@@ -147,6 +147,22 @@ public final class PatronInformation {
   }
 
   /**
+   * Returns Formatted Log Message.
+   * @return String.
+   */
+  public String getPatronLogInfo() {
+    return new StringBuilder()
+      .append("PatronInformation [language=").append(language)
+      .append(", transactionDate=").append(transactionDate)
+      .append(", summary=").append(summary)
+      .append(", institutionId=").append(institutionId)
+      .append(", patronIdentifier=").append(patronIdentifier)
+      .append(", startItem=").append(startItem)
+      .append(", endItem=").append(endItem)
+      .append(']').toString();
+  }
+
+  /**
    * Builder for {@code PatronInformation}.
    */
   public static class PatronInformationBuilder {

--- a/src/main/java/org/folio/edge/sip2/handlers/CheckinHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/CheckinHandler.java
@@ -35,7 +35,7 @@ public class CheckinHandler implements ISip2RequestHandler {
   public Future<String> execute(Object message, SessionData sessionData) {
     final Checkin checkin = (Checkin) message;
 
-    log.debug("Checkin: {}", () -> checkin);
+    log.info("Checkin: {}", checkin::getCheckInLogInfo);
 
     final Future<CheckinResponse> circulationFuture =
         circulationRepository.performCheckinCommand(checkin, sessionData);

--- a/src/main/java/org/folio/edge/sip2/handlers/CheckoutHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/CheckoutHandler.java
@@ -35,7 +35,7 @@ public class CheckoutHandler implements ISip2RequestHandler {
   public Future<String> execute(Object message, SessionData sessionData) {
     final Checkout checkout = (Checkout) message;
 
-    log.debug("Checkout: {}", () -> checkout);
+    log.info("Checkout: {}", checkout::getCheckOutLogInfo);
 
     final Future<CheckoutResponse> circulationFuture =
         circulationRepository.performCheckoutCommand(checkout, sessionData);

--- a/src/main/java/org/folio/edge/sip2/handlers/EndPatronSessionHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/EndPatronSessionHandler.java
@@ -37,7 +37,7 @@ public class EndPatronSessionHandler implements ISip2RequestHandler {
   public Future<String> execute(Object message, SessionData sessionData) {
 
     final EndPatronSession endPatronSession = (EndPatronSession) message;
-    log.debug("EndPatronSession: {}", () -> endPatronSession);
+    log.info("EndPatronSession: {}", endPatronSession::getPatronSessionLogInfo);
 
     final Future<EndSessionResponse> endPatronSessionFuture =
         patronRepository.performEndPatronSessionCommand(endPatronSession, sessionData);

--- a/src/main/java/org/folio/edge/sip2/handlers/LoginHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/LoginHandler.java
@@ -33,7 +33,7 @@ public class LoginHandler implements ISip2RequestHandler {
   public Future<String> execute(Object message, SessionData sessionData) {
     final Login login = (Login) message;
 
-    log.debug("Login: {}", () -> login);
+    log.info("Login: {}", login::getLoginLogInfo);
 
     final Future<LoginResponse> responseFuture = loginRepository.login(login, sessionData);
 

--- a/src/main/java/org/folio/edge/sip2/handlers/PatronInformationHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/PatronInformationHandler.java
@@ -35,7 +35,7 @@ public class PatronInformationHandler implements ISip2RequestHandler {
   public Future<String> execute(Object message, SessionData sessionData) {
     final PatronInformation patronInformation = (PatronInformation) message;
 
-    log.debug("Patron Information: {}", () -> patronInformation);
+    log.info("Patron Information: {}", patronInformation::getPatronLogInfo);
 
     // We need to collect data from the following places:
     // - mod-users

--- a/src/test/java/org/folio/edge/sip2/domain/messages/requests/CheckinTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/requests/CheckinTests.java
@@ -6,6 +6,7 @@ import static org.folio.edge.sip2.domain.messages.requests.Checkin.builder;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -254,5 +255,6 @@ class CheckinTests {
         .cancel(cancel)
         .build();
     assertEquals(expectedString, ci.toString());
+    assertNotNull(ci.getCheckInLogInfo());
   }
 }

--- a/src/test/java/org/folio/edge/sip2/domain/messages/requests/CheckoutTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/requests/CheckoutTests.java
@@ -6,6 +6,7 @@ import static org.folio.edge.sip2.domain.messages.requests.Checkout.builder;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -362,5 +363,6 @@ class CheckoutTests {
         .cancel(cancel)
         .build();
     assertEquals(expectedString, co.toString());
+    assertNotNull(co.getCheckOutLogInfo());
   }
 }

--- a/src/test/java/org/folio/edge/sip2/domain/messages/requests/EndPatronSessionTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/requests/EndPatronSessionTests.java
@@ -4,6 +4,7 @@ import static org.folio.edge.sip2.domain.messages.requests.EndPatronSession.buil
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -153,5 +154,6 @@ class EndPatronSessionTests {
         .patronPassword(patronPassword)
         .build();
     assertEquals(expectedString, eps.toString());
+    assertNotNull(eps.getPatronSessionLogInfo());
   }
 }

--- a/src/test/java/org/folio/edge/sip2/domain/messages/requests/LoginTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/requests/LoginTests.java
@@ -4,6 +4,7 @@ import static org.folio.edge.sip2.domain.messages.requests.Login.builder;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -144,5 +145,6 @@ class LoginTests {
         .locationCode(locationCode)
         .build();
     assertEquals(expectedString, l.toString());
+    assertNotNull(l.getLoginLogInfo());
   }
 }

--- a/src/test/java/org/folio/edge/sip2/domain/messages/requests/PatronInformationTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/requests/PatronInformationTests.java
@@ -8,6 +8,7 @@ import static org.folio.edge.sip2.domain.messages.requests.PatronInformation.bui
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -272,5 +273,6 @@ class PatronInformationTests {
         .endItem(endItem)
         .build();
     assertEquals(expectedString, pi.toString());
+    assertNotNull(pi.getPatronLogInfo());
   }
 }


### PR DESCRIPTION
SIP2-124 ( https://issues.folio.org/browse/SIP2-124 ) 

#Purpose: 

- SIP2 log currently only logs sip response messages.
- When there are problems, I need to see the sip2 request that was made to troubleshoot the issue.
- May need to consider any requests containing potential sensitive information (such as passwords) - before logging

#Approach 

- Handler level logs now available 
- sensitive information is removed from logs 
