### PR TITLE
SIP2-178: Vert.x 4.4.6 fixing Netty HTTP/2 DoS (CVE-2023-44487)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <exec.mainClass>org.folio.edge.sip2.MainVerticle</exec.mainClass>
-    <vertx.version>4.3.4</vertx.version>
+    <vertx.version>4.4.6</vertx.version>
     <log4j2.version>2.19.0</log4j2.version>
     <micrometer.version>1.9.4</micrometer.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -51,6 +51,13 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>${log4j2.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
@@ -69,13 +76,6 @@
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
         <version>5.8.2</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-bom</artifactId>
-        <version>${log4j2.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -122,7 +122,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Upgrade Vert.x from 4.3.4 to 4.4.6. This indirectly upgrades Netty from 4.1.82.Final to 4.1.100.Final fixing HTTP/2 Denial of Service (DoS): https://nvd.nist.gov/vuln/detail/CVE-2023-44487

log4j-bom must be listed before vertx-stack-depchain in `<dependencyManagement>` so that log4j-bom overwrites the log4j versions from vertx-stack-depchain; otherwise version mismatches result in class not found exceptions.

For log4j 2.19.0 log4j-slf4j-impl won't work, only log4j-slf4j2-impl.