### PR TITLE
[SIP2-200-1] Enable TLS on WebClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http</artifactId>
+      <version>4.1.107.Final</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.folio.okapi</groupId>
       <artifactId>okapi-common</artifactId>
       <version>5.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>4.1.107.Final</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/folio/edge/sip2/MainVerticle.java
+++ b/src/main/java/org/folio/edge/sip2/MainVerticle.java
@@ -66,6 +66,7 @@ import org.folio.edge.sip2.parser.Message;
 import org.folio.edge.sip2.parser.Parser;
 import org.folio.edge.sip2.session.SessionData;
 import org.folio.edge.sip2.utils.TenantUtils;
+import org.folio.edge.sip2.utils.WebClientUtils;
 
 public class MainVerticle extends AbstractVerticle {
 
@@ -324,30 +325,7 @@ public class MainVerticle extends AbstractVerticle {
   private void setupHanlders() {
     if (handlers == null) {
       String okapiUrl = config().getString("okapiUrl");
-      JsonObject jsonObject = config().getJsonObject("netServerOptions", new JsonObject());
-
-      final WebClient webClient;
-      if (!jsonObject.containsKey("pemKeyCertOptions") && Objects.nonNull(jsonObject.getJsonObject("pemKeyCertOptions"))) {
-        @SuppressWarnings("unchecked")
-        Optional<String> optionalCertPath = jsonObject.getJsonObject("pemKeyCertOptions")
-          .getJsonArray("certPaths")
-          .getList()
-          .stream()
-          .findAny();
-        if (optionalCertPath.isEmpty()) {
-          throw new RuntimeException("TLS certPaths is not found in config");
-        }
-
-        final PemTrustOptions pemTrustOptions = new PemTrustOptions();
-        pemTrustOptions.addCertPath(optionalCertPath.get());
-        final WebClientOptions webClientOptions = new WebClientOptions()
-          .setSsl(true)
-          .setTrustOptions(pemTrustOptions);
-        webClient = WebClient.create(vertx, webClientOptions);
-      } else {
-        webClient = WebClient.create(vertx);
-      }
-
+      final WebClient webClient = WebClientUtils.create(vertx, config());
       final Injector injector = Guice.createInjector(
           new FolioResourceProviderModule(okapiUrl, webClient),
           new ApplicationModule());

--- a/src/main/java/org/folio/edge/sip2/MainVerticle.java
+++ b/src/main/java/org/folio/edge/sip2/MainVerticle.java
@@ -25,7 +25,6 @@ import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.pointer.JsonPointer;
 import io.vertx.core.net.NetServer;

--- a/src/main/java/org/folio/edge/sip2/MainVerticle.java
+++ b/src/main/java/org/folio/edge/sip2/MainVerticle.java
@@ -37,7 +37,6 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;

--- a/src/main/java/org/folio/edge/sip2/MainVerticle.java
+++ b/src/main/java/org/folio/edge/sip2/MainVerticle.java
@@ -30,7 +30,6 @@ import io.vertx.core.json.pointer.JsonPointer;
 import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetServerOptions;
 import io.vertx.core.net.NetSocket;
-import io.vertx.core.net.PemTrustOptions;
 import io.vertx.core.parsetools.RecordParser;
 import io.vertx.ext.web.client.WebClient;
 import java.nio.charset.Charset;
@@ -38,9 +37,7 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
-import io.vertx.ext.web.client.WebClientOptions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;

--- a/src/main/java/org/folio/edge/sip2/utils/WebClientConfigException.java
+++ b/src/main/java/org/folio/edge/sip2/utils/WebClientConfigException.java
@@ -1,0 +1,8 @@
+package org.folio.edge.sip2.utils;
+
+public class WebClientConfigException extends RuntimeException {
+
+  public WebClientConfigException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/folio/edge/sip2/utils/WebClientUtils.java
+++ b/src/main/java/org/folio/edge/sip2/utils/WebClientUtils.java
@@ -31,7 +31,7 @@ public class WebClientUtils {
       JsonArray certPaths = netServerOptions.getJsonObject(SYS_PEM_KEY_CERT_OPTIONS)
         .getJsonArray(SYS_CERT_PATHS);
       if (Objects.isNull(certPaths)) {
-        throw new RuntimeException("No TLS certPaths were added into the PemTrustOptions");
+        throw new RuntimeException("No TLS certPaths were found in config");
       }
 
       final PemTrustOptions pemTrustOptions = new PemTrustOptions();

--- a/src/main/java/org/folio/edge/sip2/utils/WebClientUtils.java
+++ b/src/main/java/org/folio/edge/sip2/utils/WebClientUtils.java
@@ -3,13 +3,12 @@ package org.folio.edge.sip2.utils;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import java.util.Objects;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import java.util.Objects;
 
 public class WebClientUtils {
 
@@ -22,10 +21,16 @@ public class WebClientUtils {
   private WebClientUtils() {
   }
 
+  /**
+   * Create WebClient with TLS
+   * @param vertx instance
+   * @param config json config
+   * @return WebClient
+   */
   public static WebClient create(Vertx vertx, JsonObject config) {
     JsonObject netServerOptions = config.getJsonObject(SYS_NET_SERVER_OPTIONS);
-    if (Objects.nonNull(netServerOptions) &&
-      netServerOptions.containsKey(SYS_PEM_KEY_CERT_OPTIONS)) {
+    if (Objects.nonNull(netServerOptions)
+        && netServerOptions.containsKey(SYS_PEM_KEY_CERT_OPTIONS)) {
       log.info("Creating WebClient with TLS on...");
 
       JsonArray certPaths = netServerOptions.getJsonObject(SYS_PEM_KEY_CERT_OPTIONS)

--- a/src/main/java/org/folio/edge/sip2/utils/WebClientUtils.java
+++ b/src/main/java/org/folio/edge/sip2/utils/WebClientUtils.java
@@ -48,7 +48,7 @@ public class WebClientUtils {
           .setTrustOptions(pemTrustOptions);
       return WebClient.create(vertx, webClientOptions);
     } else {
-      log.info("Creating WebClient without TLS off...");
+      log.info("Creating WebClient with TLS off...");
       return WebClient.create(vertx);
     }
   }

--- a/src/main/java/org/folio/edge/sip2/utils/WebClientUtils.java
+++ b/src/main/java/org/folio/edge/sip2/utils/WebClientUtils.java
@@ -38,8 +38,8 @@ public class WebClientUtils {
       certPaths.forEach(entry -> pemTrustOptions.addCertPath((String) entry));
 
       final WebClientOptions webClientOptions = new WebClientOptions()
-        .setSsl(true)
-        .setTrustOptions(pemTrustOptions);
+          .setSsl(true)
+          .setTrustOptions(pemTrustOptions);
       return WebClient.create(vertx, webClientOptions);
     } else {
       log.info("Creating WebClient without TLS off...");

--- a/src/main/java/org/folio/edge/sip2/utils/WebClientUtils.java
+++ b/src/main/java/org/folio/edge/sip2/utils/WebClientUtils.java
@@ -17,7 +17,6 @@ public class WebClientUtils {
   public static final String SYS_NET_SERVER_OPTIONS = "netServerOptions";
   public static final String SYS_PEM_KEY_CERT_OPTIONS = "pemKeyCertOptions";
   public static final String SYS_CERT_PATHS = "certPaths";
-
   private static final Logger log = LogManager.getLogger();
 
   private WebClientUtils() {
@@ -25,11 +24,12 @@ public class WebClientUtils {
 
   public static WebClient create(Vertx vertx, JsonObject config) {
     JsonObject netServerOptions = config.getJsonObject(SYS_NET_SERVER_OPTIONS);
-    if (Objects.nonNull(netServerOptions) && netServerOptions.containsKey(SYS_PEM_KEY_CERT_OPTIONS)) {
+    if (Objects.nonNull(netServerOptions) &&
+      netServerOptions.containsKey(SYS_PEM_KEY_CERT_OPTIONS)) {
       log.info("Creating WebClient with TLS on...");
 
       JsonArray certPaths = netServerOptions.getJsonObject(SYS_PEM_KEY_CERT_OPTIONS)
-        .getJsonArray(SYS_CERT_PATHS);
+          .getJsonArray(SYS_CERT_PATHS);
       if (Objects.isNull(certPaths)) {
         throw new RuntimeException("No TLS certPaths were found in config");
       }

--- a/src/main/java/org/folio/edge/sip2/utils/WebClientUtils.java
+++ b/src/main/java/org/folio/edge/sip2/utils/WebClientUtils.java
@@ -3,12 +3,13 @@ package org.folio.edge.sip2.utils;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import java.util.Objects;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
+import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
 
 public class WebClientUtils {
 
@@ -22,7 +23,7 @@ public class WebClientUtils {
   }
 
   /**
-   * Create WebClient with TLS
+   * Create WebClient with TLS.
    * @param vertx instance
    * @param config json config
    * @return WebClient

--- a/src/main/java/org/folio/edge/sip2/utils/WebClientUtils.java
+++ b/src/main/java/org/folio/edge/sip2/utils/WebClientUtils.java
@@ -37,7 +37,7 @@ public class WebClientUtils {
       JsonArray certPaths = netServerOptions.getJsonObject(SYS_PEM_KEY_CERT_OPTIONS)
           .getJsonArray(SYS_CERT_PATHS);
       if (Objects.isNull(certPaths)) {
-        throw new RuntimeException("No TLS certPaths were found in config");
+        throw new WebClientConfigException("No TLS certPaths were found in config");
       }
 
       final PemTrustOptions pemTrustOptions = new PemTrustOptions();

--- a/src/main/java/org/folio/edge/sip2/utils/WebClientUtils.java
+++ b/src/main/java/org/folio/edge/sip2/utils/WebClientUtils.java
@@ -36,7 +36,7 @@ public class WebClientUtils {
 
       JsonArray certPaths = netServerOptions.getJsonObject(SYS_PEM_KEY_CERT_OPTIONS)
           .getJsonArray(SYS_CERT_PATHS);
-      if (Objects.isNull(certPaths)) {
+      if (Objects.isNull(certPaths) || certPaths.isEmpty()) {
         throw new WebClientConfigException("No TLS certPaths were found in config");
       }
 

--- a/src/main/java/org/folio/edge/sip2/utils/WebClientUtils.java
+++ b/src/main/java/org/folio/edge/sip2/utils/WebClientUtils.java
@@ -1,0 +1,49 @@
+package org.folio.edge.sip2.utils;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.PemTrustOptions;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Objects;
+
+public class WebClientUtils {
+
+  public static final String SYS_PORT = "port";
+  public static final String SYS_NET_SERVER_OPTIONS = "netServerOptions";
+  public static final String SYS_PEM_KEY_CERT_OPTIONS = "pemKeyCertOptions";
+  public static final String SYS_CERT_PATHS = "certPaths";
+
+  private static final Logger log = LogManager.getLogger();
+
+  private WebClientUtils() {
+  }
+
+  public static WebClient create(Vertx vertx, JsonObject config) {
+    JsonObject netServerOptions = config.getJsonObject(SYS_NET_SERVER_OPTIONS);
+    if (Objects.nonNull(netServerOptions) && netServerOptions.containsKey(SYS_PEM_KEY_CERT_OPTIONS)) {
+      log.info("Creating WebClient with TLS on...");
+
+      JsonArray certPaths = netServerOptions.getJsonObject(SYS_PEM_KEY_CERT_OPTIONS)
+        .getJsonArray(SYS_CERT_PATHS);
+      if (Objects.isNull(certPaths)) {
+        throw new RuntimeException("No TLS certPaths were added into the PemTrustOptions");
+      }
+
+      final PemTrustOptions pemTrustOptions = new PemTrustOptions();
+      certPaths.forEach(entry -> pemTrustOptions.addCertPath((String) entry));
+
+      final WebClientOptions webClientOptions = new WebClientOptions()
+        .setSsl(true)
+        .setTrustOptions(pemTrustOptions);
+      return WebClient.create(vertx, webClientOptions);
+    } else {
+      log.info("Creating WebClient without TLS off...");
+      return WebClient.create(vertx);
+    }
+  }
+}

--- a/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
+++ b/src/test/java/org/folio/edge/sip2/api/MainVerticleTests.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.junit5.VertxTestContext;
 import java.text.SimpleDateFormat;

--- a/src/test/java/org/folio/edge/sip2/utils/WebClientUtilsTests.java
+++ b/src/test/java/org/folio/edge/sip2/utils/WebClientUtilsTests.java
@@ -61,6 +61,19 @@ public class WebClientUtilsTests {
   }
 
   @Test
+  void testCreateWebClientTlsOnMultipleCerts(Vertx vertx) {
+    JsonArray certPathsArray = new JsonArray()
+        .add(SelfSignedCertificate.create().certificatePath())
+        .add(SelfSignedCertificate.create().certificatePath())
+        .add(SelfSignedCertificate.create().certificatePath());
+    JsonObject certPaths = new JsonObject().put(SYS_CERT_PATHS, certPathsArray);
+
+    JsonObject config = new JsonObject().put(SYS_NET_SERVER_OPTIONS, new JsonObject()
+      .put(SYS_PEM_KEY_CERT_OPTIONS, certPaths));
+    Assertions.assertDoesNotThrow(() -> WebClientUtils.create(vertx, config));
+  }
+
+  @Test
   void testCreateWebClientWithMissingCertPaths(Vertx vertx) {
     JsonObject config = new JsonObject().put(SYS_NET_SERVER_OPTIONS, new JsonObject()
         .put(SYS_PEM_KEY_CERT_OPTIONS, new JsonObject()));

--- a/src/test/java/org/folio/edge/sip2/utils/WebClientUtilsTests.java
+++ b/src/test/java/org/folio/edge/sip2/utils/WebClientUtilsTests.java
@@ -34,39 +34,39 @@ public class WebClientUtilsTests {
   private SelfSignedCertificate selfSignedCertificate;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     this.serverPort = getRandomPort();
     this.selfSignedCertificate = SelfSignedCertificate.create();
   }
 
   @AfterEach
-  public void tearDown() {
+  void tearDown() {
     this.serverPort = null;
     this.selfSignedCertificate = null;
   }
 
   @Test
-  public void testCreateWebClientTlsOff(Vertx vertx) {
+  void testCreateWebClientTlsOff(Vertx vertx) {
     JsonObject config = new JsonObject();
     Assertions.assertDoesNotThrow(() -> WebClientUtils.create(vertx, config));
   }
 
   @Test
-  public void testCreateWebClientTlsOn(Vertx vertx) {
+  void testCreateWebClientTlsOn(Vertx vertx) {
     JsonObject config = new JsonObject().put(SYS_NET_SERVER_OPTIONS, new JsonObject()
         .put(SYS_PEM_KEY_CERT_OPTIONS, selfSignedCertificate.keyCertOptions().toJson()));
     Assertions.assertDoesNotThrow(() -> WebClientUtils.create(vertx, config));
   }
 
   @Test
-  public void testCreateWebClientWithMissingCertPaths(Vertx vertx) {
+  void testCreateWebClientWithMissingCertPaths(Vertx vertx) {
     JsonObject config = new JsonObject().put(SYS_NET_SERVER_OPTIONS, new JsonObject()
         .put(SYS_PEM_KEY_CERT_OPTIONS, new JsonObject()));
-    Assertions.assertThrows(RuntimeException.class, () -> WebClientUtils.create(vertx, config));
+    Assertions.assertThrows(WebClientConfigException.class, () -> WebClientUtils.create(vertx, config));
   }
 
   @Test
-  public void testWebClientServerCommunication(Vertx vertx, VertxTestContext testContext) {
+  void testWebClientServerCommunication(Vertx vertx, VertxTestContext testContext) {
     JsonObject sipConfig = getCommonSipConfig(vertx);
 
     sipConfig.put(SYS_PORT, serverPort);
@@ -88,7 +88,7 @@ public class WebClientUtilsTests {
   }
 
   @Test
-  public void testFailingWebClientServerCommunication(Vertx vertx, VertxTestContext testContext) {
+  void testFailingWebClientServerCommunication(Vertx vertx, VertxTestContext testContext) {
     JsonObject sipConfig = getCommonSipConfig(vertx);
 
     sipConfig.put(SYS_PORT, serverPort);

--- a/src/test/java/org/folio/edge/sip2/utils/WebClientUtilsTests.java
+++ b/src/test/java/org/folio/edge/sip2/utils/WebClientUtilsTests.java
@@ -1,5 +1,6 @@
 package org.folio.edge.sip2.utils;
 
+import static org.folio.edge.sip2.utils.WebClientUtils.SYS_CERT_PATHS;
 import static org.folio.edge.sip2.utils.WebClientUtils.SYS_NET_SERVER_OPTIONS;
 import static org.folio.edge.sip2.utils.WebClientUtils.SYS_PEM_KEY_CERT_OPTIONS;
 import static org.folio.edge.sip2.utils.WebClientUtils.SYS_PORT;
@@ -10,6 +11,7 @@ import io.vertx.core.file.FileSystem;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.SelfSignedCertificate;
 import io.vertx.ext.web.client.WebClient;
@@ -35,7 +37,7 @@ public class WebClientUtilsTests {
 
   @BeforeEach
   void setup() {
-    this.serverPort = getRandomPort();
+    this.serverPort = getAvailablePort();
     this.selfSignedCertificate = SelfSignedCertificate.create();
   }
 
@@ -64,6 +66,15 @@ public class WebClientUtilsTests {
         .put(SYS_PEM_KEY_CERT_OPTIONS, new JsonObject()));
     Assertions.assertThrows(WebClientConfigException.class,
         () -> WebClientUtils.create(vertx, config));
+  }
+
+  @Test
+  void testCreateWebClientWithEmptyCertPaths(Vertx vertx) {
+    JsonObject config = new JsonObject().put(SYS_NET_SERVER_OPTIONS, new JsonObject()
+      .put(SYS_PEM_KEY_CERT_OPTIONS, new JsonObject()
+          .put(SYS_CERT_PATHS, new JsonArray())));
+    Assertions.assertThrows(WebClientConfigException.class,
+      () -> WebClientUtils.create(vertx, config));
   }
 
   @Test
@@ -131,7 +142,7 @@ public class WebClientUtilsTests {
     return fileSystem.readFileBlocking("test-sip2.conf").toJsonObject();
   }
 
-  private static int getRandomPort() {
+  private static int getAvailablePort() {
     do {
       try (ServerSocket socket = new ServerSocket(0)) {
         return socket.getLocalPort();

--- a/src/test/java/org/folio/edge/sip2/utils/WebClientUtilsTests.java
+++ b/src/test/java/org/folio/edge/sip2/utils/WebClientUtilsTests.java
@@ -71,10 +71,9 @@ public class WebClientUtilsTests {
   @Test
   void testCreateWebClientWithEmptyCertPaths(Vertx vertx) {
     JsonObject config = new JsonObject().put(SYS_NET_SERVER_OPTIONS, new JsonObject()
-      .put(SYS_PEM_KEY_CERT_OPTIONS, new JsonObject()
-          .put(SYS_CERT_PATHS, new JsonArray())));
+        .put(SYS_PEM_KEY_CERT_OPTIONS, new JsonObject().put(SYS_CERT_PATHS, new JsonArray())));
     Assertions.assertThrows(WebClientConfigException.class,
-      () -> WebClientUtils.create(vertx, config));
+        () -> WebClientUtils.create(vertx, config));
   }
 
   @Test

--- a/src/test/java/org/folio/edge/sip2/utils/WebClientUtilsTests.java
+++ b/src/test/java/org/folio/edge/sip2/utils/WebClientUtilsTests.java
@@ -62,7 +62,8 @@ public class WebClientUtilsTests {
   void testCreateWebClientWithMissingCertPaths(Vertx vertx) {
     JsonObject config = new JsonObject().put(SYS_NET_SERVER_OPTIONS, new JsonObject()
         .put(SYS_PEM_KEY_CERT_OPTIONS, new JsonObject()));
-    Assertions.assertThrows(WebClientConfigException.class, () -> WebClientUtils.create(vertx, config));
+    Assertions.assertThrows(WebClientConfigException.class,
+        () -> WebClientUtils.create(vertx, config));
   }
 
   @Test

--- a/src/test/java/org/folio/edge/sip2/utils/WebClientUtilsTests.java
+++ b/src/test/java/org/folio/edge/sip2/utils/WebClientUtilsTests.java
@@ -102,8 +102,8 @@ public class WebClientUtilsTests {
     webClient.get(serverPort, "localhost", "/")
         .send()
         .onComplete(testContext.failing(err -> {
-          log.info("Connection error: ", err);
-          testContext.completeNow();
+           log.info("Connection error: ", err);
+           testContext.completeNow();
         }));
   }
 

--- a/src/test/java/org/folio/edge/sip2/utils/WebClientUtilsTests.java
+++ b/src/test/java/org/folio/edge/sip2/utils/WebClientUtilsTests.java
@@ -1,0 +1,142 @@
+package org.folio.edge.sip2.utils;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.vertx.core.Vertx;
+import io.vertx.core.file.FileSystem;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.SelfSignedCertificate;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+import static org.folio.edge.sip2.utils.WebClientUtils.SYS_NET_SERVER_OPTIONS;
+import static org.folio.edge.sip2.utils.WebClientUtils.SYS_PEM_KEY_CERT_OPTIONS;
+import static org.folio.edge.sip2.utils.WebClientUtils.SYS_PORT;
+
+@ExtendWith(VertxExtension.class)
+public class WebClientUtilsTests {
+
+  private static final String RESPONSE_MESSAGE = "<OK>";
+
+  private static final Logger log = LogManager.getLogger();
+  private Integer serverPort;
+  private SelfSignedCertificate selfSignedCertificate;
+
+  @BeforeEach
+  public void setup() {
+    this.serverPort = getRandomPort();
+    this.selfSignedCertificate = SelfSignedCertificate.create();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    this.serverPort = null;
+    this.selfSignedCertificate = null;
+  }
+
+  @Test
+  public void testCreateWebClientTlsOff(Vertx vertx) {
+    JsonObject config = new JsonObject();
+    Assertions.assertDoesNotThrow(() -> WebClientUtils.create(vertx, config));
+  }
+
+  @Test
+  public void testCreateWebClientTlsOn(Vertx vertx) {
+    JsonObject config = new JsonObject().put(SYS_NET_SERVER_OPTIONS, new JsonObject()
+      .put(SYS_PEM_KEY_CERT_OPTIONS, selfSignedCertificate.keyCertOptions().toJson()));
+    Assertions.assertDoesNotThrow(() -> WebClientUtils.create(vertx, config));
+  }
+
+  @Test
+  public void testCreateWebClientWithMissingCertPaths(Vertx vertx) {
+    JsonObject config = new JsonObject().put(SYS_NET_SERVER_OPTIONS, new JsonObject()
+      .put(SYS_PEM_KEY_CERT_OPTIONS, new JsonObject()));
+    Assertions.assertThrows(RuntimeException.class, () -> WebClientUtils.create(vertx, config));
+  }
+
+  @Test
+  public void testWebClientServerCommunication(Vertx vertx, VertxTestContext testContext) {
+    JsonObject sipConfig = getCommonSipConfig(vertx);
+
+    sipConfig.put(SYS_PORT, serverPort);
+    sipConfig.put(SYS_NET_SERVER_OPTIONS, new JsonObject()
+      .put(SYS_PEM_KEY_CERT_OPTIONS, selfSignedCertificate.keyCertOptions().toJson()));
+
+    createServerTlsOn(vertx, testContext);
+
+    final WebClient webClient = WebClientUtils.create(vertx, sipConfig);
+    webClient.get(serverPort, "localhost", "/")
+      .send()
+      .onComplete(testContext.succeeding(response -> {
+        String message = response.body().toString();
+        log.info("WebClient sent message to server port {}, response message: {}", serverPort, message);
+        Assertions.assertEquals(HttpResponseStatus.OK.code(), response.statusCode());
+        Assertions.assertEquals(RESPONSE_MESSAGE, message);
+        testContext.completeNow();
+      }));
+  }
+
+  @Test
+  public void testFailingWebClientServerCommunication(Vertx vertx, VertxTestContext testContext) {
+    JsonObject sipConfig = getCommonSipConfig(vertx);
+
+    sipConfig.put(SYS_PORT, serverPort);
+    sipConfig.put(SYS_NET_SERVER_OPTIONS, new JsonObject());
+
+    createServerTlsOn(vertx, testContext);
+
+    final WebClient webClient = WebClientUtils.create(vertx, sipConfig);
+    webClient.get(serverPort, "localhost", "/")
+      .send()
+      .onComplete(testContext.failing(err -> {
+        log.info("Connection error: ", err);
+        testContext.completeNow();
+      }));
+  }
+
+  private void createServerTlsOn(Vertx vertx, VertxTestContext testContext) {
+    final HttpServerOptions httpServerOptions = new HttpServerOptions()
+      .setPort(serverPort)
+      .setSsl(true)
+      .setKeyCertOptions(selfSignedCertificate.keyCertOptions());
+
+    final HttpServer httpServer = vertx.createHttpServer(httpServerOptions);
+    httpServer
+      .requestHandler(req -> req.response().putHeader(HttpHeaders.CONTENT_TYPE, "text/plain").end(RESPONSE_MESSAGE))
+      .listen(serverPort, http -> {
+        if (http.succeeded()) {
+          log.info("Server started on port: {}", serverPort);
+        } else {
+          testContext.failNow(http.cause());
+        }
+      });
+  }
+
+  private static JsonObject getCommonSipConfig(Vertx vertx) {
+    final FileSystem fileSystem = vertx.fileSystem();
+    return fileSystem.readFileBlocking("test-sip2.conf").toJsonObject();
+  }
+
+  private static int getRandomPort() {
+    do {
+      try (ServerSocket socket = new ServerSocket(0)) {
+        return socket.getLocalPort();
+      } catch (IOException e) {
+        // ignore
+      }
+    } while (true);
+  }
+}

--- a/src/test/java/org/folio/edge/sip2/utils/WebClientUtilsTests.java
+++ b/src/test/java/org/folio/edge/sip2/utils/WebClientUtilsTests.java
@@ -69,7 +69,7 @@ public class WebClientUtilsTests {
     JsonObject certPaths = new JsonObject().put(SYS_CERT_PATHS, certPathsArray);
 
     JsonObject config = new JsonObject().put(SYS_NET_SERVER_OPTIONS, new JsonObject()
-      .put(SYS_PEM_KEY_CERT_OPTIONS, certPaths));
+        .put(SYS_PEM_KEY_CERT_OPTIONS, certPaths));
     Assertions.assertDoesNotThrow(() -> WebClientUtils.create(vertx, config));
   }
 

--- a/src/test/java/org/folio/edge/sip2/utils/WebClientUtilsTests.java
+++ b/src/test/java/org/folio/edge/sip2/utils/WebClientUtilsTests.java
@@ -12,15 +12,15 @@ import io.vertx.core.file.FileSystem;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
+import java.io.IOException;
 import io.vertx.core.json.JsonObject;
+import java.net.ServerSocket;
 import io.vertx.core.net.SelfSignedCertificate;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import java.io.IOException;
-import java.net.ServerSocket;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -82,7 +82,7 @@ public class WebClientUtilsTests {
         .send()
         .onComplete(testContext.succeeding(response -> {
           String message = response.body().toString();
-          log.info("WebClient sent message to server port {}, response message: {}", serverPort, message);
+          log.info("WebClient sent message to port {}, message: {}", serverPort, message);
           Assertions.assertEquals(HttpResponseStatus.OK.code(), response.statusCode());
           Assertions.assertEquals(RESPONSE_MESSAGE, message);
           testContext.completeNow();
@@ -102,8 +102,8 @@ public class WebClientUtilsTests {
     webClient.get(serverPort, "localhost", "/")
         .send()
         .onComplete(testContext.failing(err -> {
-           log.info("Connection error: ", err);
-           testContext.completeNow();
+          log.info("Connection error: ", err);
+          testContext.completeNow();
         }));
   }
 

--- a/src/test/java/org/folio/edge/sip2/utils/WebClientUtilsTests.java
+++ b/src/test/java/org/folio/edge/sip2/utils/WebClientUtilsTests.java
@@ -1,7 +1,5 @@
 package org.folio.edge.sip2.utils;
 
-
-
 import static org.folio.edge.sip2.utils.WebClientUtils.SYS_NET_SERVER_OPTIONS;
 import static org.folio.edge.sip2.utils.WebClientUtils.SYS_PEM_KEY_CERT_OPTIONS;
 import static org.folio.edge.sip2.utils.WebClientUtils.SYS_PORT;
@@ -12,13 +10,13 @@ import io.vertx.core.file.FileSystem;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
-import java.io.IOException;
 import io.vertx.core.json.JsonObject;
-import java.net.ServerSocket;
 import io.vertx.core.net.SelfSignedCertificate;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import java.io.IOException;
+import java.net.ServerSocket;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;


### PR DESCRIPTION
Enable TLS on WebClient using certs and keys paths from the Json config
https://folio-org.atlassian.net/browse/SIP2-200
https://folio-org.atlassian.net/browse/SIP2-201