### PR TITLE
[SIP2-205] Issue with edge-sip2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -432,7 +432,6 @@
             </goals>
             <configuration>
               <ignoreNonCompile>true</ignoreNonCompile>
-              <failOnWarning>true</failOnWarning>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -192,11 +192,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec-http</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.folio.okapi</groupId>
       <artifactId>okapi-common</artifactId>
       <version>5.0.0</version>


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/SIP2-205

Dependency was added in scope of main SSL https://github.com/folio-org/edge-sip2/pull/164/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R194 only to avoid maven dependency plugin warning.

This dependency prevents application from starting, so has been deleted.