### PR TITLE
[SIP2-121] - SIP2: Renew response

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 3.1.0 Draft
+* [SIP2-121](https://issues.folio.org/browse/SIP2-121): SIP2: Renew response
+
 ## 3.0.0 2023-02-23
 * [SIP2-123](https://issues.folio.org/browse/SIP2-123): SIP2: Item Information Response
 * [SIP2-125](https://issues.folio.org/browse/SIP2-125): Logging improvement

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ All permission associated with edge-sip2
     users.item.get
     automated-patron-blocks.collection.get
     inventory.items.collection.get
+    circulation.renew-by-barcode.post
 ```
 
 #### Security concerns for developers

--- a/src/main/java/org/folio/edge/sip2/MainVerticle.java
+++ b/src/main/java/org/folio/edge/sip2/MainVerticle.java
@@ -7,6 +7,7 @@ import static org.folio.edge.sip2.parser.Command.END_PATRON_SESSION;
 import static org.folio.edge.sip2.parser.Command.ITEM_INFORMATION;
 import static org.folio.edge.sip2.parser.Command.LOGIN;
 import static org.folio.edge.sip2.parser.Command.PATRON_INFORMATION;
+import static org.folio.edge.sip2.parser.Command.RENEW;
 import static org.folio.edge.sip2.parser.Command.REQUEST_ACS_RESEND;
 import static org.folio.edge.sip2.parser.Command.REQUEST_SC_RESEND;
 import static org.folio.edge.sip2.parser.Command.SC_STATUS;
@@ -42,6 +43,7 @@ import org.folio.edge.sip2.handlers.ISip2RequestHandler;
 import org.folio.edge.sip2.handlers.ItemInformationHandler;
 import org.folio.edge.sip2.handlers.LoginHandler;
 import org.folio.edge.sip2.handlers.PatronInformationHandler;
+import org.folio.edge.sip2.handlers.RenewHandler;
 import org.folio.edge.sip2.metrics.Metrics;
 import org.folio.edge.sip2.modules.ApplicationModule;
 import org.folio.edge.sip2.modules.FolioResourceProviderModule;
@@ -78,7 +80,7 @@ public class MainVerticle extends AbstractVerticle {
 
   @Override
   public void start(Promise<Void> startFuture) {
-    log.debug("Startup configuration: {}", () -> getSanitizedConfig());
+    log.debug("Startup configuration: {}", this::getSanitizedConfig);
 
     // We need to reduce the complexity of this method...
     if (handlers == null) {
@@ -98,6 +100,7 @@ public class MainVerticle extends AbstractVerticle {
       handlers.put(REQUEST_SC_RESEND, HandlersFactory.getInvalidMessageHandler());
       handlers.put(END_PATRON_SESSION, injector.getInstance(EndPatronSessionHandler.class));
       handlers.put(ITEM_INFORMATION, injector.getInstance(ItemInformationHandler.class));
+      handlers.put(RENEW,  injector.getInstance(RenewHandler.class));
     }
 
     //set Config object's defaults
@@ -175,7 +178,7 @@ public class MainVerticle extends AbstractVerticle {
           ISip2RequestHandler handler = handlers.get(command);
 
           if (handler == null) {
-            log.error("Error locating handler for command; " + command.name());
+            log.error("Error locating handler for command {}", command.name());
             sample.stop(metrics.commandTimer(command));
             return;
           }

--- a/src/main/java/org/folio/edge/sip2/handlers/RenewHandler.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/RenewHandler.java
@@ -1,0 +1,60 @@
+package org.folio.edge.sip2.handlers;
+
+import freemarker.template.Template;
+import io.vertx.core.Future;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.edge.sip2.domain.messages.requests.Renew;
+import org.folio.edge.sip2.domain.messages.responses.RenewResponse;
+import org.folio.edge.sip2.handlers.freemarker.FormatDateTimeMethodModel;
+import org.folio.edge.sip2.handlers.freemarker.FreemarkerUtils;
+import org.folio.edge.sip2.repositories.CirculationRepository;
+import org.folio.edge.sip2.session.SessionData;
+
+public class RenewHandler implements ISip2RequestHandler {
+  private static final Logger log = LogManager.getLogger();
+
+  private final CirculationRepository circulationRepository;
+  private final Template commandTemplate;
+
+  @Inject
+  RenewHandler(
+      CirculationRepository circulationRepository,
+        @Named("renewResponse") Template commandTemplate) {
+    this.circulationRepository = Objects.requireNonNull(circulationRepository,
+        "CirculationRepository cannot be null");
+    this.commandTemplate = Objects.requireNonNull(commandTemplate, "Template cannot be null");
+  }
+
+  @Override
+  public Future<String> execute(Object message, SessionData sessionData) {
+    final Renew renew = (Renew) message;
+
+    log.debug("Renew: {}", () -> renew);
+
+    final Future<RenewResponse> renewFuture =
+        circulationRepository.performRenewCommand(renew, sessionData);
+
+    return renewFuture.compose(renewResponse -> {
+      log.info("RenewResponse: {}", () -> renewResponse);
+
+      final Map<String, Object> root = new HashMap<>();
+      root.put("formatDateTime", new FormatDateTimeMethodModel());
+      root.put("delimiter", sessionData.getFieldDelimiter());
+      root.put("renewResponse", renewResponse);
+      root.put("timezone", sessionData.getTimeZone());
+
+      final String response = FreemarkerUtils
+          .executeFreemarkerTemplate(root, commandTemplate);
+
+      log.debug("SIP renew response: {}", response);
+
+      return Future.succeededFuture(response);
+    });
+  }
+}

--- a/src/main/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerRepository.java
+++ b/src/main/java/org/folio/edge/sip2/handlers/freemarker/FreemarkerRepository.java
@@ -7,6 +7,7 @@ import static org.folio.edge.sip2.parser.Command.END_SESSION_RESPONSE;
 import static org.folio.edge.sip2.parser.Command.ITEM_INFORMATION_RESPONSE;
 import static org.folio.edge.sip2.parser.Command.LOGIN_RESPONSE;
 import static org.folio.edge.sip2.parser.Command.PATRON_INFORMATION_RESPONSE;
+import static org.folio.edge.sip2.parser.Command.RENEW_RESPONSE;
 import static org.folio.edge.sip2.parser.Command.REQUEST_SC_RESEND;
 
 import freemarker.template.Configuration;
@@ -68,6 +69,7 @@ public class FreemarkerRepository {
     addTemplate(PATRON_INFORMATION_RESPONSE, "PatronInformationResponse.ftl", configuration);
     addTemplate(END_SESSION_RESPONSE, "EndSessionResponse.ftl", configuration);
     addTemplate(ITEM_INFORMATION_RESPONSE, "ItemInformationResponse.ftl", configuration);
+    addTemplate(RENEW_RESPONSE, "RenewResponse.ftl", configuration);
   }
 
   private void addTemplate(Command commmand, String templateName, Configuration configuration) {

--- a/src/main/java/org/folio/edge/sip2/modules/ApplicationModule.java
+++ b/src/main/java/org/folio/edge/sip2/modules/ApplicationModule.java
@@ -6,6 +6,7 @@ import static org.folio.edge.sip2.parser.Command.END_SESSION_RESPONSE;
 import static org.folio.edge.sip2.parser.Command.ITEM_INFORMATION_RESPONSE;
 import static org.folio.edge.sip2.parser.Command.LOGIN_RESPONSE;
 import static org.folio.edge.sip2.parser.Command.PATRON_INFORMATION_RESPONSE;
+import static org.folio.edge.sip2.parser.Command.RENEW_RESPONSE;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
@@ -79,4 +80,11 @@ public class ApplicationModule extends AbstractModule {
   Template provideItemInformationResponseTemplate() {
     return FreemarkerRepository.getInstance().getFreemarkerTemplate(ITEM_INFORMATION_RESPONSE);
   }
+
+  @Provides
+  @Named("renewResponse")
+  Template renewResponseTemplate() {
+    return FreemarkerRepository.getInstance().getFreemarkerTemplate(RENEW_RESPONSE);
+  }
+
 }

--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -536,6 +536,17 @@ public class CirculationRepository {
    */
   public Future<RenewResponse> performRenewCommand(Renew renew,
                                                    SessionData sessionData) {
+    if (renew.getItemIdentifier() == null && renew.getTitleIdentifier() == null) {
+      return Future.succeededFuture(RenewResponse.builder()
+        .ok(FALSE)
+        .transactionDate(OffsetDateTime.now(clock))
+        .institutionId(renew.getInstitutionId())
+        .screenMessage(Arrays.asList("Either or both of the 'item identifier' or "
+           + "'title identifier' fields must be present for the message to"
+           + " be useful."))
+        .build());
+    }
+
     final String institutionId = renew.getInstitutionId();
     final String patronIdentifier = renew.getPatronIdentifier();
     final String patronPassword = renew.getPatronPassword();
@@ -588,7 +599,6 @@ public class CirculationRepository {
               .patronIdentifier(patronIdentifier)
               .itemIdentifier(barcode)
               .titleIdentifier(instanceId)
-
               .dueDate(dueDate)
               .screenMessage(Optional.of(resource.getErrorMessages())
                 .filter(v -> !v.isEmpty())

--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -539,6 +539,7 @@ public class CirculationRepository {
     if (renew.getItemIdentifier() == null && renew.getTitleIdentifier() == null) {
       return Future.succeededFuture(RenewResponse.builder()
         .ok(FALSE)
+        .renewalOk(FALSE)
         .transactionDate(OffsetDateTime.now(clock))
         .institutionId(renew.getInstitutionId())
         .screenMessage(Arrays.asList("Either or both of the 'item identifier' or "
@@ -557,6 +558,7 @@ public class CirculationRepository {
         if (FALSE.equals(verification.getPasswordVerified())) {
           return Future.succeededFuture(RenewResponse.builder()
             .ok(FALSE)
+            .renewalOk(FALSE)
             .transactionDate(OffsetDateTime.now(clock))
             .institutionId(institutionId)
             .screenMessage(verification.getErrorMessages())

--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -542,7 +542,7 @@ public class CirculationRepository {
         .renewalOk(FALSE)
         .transactionDate(OffsetDateTime.now(clock))
         .institutionId(renew.getInstitutionId())
-        .screenMessage(Arrays.asList("Either or both of the 'item identifier' or "
+        .screenMessage(Collections.singletonList("Either or both of the 'item identifier' or "
            + "'title identifier' fields must be present for the message to"
            + " be useful."))
         .build());

--- a/src/main/resources/templates/RenewResponse.ftl
+++ b/src/main/resources/templates/RenewResponse.ftl
@@ -15,11 +15,9 @@
 <#-- institution id: variable-length required field -->
 <@lib.institutionId value=renewResponse.institutionId/>
 <#-- patron identifier: variable-length required field -->
-<@lib.patronIdentifier value=renewResponse.patronIdentifier/>
-<#-- item identifier: variable-length required field -->
-<@lib.itemIdentifier value=renewResponse.itemIdentifier/>
+<@lib.patronIdentifier value=renewResponse.patronIdentifier!""/>
 <#-- title identifier: variable-length required field -->
-<@lib.titleIdentifier value=renewResponse.titleIdentifier/>
+<@lib.titleIdentifier value=renewResponse.titleIdentifier!""/>
 <#-- due date: variable-length required field -->
 <@lib.dueDate value=renewResponse.dueDate!""/>
 <#--
@@ -38,8 +36,6 @@
 <@lib.feeAmount value=renewResponse.feeAmount!""/>
 <#-- media type: 3-char, fixed-length optional field -->
 <@lib.mediaType value=renewResponse.mediaType!""/>
-<#-- item properties: variable-length optional field -->
-<@lib.itemProperties value=renewResponse.itemProperties!""/>
 <#--
     transaction id: variable-length optional field
     May be assigned by the ACS when renewing the item involves a fee

--- a/src/test/java/org/folio/edge/sip2/domain/messages/requests/RenewTests.java
+++ b/src/test/java/org/folio/edge/sip2/domain/messages/requests/RenewTests.java
@@ -5,9 +5,8 @@ import static java.lang.Boolean.TRUE;
 import static org.folio.edge.sip2.domain.messages.requests.Renew.builder;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Test;
@@ -292,8 +291,7 @@ class RenewTests {
         .itemProperties(itemProperties)
         .feeAcknowledged(feeAcknowledged)
         .build();
-    assertTrue(r1.equals(r2));
-    assertTrue(r1.equals(r2));
+    assertEquals(r1, r2);
   }
 
   @Test
@@ -326,8 +324,7 @@ class RenewTests {
         .itemProperties("Give me a book!")
         .feeAcknowledged(FALSE)
         .build();
-    assertFalse(r1.equals(r2));
-    assertFalse(r1.equals(r2));
+    assertNotEquals(r1, r2);
   }
 
   @Test


### PR DESCRIPTION
## Purpose
The purpose of this ticket is to implement renew command in SIP2. https://issues.folio.org/browse/SIP2-121

## Approach
Relevant code is added to handle the Renew an item command, which would handle the command to respond with renew response message as per the specifications laid down in 3M SIP2 document.

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.
   - [x] Check logging.

 If there are breaking changes, please **STOP** and consider the following:

 - What other modules will these changes impact?
 - Do JIRAs exist to update the impacted modules?
   - [ ] If not, please create them
   - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
   - [ ] Do they have all they appropriate links to blocked/related issues?
 - Are the JIRAs under active development?
   - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
 - Do PRs exist for these changes?
   - [ ] If so, have they been approved?

## Testing evidences
Renew command succeeded -- 
![image](https://user-images.githubusercontent.com/34331959/223644760-3a2ff23b-2bfc-4db4-ba1f-4837627acd0f.png)

Renew command not succeeded --
![image](https://user-images.githubusercontent.com/34331959/223644973-e940f0ac-d80f-4bf7-b5dc-f5ad7ac0506d.png)

