### PR TITLE
[SIP2-127] - Adding missing permission in sip2.all permission set

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ All permission associated with edge-sip2
     accounts.item.get
     users.collection.get
     users.item.get
-    
+    automated-patron-blocks.collection.get
 ```
 
 #### Security concerns for developers

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -47,7 +47,8 @@
         "accounts.collection.get",
         "accounts.item.get",
         "users.collection.get",
-        "users.item.get"
+        "users.item.get",
+        "automated-patron-blocks.collection.get"
       ]
     }
   ],


### PR DESCRIPTION
[SIP2-127] ( https://issues.folio.org/browse/SIP2-127 )

## Purpose : 

- Add missing permission automated-patron-blocks.collection.get in descriptor &  readme file for edge-sip.all permission set.

## Approach :

- Updated module-descriptor & Readme file 

## Verification : 

- Created user in rancher with the following permissions 

- API used to add permission set details in readme.md file.
- Test against the item checkout API used with sip testing tool before and after the permission with the rancher environment.

![image](https://user-images.githubusercontent.com/34331959/195793782-d3c12482-b044-453a-a853-4a0cf7b211d6.png)
