### PR TITLE
SIP2-252: CQL injection, encode CQL strings, use percent encoding

### DIFF
--- a/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/CirculationRepository.java
@@ -4,6 +4,7 @@ import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static org.folio.edge.sip2.utils.JsonUtils.getChildString;
 import static org.folio.edge.sip2.utils.JsonUtils.getSubChildString;
+import static org.folio.edge.sip2.utils.Utils.TITLE_NOT_FOUND;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
@@ -52,7 +53,6 @@ public class CirculationRepository {
   private static final Logger log = LogManager.getLogger();
 
   private static final String UNKNOWN = "";
-  public static final String TITLE_NOT_FOUND = "TITLE NOT FOUND";
   public static final String TITLE = "title";
   public static final String DUE_DATE = "dueDate";
   public static final String ITEM_BARCODE = "itemBarcode";
@@ -558,18 +558,17 @@ public class CirculationRepository {
     @Override
     public String getPath() {
       final StringBuilder qSb = new StringBuilder()
-          .append("(")
           .append(idField)
-          .append("==")
-          .append(idValue)
-          .append(" and status=Open");
+          .append("==");
+      StringUtil.appendCqlEncoded(qSb, idValue);
+      qSb.append(" and status=\"Open\"");
       if (requestType != null) {
-        qSb.append(" and requestType==").append(requestType);
+        qSb.append(" and requestType==");
+        StringUtil.appendCqlEncoded(qSb, requestType);
       }
-      qSb.append(')');
       final StringBuilder urlSb = new StringBuilder()
           .append("/circulation/requests?query=")
-          .append(Utils.encode(qSb.toString()));
+          .append(PercentCodec.encode(qSb.toString()));
 
       return appendLimits(urlSb).toString();
     }
@@ -590,8 +589,8 @@ public class CirculationRepository {
 
     @Override
     public String getPath() {
-      String query = Utils.encode("(userId==" + userId + " and status.name=Open)");
-      return "/circulation/loans?query=" + query;
+      var query = "(userId==" + StringUtil.cqlEncode(userId) + " and status.name=\"Open\")";
+      return "/circulation/loans?query=" + PercentCodec.encode(query);
     }
   }
 
@@ -614,14 +613,14 @@ public class CirculationRepository {
     @Override
     public String getPath() {
       final StringBuilder qSb = new StringBuilder()
-          .append("(userId==")
-          .append(userId)
-          .append(" and status.name=Open and dueDate<")
+          .append("(userId==");
+      StringUtil.appendCqlEncoded(qSb, userId);
+      qSb.append(" and status.name=\"Open\" and dueDate<")
           .append(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(dueDate))
           .append(')');
       final StringBuilder path = new StringBuilder()
           .append("/circulation/loans?query=")
-          .append(Utils.encode(qSb.toString()));
+          .append(PercentCodec.encode(qSb.toString()));
 
       return appendLimits(path).toString();
     }
@@ -893,7 +892,7 @@ public class CirculationRepository {
     public String getPath() {
       StringBuilder query = new StringBuilder("items.barcode==");
       StringUtil.appendCqlEncoded(query, itemBarcode);
-      return "/search/instances?limit=1&query=" + PercentCodec.encode(query.toString());
+      return "/search/instances?limit=1&query=" + PercentCodec.encode(query);
     }
 
   }

--- a/src/main/java/org/folio/edge/sip2/repositories/ConfigurationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/ConfigurationRepository.java
@@ -24,6 +24,7 @@ import org.folio.edge.sip2.domain.messages.responses.ACSStatus;
 import org.folio.edge.sip2.domain.messages.responses.ACSStatus.ACSStatusBuilder;
 import org.folio.edge.sip2.session.SessionData;
 import org.folio.edge.sip2.utils.Utils;
+import org.folio.util.PercentCodec;
 
 public class ConfigurationRepository {
 
@@ -291,7 +292,7 @@ public class ConfigurationRepository {
       }
       String partialPath = pathStringBuilder.toString();
       log.debug("Configuration path before encoding: {}", partialPath);
-      String path =  "/configurations/entries?query=" + Utils.encode(partialPath);
+      String path =  "/configurations/entries?query=" + PercentCodec.encode(partialPath);
 
       log.debug("Parsed mod-config path: {}", path);
 

--- a/src/main/java/org/folio/edge/sip2/repositories/ItemRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/ItemRepository.java
@@ -66,7 +66,7 @@ public class ItemRepository {
     public String getPath() {
       StringBuilder query = new StringBuilder("barcode==");
       StringUtil.appendCqlEncoded(query, itemIdentifier);
-      return "/inventory/items?limit=1&query=" + PercentCodec.encode(query.toString());
+      return "/inventory/items?limit=1&query=" + PercentCodec.encode(query);
     }
 
 
@@ -157,9 +157,9 @@ public class ItemRepository {
     }
 
     public String getPath() {
-      String query = Utils.encode("status==(Open - Awaiting pickup or Open - In Transit) and "
-          + "(itemId==" + itemUuid + ")");
-      return "/circulation/requests?limit=1&query=" + query;
+      var query = "status==(\"Open - Awaiting pickup\" or \"Open - In Transit\") and "
+          + "(itemId==" + StringUtil.cqlEncode(itemUuid) + ")";
+      return "/circulation/requests?limit=1&query=" + PercentCodec.encode(query);
     }
 
     @Override
@@ -189,8 +189,8 @@ public class ItemRepository {
     }
 
     public String getPath() {
-      String query = Utils.encode("(itemId==" + itemId + " and status.name=Open)");
-      return "/circulation/loans?query=" + query;
+      var query = "(itemId==" + StringUtil.cqlEncode(itemId) + " and status.name=Open)";
+      return "/circulation/loans?query=" + PercentCodec.encode(query);
     }
 
     @Override

--- a/src/main/java/org/folio/edge/sip2/repositories/UsersRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/UsersRepository.java
@@ -14,7 +14,8 @@ import org.folio.edge.sip2.repositories.domain.ExtendedUser;
 import org.folio.edge.sip2.repositories.domain.PatronPasswordVerificationRecords;
 import org.folio.edge.sip2.repositories.domain.User;
 import org.folio.edge.sip2.session.SessionData;
-import org.folio.edge.sip2.utils.Utils;
+import org.folio.util.PercentCodec;
+import org.folio.util.StringUtil;
 
 /**
  * Provides interaction with the users service.
@@ -157,15 +158,15 @@ public class UsersRepository {
 
     @Override
     public String getPath() {
+      var identifierQuoted = StringUtil.cqlEncode(identifier);
       StringBuilder query = new StringBuilder()
-          .append("(barcode==")
-          .append(identifier)
+          .append("barcode==")
+          .append(identifierQuoted)
           .append(" or externalSystemId==")
-          .append(identifier)
+          .append(identifierQuoted)
           .append(" or username==")
-          .append(identifier)
-          .append(')');
-      return "/users?limit=1&query=" + Utils.encode(query.toString());
+          .append(identifierQuoted);
+      return "/users?limit=1&query=" + PercentCodec.encode(query.toString());
     }
 
     @Override

--- a/src/main/java/org/folio/edge/sip2/utils/Utils.java
+++ b/src/main/java/org/folio/edge/sip2/utils/Utils.java
@@ -1,8 +1,6 @@
 package org.folio.edge.sip2.utils;
 
 import io.vertx.core.json.JsonObject;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -11,9 +9,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import org.folio.edge.sip2.repositories.CirculationRepository;
 import org.folio.edge.sip2.repositories.IResource;
 import org.folio.edge.sip2.repositories.RequestThrowable;
+import org.folio.util.StringUtil;
 
 /**
  * Utils for the repository implementations.
@@ -22,6 +20,8 @@ import org.folio.edge.sip2.repositories.RequestThrowable;
  *
  */
 public final class Utils {
+  public static final String TITLE_NOT_FOUND = "TITLE NOT FOUND";
+
   private Utils() {
     super();
   }
@@ -86,7 +86,7 @@ public final class Utils {
    * @param queryStringParameters an ordered list of query string parameters to parse
    * @param delimiter e.g. "&"|" AND "; spaces included if that's how it's supposed to be formatted
    * @param operator e.g. "=" | "==" | "<" | ">""
-   * @return parsed query string: e.g, "module==edge-sip2 AND configName==acsTenantConfig"
+   * @return parsed query string: e.g, {@code module=="edge-sip2" AND configName=="acsTenantConfig"}
    */
   public static String buildQueryString(Map<String,String> queryStringParameters,
                                         String delimiter,
@@ -100,15 +100,11 @@ public final class Utils {
         stringBuilder.append(firstParamEmpty ? "" : delimiter)
                      .append(entry.getKey())
                      .append(operator)
-                     .append(entry.getValue());
+                     .append(StringUtil.cqlEncode(entry.getValue()));
         firstParamEmpty = false;
       }
     }
     return stringBuilder.toString();
-  }
-
-  public static String encode(String url) {
-    return URLEncoder.encode(url, StandardCharsets.UTF_8);
   }
 
   /**
@@ -126,7 +122,7 @@ public final class Utils {
 
       @Override
       public String getTitle() {
-        return CirculationRepository.TITLE_NOT_FOUND;
+        return TITLE_NOT_FOUND;
       }
 
       @Override

--- a/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/CirculationRepositoryTests.java
@@ -45,8 +45,8 @@ import org.folio.edge.sip2.repositories.domain.ExtendedUser;
 import org.folio.edge.sip2.repositories.domain.PatronPasswordVerificationRecords;
 import org.folio.edge.sip2.repositories.domain.User;
 import org.folio.edge.sip2.session.SessionData;
-import org.folio.edge.sip2.utils.Utils;
 import org.folio.okapi.common.refreshtoken.client.ClientException;
+import org.folio.util.PercentCodec;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -1454,7 +1454,7 @@ class CirculationRepositoryTests {
         .put("totalRecords", 1);
 
     final String expectedPath = "/circulation/loans?query="
-        + Utils.encode("(userId==" + userId + " and status.name=Open)");
+        + PercentCodec.encode("(userId==\"" + userId + "\" and status.name=\"Open\")");
 
     when(mockFolioProvider.retrieveResource(
         argThat((IRequestData data) -> data.getPath().equals(expectedPath))))
@@ -1526,7 +1526,7 @@ class CirculationRepositoryTests {
         .put("totalRecords", 1);
 
     final String expectedPath = "/circulation/loans?query="
-        + Utils.encode("(userId==" + userId + " and status.name=Open and dueDate<"
+        + PercentCodec.encode("(userId==\"" + userId + "\" and status.name=\"Open\" and dueDate<"
         + dueDate + ")");
 
     when(mockFolioProvider.retrieveResource(
@@ -1599,8 +1599,8 @@ class CirculationRepositoryTests {
         .put("totalRecords", 1);
 
     final String expectedPath = "/circulation/requests?query="
-        + Utils.encode("(itemId==" + itemId
-        + " and status=Open and requestType==Recall)");
+        + PercentCodec.encode("itemId==\"" + itemId + "\""
+        + " and status=\"Open\" and requestType==\"Recall\"");
 
     when(mockFolioProvider.retrieveResource(
         argThat((IRequestData data) -> data.getPath().equals(expectedPath))))

--- a/src/test/java/org/folio/edge/sip2/repositories/UsersRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/UsersRepositoryTests.java
@@ -1,6 +1,7 @@
 package org.folio.edge.sip2.repositories;
 
 import static org.folio.edge.sip2.api.support.TestUtils.getJsonFromFile;
+import static org.folio.util.PercentCodec.encode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -22,7 +23,6 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.session.SessionData;
-import org.folio.edge.sip2.utils.Utils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -61,10 +61,6 @@ public class UsersRepositoryTests {
 
     final String barcode = "997383903573496";
     final String userId = "4f0e711c-d583-41e0-9555-b62f1725023f";
-    final String expectedUsersQueryPath = "/users?limit=1&query="
-        + Utils.encode("(barcode==" + barcode
-        + " or externalSystemId==" + barcode
-        + " or username==" + barcode + ')');
 
     final String expectedUsersBlQueryPath = "/bl-users/by-id/" + userId;
 
@@ -76,8 +72,7 @@ public class UsersRepositoryTests {
 
     doReturn(Future.succeededFuture(new FolioResource(userResponse,
         MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))))
-        .when(mockFolioProvider).retrieveResource(
-            argThat((IRequestData data) -> data.getPath().equals(expectedUsersQueryPath)));
+        .when(mockFolioProvider).retrieveResource(usersQueryPath(barcode));
 
     final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
 
@@ -103,10 +98,6 @@ public class UsersRepositoryTests {
 
     final String username = "leslie";
     final String userId = "4f0e711c-d583-41e0-9555-b62f1725023f";
-    final String expectedUsersQueryPath = "/users?limit=1&query="
-        + Utils.encode("(barcode==" + username
-        + " or externalSystemId==" + username
-        + " or username==" + username + ')');
 
     final String expectedUsersBlQueryPath = "/bl-users/by-id/" + userId;
 
@@ -117,8 +108,7 @@ public class UsersRepositoryTests {
 
     doReturn(Future.succeededFuture(new FolioResource(userResponse,
         MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))))
-        .when(mockFolioProvider).retrieveResource(
-            argThat((IRequestData data) -> data.getPath().equals(expectedUsersQueryPath)));
+        .when(mockFolioProvider).retrieveResource(usersQueryPath(username));
 
     final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
 
@@ -144,10 +134,6 @@ public class UsersRepositoryTests {
 
     final String username = "leslie";
     final String userId = "4f0e711c-d583-41e0-9555-b62f1725023f";
-    final String expectedUsersQueryPath = "/users?limit=1&query="
-        + Utils.encode("(barcode==" + username
-        + " or externalSystemId==" + username
-        + " or username==" + username + ')');
 
     final String expectedUsersBlQueryPath = "/bl-users/by-id/" + userId;
 
@@ -158,8 +144,7 @@ public class UsersRepositoryTests {
 
     doReturn(Future.succeededFuture(new FolioResource(userResponse,
         MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))))
-        .when(mockFolioProvider).retrieveResource(
-        argThat((IRequestData data) -> data.getPath().equals(expectedUsersQueryPath)));
+        .when(mockFolioProvider).retrieveResource(usersQueryPath(username));
 
     final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
 
@@ -193,10 +178,6 @@ public class UsersRepositoryTests {
 
     final String extSystemId = "4f0e711c-d583-41e0-9555-b62f1725023f";
     final String userId = "4f0e711c-d583-41e0-9555-b62f1725023f";
-    final String expectedUsersQueryPath = "/users?limit=1&query="
-        + Utils.encode("(barcode==" + extSystemId
-        + " or externalSystemId==" + extSystemId
-        + " or username==" + extSystemId + ')');
 
     final String expectedUsersBlQueryPath = "/bl-users/by-id/" + userId;
     IResourceProvider<IRequestData> mockFolioProvider
@@ -209,8 +190,7 @@ public class UsersRepositoryTests {
 
     doReturn(Future.succeededFuture(new FolioResource(userResponse,
         MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))))
-        .when(mockFolioProvider).retrieveResource(
-            argThat((IRequestData data) -> data.getPath().equals(expectedUsersQueryPath)));
+        .when(mockFolioProvider).retrieveResource(usersQueryPath(extSystemId));
 
     final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
 
@@ -230,15 +210,9 @@ public class UsersRepositoryTests {
       @Mock IResourceProvider<IRequestData> mockFolioProvider) {
 
     final String barcode = "1234667";
-    final String userId = "4f0e711c-d583-41e0-9555-b62f1725023f";
-    final String expectedUsersQueryPath = "/users?limit=1&query="
-        + Utils.encode("(barcode==" + barcode
-        + " or externalSystemId==" + barcode
-        + " or username==" + barcode + ')');
 
     doReturn(Future.failedFuture(new NoStackTraceThrowable("Test failure")))
-        .when(mockFolioProvider).retrieveResource(
-            argThat((IRequestData data) -> data.getPath().equals(expectedUsersQueryPath)));
+        .when(mockFolioProvider).retrieveResource(usersQueryPath(barcode));
 
     final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
 
@@ -306,11 +280,6 @@ public class UsersRepositoryTests {
     final String userBlResponseJson = getJsonFromFile("json/bl_user_response.json");
     final JsonObject userBlResponse = new JsonObject(userBlResponseJson);
 
-    final String expectedUsersQueryPath = "/users?limit=1&query="
-        + Utils.encode("(barcode==" + barcode
-        + " or externalSystemId==" + barcode
-        + " or username==" + barcode + ')');
-
     final String expectedUsersBlQueryPath = "/bl-users/by-id/" + userId;
 
     doReturn(Future.succeededFuture(
@@ -324,8 +293,7 @@ public class UsersRepositoryTests {
 
     doReturn(Future.succeededFuture(new FolioResource(userResponse,
         MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))))
-          .when(mockFolioProvider).retrieveResource(
-            argThat((IRequestData data) -> data.getPath().equals(expectedUsersQueryPath)));
+          .when(mockFolioProvider).retrieveResource(usersQueryPath(barcode));
 
     final SessionData sessionData = TestUtils.getMockedSessionData();
     final UsersRepository usersRepository = new UsersRepository(mockFolioProvider);
@@ -351,11 +319,6 @@ public class UsersRepositoryTests {
     final String userBlResponseJson = getJsonFromFile("json/bl_user_response.json");
     final JsonObject userBlResponse = new JsonObject(userBlResponseJson);
 
-    final String expectedUsersQueryPath = "/users?limit=1&query="
-        + Utils.encode("(barcode==" + barcode
-        + " or externalSystemId==" + barcode
-        + " or username==" + barcode + ')');
-
     final String expectedUsersBlQueryPath = "/bl-users/by-id/" + userId;
 
     //doReturn(Future.failedFuture(new NoStackTraceThrowable("Test failure")))
@@ -369,8 +332,7 @@ public class UsersRepositoryTests {
 
     doReturn(Future.succeededFuture(new FolioResource(userResponse,
         MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))))
-        .when(mockFolioProvider).retrieveResource(
-            argThat((IRequestData data) -> data.getPath().equals(expectedUsersQueryPath)));
+        .when(mockFolioProvider).retrieveResource(usersQueryPath(barcode));
 
     final SessionData sessionData = TestUtils.getMockedSessionData();
     sessionData.setPatronPasswordVerificationRequired(true);
@@ -395,11 +357,6 @@ public class UsersRepositoryTests {
     final String userBlResponseJson = getJsonFromFile("json/bl_user_response.json");
     final JsonObject userBlResponse = new JsonObject(userBlResponseJson);
 
-    final String expectedUsersQueryPath = "/users?limit=1&query="
-        + Utils.encode("(barcode==" + barcode
-        + " or externalSystemId==" + barcode
-        + " or username==" + barcode + ')');
-
     final String expectedUsersBlQueryPath = "/bl-users/by-id/" + userId;
 
     doReturn(Future.succeededFuture(
@@ -413,8 +370,7 @@ public class UsersRepositoryTests {
 
     doReturn(Future.succeededFuture(new FolioResource(userResponse,
         MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))))
-          .when(mockFolioProvider).retrieveResource(
-            argThat((IRequestData data) -> data.getPath().equals(expectedUsersQueryPath)));
+          .when(mockFolioProvider).retrieveResource(usersQueryPath(barcode));
 
     final SessionData sessionData = TestUtils.getMockedSessionData();
     sessionData.setPatronPasswordVerificationRequired(true);
@@ -439,11 +395,6 @@ public class UsersRepositoryTests {
     final String userBlResponseJson = getJsonFromFile("json/bl_user_response.json");
     final JsonObject userBlResponse = new JsonObject(userBlResponseJson);
 
-    final String expectedUsersQueryPath = "/users?limit=1&query="
-        + Utils.encode("(barcode==" + barcode
-        + " or externalSystemId==" + barcode
-        + " or username==" + barcode + ')');
-
     final String expectedUsersBlQueryPath = "/bl-users/by-id/" + userId;
 
     doReturn(Future.succeededFuture(new FolioResource(userBlResponse,
@@ -453,8 +404,7 @@ public class UsersRepositoryTests {
 
     doReturn(Future.succeededFuture(new FolioResource(userResponse,
         MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))))
-          .when(mockFolioProvider).retrieveResource(
-            argThat((IRequestData data) -> data.getPath().equals(expectedUsersQueryPath)));
+          .when(mockFolioProvider).retrieveResource(usersQueryPath(barcode));
 
     final SessionData sessionData = TestUtils.getMockedSessionData();
     sessionData.setPatronPasswordVerificationRequired(false);
@@ -474,14 +424,8 @@ public class UsersRepositoryTests {
 
     final String barcode = "997383903573496";
 
-    final String expectedUsersQueryPath = "/users?limit=1&query="
-        + Utils.encode("(barcode==" + barcode
-        + " or externalSystemId==" + barcode
-        + " or username==" + barcode + ')');
-
     doReturn(Future.failedFuture(new NoStackTraceThrowable("Null User or Something")))
-        .when(mockFolioProvider).retrieveResource(
-        argThat((IRequestData data) -> data.getPath().equals(expectedUsersQueryPath)));
+        .when(mockFolioProvider).retrieveResource(usersQueryPath(barcode));
 
     final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
 
@@ -507,10 +451,6 @@ public class UsersRepositoryTests {
 
     final String barcode = "997383903573496";
     final String userId = "4f0e711c-d583-41e0-9555-b62f1725023f";
-    final String expectedUsersQueryPath = "/users?limit=1&query="
-        + Utils.encode("(barcode==" + barcode
-        + " or externalSystemId==" + barcode
-        + " or username==" + barcode + ')');
 
     final String expectedUsersBlQueryPath = "/bl-users/by-id/" + userId;
 
@@ -520,8 +460,7 @@ public class UsersRepositoryTests {
 
     doReturn(Future.succeededFuture(new FolioResource(userResponse,
         MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))))
-        .when(mockFolioProvider).retrieveResource(
-        argThat((IRequestData data) -> data.getPath().equals(expectedUsersQueryPath)));
+        .when(mockFolioProvider).retrieveResource(usersQueryPath(barcode));
 
     final SessionData sessionData = SessionData.createSession("diku", '|', false, "IBM850");
 
@@ -537,5 +476,13 @@ public class UsersRepositoryTests {
   @Test
   public void testPinRequestData() {
 
+  }
+
+  private IRequestData usersQueryPath(final String searchString) {
+    final String expectedUsersQueryPath = "/users?limit=1&query="
+        + encode("barcode==\"" + searchString + "\""
+        + " or externalSystemId==\"" + searchString + "\""
+        + " or username==\"" + searchString + "\"");
+    return argThat((IRequestData data) -> data.getPath().equals(expectedUsersQueryPath));
   }
 }

--- a/src/test/java/org/folio/edge/sip2/utils/UtilsTests.java
+++ b/src/test/java/org/folio/edge/sip2/utils/UtilsTests.java
@@ -3,8 +3,6 @@ package org.folio.edge.sip2.utils;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -22,7 +20,7 @@ public class UtilsTests {
     final String delimeter = " AND ";
     final String equalDelimeter = "==";
 
-    String expectedString = "key1==value1 AND key3==value3";
+    String expectedString = "key1==\"value1\" AND key3==\"value3\"";
 
     String output = Utils.buildQueryString(queryStringParams, delimeter, equalDelimeter);
     assertEquals(expectedString, output);
@@ -36,13 +34,13 @@ public class UtilsTests {
     queryStringParams.put("key2", "");
     queryStringParams.put("key3", "value3");
     queryStringParams.put("key4", "");
-    queryStringParams.put("key5", "value5");
+    queryStringParams.put("key5", "value5?");
     queryStringParams.put("key6", "");
 
     final String delimeter = "&";
     final String equalDelimeter = "=";
 
-    String expectedString = "key3=value3&key5=value5";
+    String expectedString = "key3=\"value3\"&key5=\"value5\\?\"";
 
     String output = Utils.buildQueryString(queryStringParams, delimeter, equalDelimeter);
     assertEquals(expectedString, output);
@@ -51,11 +49,5 @@ public class UtilsTests {
   @Test
   public void testIsStringNullOrEmpty() {
     assertTrue(Utils.isStringNullOrEmpty(""));
-  }
-
-  @Test
-  void testEncode() {
-    String url = "item = ab39%3183-194&bp23909&item2 == 23ab3;";
-    assertEquals(URLEncoder.encode(url, StandardCharsets.UTF_8), Utils.encode(url));
   }
 }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/SIP2-252

## Purpose
To avoid CQL injection edge-sip2 needs to properly encode strings:

* Put query strings into quotes
* Encode special CQL characters
* Use percent encoding, not URL encoding, as required by RFC 3986 Section 2.3 https://datatracker.ietf.org/doc/html/rfc3986#section-2.3

## Approach
* Put query strings into quotes
* Encode special CQL characters
* Use percent encoding

Use StringUtil (from RMB).

Use PercentCodec (from RMB).
PercentCodec replaces URLEncoder.encode that uses a wrong encoding.
PercentCodec replaces Utils.encode that this PR removes because it uses a wrong encoding.

Move TITLE_NOT_FOUND from CirculationRepository to Utils to avoid a circulat dependency.

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [x] There are no breaking changes in this PR.
   - [x] Check logging.