### PR TITLE
SIP2-136

### DIFF
--- a/src/main/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerUtils.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerUtils.java
@@ -5,6 +5,7 @@ import freemarker.template.TemplateException;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.util.HashMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -35,6 +36,13 @@ public class FreemarkerUtils {
       template.process(data, out);
       outputString = out.toString();
     } catch (TemplateException e) {
+      if (data instanceof HashMap) {
+        HashMap<String, Object> dataMap = (HashMap<String, Object>) data;
+        if (dataMap.containsKey("timezone") && (dataMap.get("timezone") == null)) {
+          log.error("The timezone value is set to null. "
+                + "It is advice to configure the localeSettings by invoking SC Status Command.");
+        }
+      }
       log.error("Having problems finding and loading template: {} ", e.getMessage());
     } catch (IOException ioEx) {
       log.error("Having problems applying template to data: {} ", ioEx.getMessage());

--- a/src/main/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerUtils.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerUtils.java
@@ -5,7 +5,6 @@ import freemarker.template.TemplateException;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.util.HashMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -36,13 +35,6 @@ public class FreemarkerUtils {
       template.process(data, out);
       outputString = out.toString();
     } catch (TemplateException e) {
-      if (data instanceof HashMap) {
-        HashMap<String, Object> dataMap = (HashMap<String, Object>) data;
-        if (dataMap.containsKey("timezone") && (dataMap.get("timezone") == null)) {
-          log.error("The timezone value is set to null. "
-                + "It is advice to configure the localeSettings by invoking SC Status Command.");
-        }
-      }
       log.error("Having problems finding and loading template: {} ", e.getMessage());
     } catch (IOException ioEx) {
       log.error("Having problems applying template to data: {} ", ioEx.getMessage());

--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -167,7 +167,7 @@ public class CirculationRepository {
           .otherwise(Utils::handleErrors)
           .compose(res -> addTitleIfNotFound(sessionData, itemIdentifier, res))
           .map(resource -> {
-            log.info("performCheckoutCommand resource:{}",resource.getResource());
+            log.debug("performCheckoutCommand resource:{}",resource.getResource());
             final Optional<JsonObject> response = Optional.ofNullable(resource.getResource());
 
             final OffsetDateTime dueDate = response
@@ -525,8 +525,6 @@ public class CirculationRepository {
   }
 
   private class ItemRequestData extends SearchRequestData {
-    private static final String basePath = "/search/instances?limit=1&query=";
-
     private String itemBarcode;
 
     private ItemRequestData(JsonObject body, Map<String, String> headers,
@@ -539,7 +537,7 @@ public class CirculationRepository {
     public String getPath() {
 
       final StringBuilder qSb = new StringBuilder()
-          .append(basePath)
+          .append("/search/instances?limit=1&query=")
           .append("(items.barcode")
           .append("==")
           .append(itemBarcode).append(")");
@@ -549,8 +547,8 @@ public class CirculationRepository {
 
   private abstract class SearchRequestData implements IRequestData {
     private final JsonObject body;
-    private final Integer startItem;
-    private final Integer endItem;
+    final Integer startItem;
+    final Integer endItem;
     private final Map<String, String> headers;
     private final SessionData sessionData;
 

--- a/src/main/java/org/folio/edge/sip2/session/SessionData.java
+++ b/src/main/java/org/folio/edge/sip2/session/SessionData.java
@@ -1,5 +1,7 @@
 package org.folio.edge.sip2.session;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.sip2.domain.PreviousMessage;
 
 
@@ -18,8 +20,11 @@ public class SessionData {
   private String timeZone;
   private boolean patronPasswordVerificationRequired;
 
+  private static final Logger log = LogManager.getLogger();
+  private static final String DEFAULT_TIMEZONE = "Etc/UTC";
+
   private SessionData(String tenant, char fieldDelimiter,
-      boolean errorDetectionEnabled, String charset) {
+                      boolean errorDetectionEnabled, String charset) {
     this.tenant = tenant;
     this.fieldDelimiter = fieldDelimiter;
     this.errorDetectionEnabled = errorDetectionEnabled;
@@ -91,10 +96,18 @@ public class SessionData {
   }
 
   public String getTimeZone() {
-    return timeZone;
+    return timeZone != null ? timeZone : DEFAULT_TIMEZONE;
   }
 
+  /**
+   * Set the time zone.
+   * timeZone The timeZone value.
+   */
   public void setTimeZone(String timeZone) {
+    if (timeZone == null) {
+      log.warn("The timezone value is null and therefore "
+          + "default value {} will be used.", DEFAULT_TIMEZONE);
+    }
     this.timeZone = timeZone;
   }
 
@@ -107,8 +120,8 @@ public class SessionData {
   }
 
   public static SessionData createSession(String tenant, char fieldDelimiter,
-      boolean errorDetectionEnabled, String charset) {
+                                          boolean errorDetectionEnabled, String charset) {
     return new SessionData(tenant, fieldDelimiter, errorDetectionEnabled,
-        charset);
+      charset);
   }
 }

--- a/src/test/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerUtilsTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerUtilsTests.java
@@ -10,9 +10,9 @@ import org.folio.edge.sip2.parser.Command;
 import org.junit.jupiter.api.Test;
 
 
-public class FreemarkerUtilsTests {
+class FreemarkerUtilsTests {
   @Test
-  public void cannotExecuteFreemarkerTemplateGivenNullData() {
+  void cannotExecuteFreemarkerTemplateGivenNullData() {
     Template acsStatusTemplate = FreemarkerRepository.getInstance()
                                     .getFreemarkerTemplate(Command.ACS_STATUS);
     String result = FreemarkerUtils.executeFreemarkerTemplate(null, acsStatusTemplate);
@@ -20,7 +20,7 @@ public class FreemarkerUtilsTests {
   }
 
   @Test
-  public void cannotExecuteFreemarkerTemplateGivenInvalidData() {
+  void cannotExecuteFreemarkerTemplateGivenInvalidData() {
     Object data = new Date(); //give it some bogus class
     Template acsStatusTemplate = FreemarkerRepository.getInstance()
                                     .getFreemarkerTemplate(Command.ACS_STATUS);
@@ -28,19 +28,4 @@ public class FreemarkerUtilsTests {
     assertEquals("", result);
   }
 
-  @Test
-  public void cannotExecuteFreemarkerTemplateGivenInvalidTimeZone() {
-    final Map<String, Object> root = new HashMap<>();
-    root.put("formatDateTime", new FormatDateTimeMethodModel());
-    root.put("delimiter", "|");
-    root.put("checkoutResponse", null);
-    root.put("timezone", null);
-
-    Template acsStatusTemplate = FreemarkerRepository.getInstance()
-        .getFreemarkerTemplate(Command.ACS_STATUS);
-
-    final String response = FreemarkerUtils.executeFreemarkerTemplate(root, acsStatusTemplate);
-
-    assertEquals("", response);
-  }
 }

--- a/src/test/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerUtilsTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerUtilsTests.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import freemarker.template.Template;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 import org.folio.edge.sip2.parser.Command;
 import org.junit.jupiter.api.Test;
 
@@ -24,5 +26,21 @@ public class FreemarkerUtilsTests {
                                     .getFreemarkerTemplate(Command.ACS_STATUS);
     String result = FreemarkerUtils.executeFreemarkerTemplate(data, acsStatusTemplate);
     assertEquals("", result);
+  }
+
+  @Test
+  public void cannotExecuteFreemarkerTemplateGivenInvalidTimeZone() {
+    final Map<String, Object> root = new HashMap<>();
+    root.put("formatDateTime", new FormatDateTimeMethodModel());
+    root.put("delimiter", "|");
+    root.put("checkoutResponse", null);
+    root.put("timezone", null);
+
+    Template acsStatusTemplate = FreemarkerRepository.getInstance()
+        .getFreemarkerTemplate(Command.ACS_STATUS);
+
+    final String response = FreemarkerUtils.executeFreemarkerTemplate(root, acsStatusTemplate);
+
+    assertEquals("", response);
   }
 }

--- a/src/test/java/org/folio/edge/sip2/session/SessionDataTests.java
+++ b/src/test/java/org/folio/edge/sip2/session/SessionDataTests.java
@@ -2,6 +2,7 @@ package org.folio.edge.sip2.session;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
@@ -139,6 +140,12 @@ class SessionDataTests {
     assertEquals("America/Chicago", sessionData.getTimeZone());
   }
 
+  @Test
+  void testSetNullTimeZone() {
+    sessionData.setTimeZone(null);
+    assertEquals("Etc/UTC", sessionData.getTimeZone());
+  }
+
 
   @Test
   void testGetPatronPasswordVerificationRequired() {
@@ -186,7 +193,7 @@ class SessionDataTests {
     assertNull(newSessionData.getScLocation());
     assertNull(newSessionData.getUsername());
     assertNull(newSessionData.getPreviousMessage());
-    assertNull(newSessionData.getTimeZone());
+    assertNotNull(newSessionData.getTimeZone());
     assertFalse(newSessionData.isPatronPasswordVerificationRequired());
   }
 }


### PR DESCRIPTION
## Purpose
The purpose of this PR is to review the code for [SIP2-136](https://issues.folio.org/browse/SIP2-136) in which it has been decided that if the timeZone value is null then use the Default value as "Etc/UTC". 
Also, if while setting the timeZone value from localeSetting is null then a warning message will be printed in the logs and the default value (UTC) will be used as required.

## Approach
The sessionData is the place where the timeZone value is set/get. Based on the timezone's null check the default/non-default value is returned. 

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.
   - [x] Check logging.

 If there are breaking changes, please **STOP** and consider the following:

 - What other modules will these changes impact?
 - Do JIRAs exist to update the impacted modules?
   - [ ] If not, please create them
   - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
   - [ ] Do they have all they appropriate links to blocked/related issues?
 - Are the JIRAs under active development?
   - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
 - Do PRs exist for these changes?
   - [ ] If so, have they been approved?

## Evidence -
When SC status command is not invoked the CheckoutCommand functions with out any issue - 
The highlighted section yellow is the checkOut command. The red underline is the SC status command which was triggered after checkout command. 
![image](https://user-images.githubusercontent.com/34331959/218020242-ec7679d3-ed1c-463e-8f34-e935c5bb23ee.png)

Test method with timeZone value as null in localeConfig -- 
![image](https://user-images.githubusercontent.com/34331959/218021268-5b87bec4-edd5-481f-b22b-27f9807a7b5e.png)

