### PR TITLE
[SIP2-161] - Adding default security marker value 00 Other.

### DIFF
--- a/src/main/resources/templates/ItemInformationResponse.ftl
+++ b/src/main/resources/templates/ItemInformationResponse.ftl
@@ -3,7 +3,7 @@
 <#-- circulation Status: 2-char, fixed-length required field: 00 thru 99 -->
 <@lib.circulationStatus value=itemInformationResponse.circulationStatus/>
 <#-- security Marker: 2-char, fixed-length required field: 00 thru 99-->
-<@lib.securityMarker value=itemInformationResponse.securityMarker!""/>
+<@lib.securityMarker value=itemInformationResponse.securityMarker!"OTHER"/>
 <#--
     fee type: 2-char, fixed-length optional field (01 thru 99)
     The type of fee associated with checking out this item

--- a/src/test/java/org/folio/edge/sip2/handlers/ItemInformationHandlerTests.java
+++ b/src/test/java/org/folio/edge/sip2/handlers/ItemInformationHandlerTests.java
@@ -56,7 +56,7 @@ class ItemInformationHandlerTests {
 
     handler.execute(itemInformation, sessionData).onComplete(
         testContext.succeeding(sipMessage -> testContext.verify(() -> {
-          final String expectedString = "180301"
+          final String expectedString = "18030001"
               + TestUtils.getFormattedLocalDateTime(OffsetDateTime.now(clock))
               + "AB" + itemIdentifier + "|AJ|AQMain Library|AP|";
 


### PR DESCRIPTION
<!--
   If you have a relevant JIRA issue number, please put it in the issue title.
   Example: MODQM-3 - Implement GET records-editor/marc-records/{id} endpoint

   TL;DR
     - https://www.youtube.com/watch?v=5aHmO_S8FQ4
     - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
     - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
 -->

## Purpose
The purpose of this PR is to cater to expectation laid down in SIP2-161 - Item Information Response is not formed as the standard is defined.  Only two of the three required 2-digits fields are actually exposed. It seems that security marker is not exposed. The hard coded default value 00 should be set for Security Marker.
 <!--
   Why are you making this change? There is nothing more important
   to provide to the reviewer and to future readers than the cause
   that gave rise to this pull request. Be careful to avoid circular
   statements like "the purpose is to update the schema." and
   instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
   which is currently missing in the schema"

   The purpose may seem self-evident to you now, but the standard to
   hold yourself to should be "can a developer parachuting into this
   project reconstruct the necessary context merely by reading this
   section."

   If you have a relevant JIRA issue, add a link directly to the issue URL here.
   Example: https://issues.folio.org/browse/MODQM-3
  -->

## Approach
Code changes made in itemInformationResposen.ftl file to default the value of Security Marker to 00.
 <!--
  How does this change fulfill the purpose? It's best to talk
  high-level strategy and avoid code-splaining the commit history.

  The goal is not only to explain what you did, but help other
  developers *work* with your solution in the future.
 -->

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.
   - [ ] Check logging.

 If there are breaking changes, please **STOP** and consider the following:

 - What other modules will these changes impact?
 - Do JIRAs exist to update the impacted modules?
   - [ ] If not, please create them
   - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
   - [ ] Do they have all they appropriate links to blocked/related issues?
 - Are the JIRAs under active development?
   - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
 - Do PRs exist for these changes?
   - [ ] If so, have they been approved?

 Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

 While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
