### PR TITLE
SIP2-276: Fix missing currency values in FeePaidMessageParser

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## 3.5.0 In Progress
 * [SIP2-276](https://folio-org.atlassian.net/browse/SIP2-276): Add support for MYR currency type
-* * [SIP2-276](https://folio-org.atlassian.net/browse/SIP2-276): Add support for MYR currency type in FeePaidMessageParser
+* [SIP2-276](https://folio-org.atlassian.net/browse/SIP2-276): Add support for MYR currency type in FeePaidMessageParser
 
 
 ## 3.4.0 2025-03-14

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 3.5.0 In Progress
 * [SIP2-276](https://folio-org.atlassian.net/browse/SIP2-276): Add support for MYR currency type
+* * [SIP2-276](https://folio-org.atlassian.net/browse/SIP2-276): Add support for MYR currency type in FeePaidMessageParser
 
 
 ## 3.4.0 2025-03-14

--- a/src/main/java/org/folio/edge/sip2/domain/messages/enumerations/CurrencyType.java
+++ b/src/main/java/org/folio/edge/sip2/domain/messages/enumerations/CurrencyType.java
@@ -34,5 +34,21 @@ public enum CurrencyType {
   /** South African rand. **/
   ZAR,
   /** Malaysian Malaysian ringgit. */
-  MYR
+  MYR;
+
+  /**
+   * Returns the corresponding {@link CurrencyType} for the given string value.
+   * If the value does not match any enum constant, returns {@code null}.
+   *
+   * @param value the string representation of the currency type
+   * @return the matching {@code CurrencyType}, or {@code null} if not found
+   */
+  public static CurrencyType fromStringSafe(String value) {
+    for (CurrencyType type : CurrencyType.values()) {
+      if (type.name().equals(value)) {
+        return type;
+      }
+    }
+    return null;
+  }
 }

--- a/src/main/java/org/folio/edge/sip2/parser/FeePaidMessageParser.java
+++ b/src/main/java/org/folio/edge/sip2/parser/FeePaidMessageParser.java
@@ -1,13 +1,5 @@
 package org.folio.edge.sip2.parser;
 
-import static org.folio.edge.sip2.domain.messages.enumerations.CurrencyType.CAD;
-import static org.folio.edge.sip2.domain.messages.enumerations.CurrencyType.DEM;
-import static org.folio.edge.sip2.domain.messages.enumerations.CurrencyType.ESP;
-import static org.folio.edge.sip2.domain.messages.enumerations.CurrencyType.FRF;
-import static org.folio.edge.sip2.domain.messages.enumerations.CurrencyType.GBP;
-import static org.folio.edge.sip2.domain.messages.enumerations.CurrencyType.ITL;
-import static org.folio.edge.sip2.domain.messages.enumerations.CurrencyType.JPY;
-import static org.folio.edge.sip2.domain.messages.enumerations.CurrencyType.USD;
 import static org.folio.edge.sip2.domain.messages.enumerations.FeeType.ADMINISTRATIVE;
 import static org.folio.edge.sip2.domain.messages.enumerations.FeeType.COMPUTER_ACCESS_CHARGE;
 import static org.folio.edge.sip2.domain.messages.enumerations.FeeType.DAMAGE;
@@ -183,41 +175,12 @@ public class FeePaidMessageParser extends MessageParser {
 
   private CurrencyType parseCurrencyType(char [] messageChars) {
     final String currencyTypeString = new String(messageChars, position, 3);
-    final CurrencyType result;
-
-    // Should add full mapping someday: https://en.wikipedia.org/wiki/ISO_4217
-    switch (currencyTypeString) {
-      case "USD":
-        result = USD;
-        break;
-      case "CAD":
-        result = CAD;
-        break;
-      case "GPB":
-        result = GBP;
-        break;
-      case "FRF":
-        result = FRF;
-        break;
-      case "DEM":
-        result = DEM;
-        break;
-      case "ITL":
-        result = ITL;
-        break;
-      case "ESP":
-        result = ESP;
-        break;
-      case "JPY":
-        result = JPY;
-        break;
-      default:
-        log.error("Unknown currency type {}, defaulting to null",
-            currencyTypeString);
-        result = null;
+    var resulvedCurrencyType = CurrencyType.fromStringSafe(currencyTypeString);
+    if (resulvedCurrencyType == null) {
+      log.error("Unknown currency type {}, defaulting to null", currencyTypeString);
     }
 
     position += 3;
-    return result;
+    return resulvedCurrencyType;
   }
 }

--- a/src/main/java/org/folio/edge/sip2/repositories/ConfigurationRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/ConfigurationRepository.java
@@ -180,17 +180,14 @@ public class ConfigurationRepository {
           ? config.getString("currency") : "";
       currencyConfig = currencyConfig.toUpperCase();
       log.debug(sessionData, "currencyConfig is {}", currencyConfig);
-      String currencyValue = null;
-      for (CurrencyType c : CurrencyType.values()) {
-        if (c.name().equals(currencyConfig)) {
-          currencyValue = c.name();
-          break;
-        }
-      }
+      var currencyValue = CurrencyType.fromStringSafe(currencyConfig);
       if (currencyValue == null) {
         log.warn(sessionData, "No currency type found for currency code '{}'", currencyConfig);
+        sessionData.setCurrency(null);
+        return;
       }
-      sessionData.setCurrency(currencyValue);
+
+      sessionData.setCurrency(currencyValue.name());
     }
   }
 

--- a/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
@@ -321,7 +321,7 @@ public class PatronRepository {
               .institutionId(patronInformation.getInstitutionId())
               .patronIdentifier(patronInformation.getPatronIdentifier())
               .validPatron(TRUE)
-              .currencyType(matchCurrency(sessionData.getCurrency()));
+              .currencyType(CurrencyType.fromStringSafe(sessionData.getCurrency()));
           if (sessionData.isAlwaysCheckPatronPassword()
               || sessionData.isPatronPasswordVerificationRequired()) {
             builder.validPatronPassword(validPassword);
@@ -833,15 +833,6 @@ public class PatronRepository {
               "Recall", null, null, sessionData))
           .collect(Collectors.toList());
     });
-  }
-
-  private CurrencyType matchCurrency(String currencyString) {
-    for (CurrencyType c : CurrencyType.values()) {
-      if (c.name().equals(currencyString)) {
-        return c;
-      }
-    }
-    return null;
   }
 
   private Future<PatronPasswordVerificationRecords> verifyPinOrPassword(

--- a/src/test/java/org/folio/edge/sip2/parser/FeePaidMessageParserTest.java
+++ b/src/test/java/org/folio/edge/sip2/parser/FeePaidMessageParserTest.java
@@ -5,10 +5,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.folio.edge.sip2.domain.messages.enumerations.CurrencyType.MYR;
 import static org.folio.edge.sip2.domain.messages.enumerations.CurrencyType.USD;
 import static org.folio.edge.sip2.domain.messages.enumerations.FeeType.DAMAGE;
-import static org.folio.edge.sip2.domain.messages.enumerations.FeeType.OTHER_UNKNOWN;
-import static org.folio.edge.sip2.domain.messages.enumerations.PaymentType.CASH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.time.format.DateTimeFormatter;
@@ -19,12 +16,11 @@ import org.folio.edge.sip2.domain.messages.enumerations.FeeType;
 import org.folio.edge.sip2.domain.messages.enumerations.PaymentType;
 import org.folio.edge.sip2.domain.messages.requests.FeePaid;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class FeePaidMessageParserTests {
+class FeePaidMessageParserTest {
 
   private static final DateTimeFormatter DATE_TIME_FORMATTER = ofPattern("yyyyMMdd    HHmmss");
 
@@ -39,7 +35,7 @@ class FeePaidMessageParserTests {
 
     var result = parser.parse(transactionDateStr + sipMessage);
 
-    var expectedValue = feePaid(CASH, expected, DAMAGE);
+    var expectedValue = feePaid(PaymentType.CASH, expected, DAMAGE);
     assertEquals(transactionDate, result.getTransactionDate());
     verifyParsedValue(expectedValue, result);
   }
@@ -55,7 +51,7 @@ class FeePaidMessageParserTests {
 
     var result = parser.parse(transactionDateStr + sipMessage);
 
-    var expectedValue = feePaid(CASH, USD, feeType);
+    var expectedValue = feePaid(PaymentType.CASH, USD, feeType);
     assertEquals(transactionDate, result.getTransactionDate());
     verifyParsedValue(expectedValue, result);
   }
@@ -101,7 +97,7 @@ class FeePaidMessageParserTests {
 
   private static Stream<Arguments> feePaymentTypeDataProvider() {
     return Stream.of(
-        arguments("CASH", sipMsgPaymentType("01"), CASH),
+        arguments("CASH", sipMsgPaymentType("01"), PaymentType.CASH),
         arguments("VIS", sipMsgPaymentType("02"), PaymentType.VISA),
         arguments("CREDIT_CARD", sipMsgPaymentType("03"), PaymentType.CREDIT_CARD),
         arguments("Unknown Value", sipMsgPaymentType("99"), null)

--- a/src/test/java/org/folio/edge/sip2/parser/FeePaidMessageParserTests.java
+++ b/src/test/java/org/folio/edge/sip2/parser/FeePaidMessageParserTests.java
@@ -6,12 +6,15 @@ import static org.folio.edge.sip2.domain.messages.enumerations.CurrencyType.USD;
 import static org.folio.edge.sip2.domain.messages.enumerations.FeeType.DAMAGE;
 import static org.folio.edge.sip2.domain.messages.enumerations.PaymentType.CASH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import org.folio.edge.sip2.api.support.TestUtils;
 import org.folio.edge.sip2.domain.messages.requests.FeePaid;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class FeePaidMessageParserTests {
   @Test
@@ -32,6 +35,33 @@ class FeePaidMessageParserTests {
     assertEquals(DAMAGE, feePaid.getFeeType());
     assertEquals(CASH, feePaid.getPaymentType());
     assertEquals(USD, feePaid.getCurrencyType());
+    assertEquals("100.25", feePaid.getFeeAmount());
+    assertEquals("university_id", feePaid.getInstitutionId());
+    assertEquals("patron_id", feePaid.getPatronIdentifier());
+    assertEquals("", feePaid.getTerminalPassword());
+    assertEquals("1234", feePaid.getPatronPassword());
+    assertEquals("Torn page", feePaid.getFeeIdentifier());
+    assertEquals("a1b2c3d4e5", feePaid.getTransactionId());
+  }
+
+  @Test
+  void testParse_positive_currencyTypeNotFound() {
+    FeePaidMessageParser parser =
+        new FeePaidMessageParser(valueOf('|'), TestUtils.UTCTimeZone);
+    final OffsetDateTime transactionDate =
+        TestUtils.getOffsetDateTimeUtc().truncatedTo(SECONDS);
+    final DateTimeFormatter formatter = DateTimeFormatter
+        .ofPattern("yyyyMMdd    HHmmss");
+    final String transactionDateString = formatter.format(transactionDate);
+    final FeePaid feePaid = parser.parse(
+        transactionDateString + "0300ZZZ"
+            + "BV100.25|AApatron_id|AD1234|AC|"
+            + "AOuniversity_id|CGTorn page|BKa1b2c3d4e5|");
+
+    assertEquals(transactionDate, feePaid.getTransactionDate());
+    assertEquals(DAMAGE, feePaid.getFeeType());
+    assertEquals(CASH, feePaid.getPaymentType());
+    assertNull(feePaid.getCurrencyType());
     assertEquals("100.25", feePaid.getFeeAmount());
     assertEquals("university_id", feePaid.getInstitutionId());
     assertEquals("patron_id", feePaid.getPatronIdentifier());

--- a/src/test/java/org/folio/edge/sip2/parser/FeePaidMessageParserTests.java
+++ b/src/test/java/org/folio/edge/sip2/parser/FeePaidMessageParserTests.java
@@ -1,73 +1,169 @@
 package org.folio.edge.sip2.parser;
 
-import static java.lang.Character.valueOf;
+import static java.time.format.DateTimeFormatter.ofPattern;
 import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.folio.edge.sip2.domain.messages.enumerations.CurrencyType.MYR;
 import static org.folio.edge.sip2.domain.messages.enumerations.CurrencyType.USD;
 import static org.folio.edge.sip2.domain.messages.enumerations.FeeType.DAMAGE;
+import static org.folio.edge.sip2.domain.messages.enumerations.FeeType.OTHER_UNKNOWN;
 import static org.folio.edge.sip2.domain.messages.enumerations.PaymentType.CASH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.stream.Stream;
 import org.folio.edge.sip2.api.support.TestUtils;
+import org.folio.edge.sip2.domain.messages.enumerations.CurrencyType;
+import org.folio.edge.sip2.domain.messages.enumerations.FeeType;
+import org.folio.edge.sip2.domain.messages.enumerations.PaymentType;
 import org.folio.edge.sip2.domain.messages.requests.FeePaid;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class FeePaidMessageParserTests {
-  @Test
-  void testParse() {
-    FeePaidMessageParser parser =
-        new FeePaidMessageParser(valueOf('|'), TestUtils.UTCTimeZone);
-    final OffsetDateTime transactionDate =
-        TestUtils.getOffsetDateTimeUtc().truncatedTo(SECONDS);
-    final DateTimeFormatter formatter = DateTimeFormatter
-        .ofPattern("yyyyMMdd    HHmmss");
-    final String transactionDateString = formatter.format(transactionDate);
-    final FeePaid feePaid = parser.parse(
-        transactionDateString + "0300USD"
-        + "BV100.25|AApatron_id|AD1234|AC|"
-        + "AOuniversity_id|CGTorn page|BKa1b2c3d4e5|");
 
-    assertEquals(transactionDate, feePaid.getTransactionDate());
-    assertEquals(DAMAGE, feePaid.getFeeType());
-    assertEquals(CASH, feePaid.getPaymentType());
-    assertEquals(USD, feePaid.getCurrencyType());
-    assertEquals("100.25", feePaid.getFeeAmount());
-    assertEquals("university_id", feePaid.getInstitutionId());
-    assertEquals("patron_id", feePaid.getPatronIdentifier());
-    assertEquals("", feePaid.getTerminalPassword());
-    assertEquals("1234", feePaid.getPatronPassword());
-    assertEquals("Torn page", feePaid.getFeeIdentifier());
-    assertEquals("a1b2c3d4e5", feePaid.getTransactionId());
+  private static final DateTimeFormatter DATE_TIME_FORMATTER = ofPattern("yyyyMMdd    HHmmss");
+
+  @ParameterizedTest(name = "[{index}] {0}")
+  @MethodSource("currencyVarDataProvider")
+  @DisplayName("parse_parameterized_currencyType")
+  void parse_parameterized_currencyType(@SuppressWarnings("unused") String name,
+      String sipMessage, CurrencyType expected) {
+    var parser = new FeePaidMessageParser('|', TestUtils.UTCTimeZone);
+    var transactionDate = TestUtils.getOffsetDateTimeUtc().truncatedTo(SECONDS);
+    var transactionDateStr = DATE_TIME_FORMATTER.format(transactionDate);
+
+    var result = parser.parse(transactionDateStr + sipMessage);
+
+    var expectedValue = feePaid(CASH, expected, DAMAGE);
+    assertEquals(transactionDate, result.getTransactionDate());
+    verifyParsedValue(expectedValue, result);
   }
 
-  @Test
-  void testParse_positive_currencyTypeNotFound() {
-    FeePaidMessageParser parser =
-        new FeePaidMessageParser(valueOf('|'), TestUtils.UTCTimeZone);
-    final OffsetDateTime transactionDate =
-        TestUtils.getOffsetDateTimeUtc().truncatedTo(SECONDS);
-    final DateTimeFormatter formatter = DateTimeFormatter
-        .ofPattern("yyyyMMdd    HHmmss");
-    final String transactionDateString = formatter.format(transactionDate);
-    final FeePaid feePaid = parser.parse(
-        transactionDateString + "0300ZZZ"
-            + "BV100.25|AApatron_id|AD1234|AC|"
-            + "AOuniversity_id|CGTorn page|BKa1b2c3d4e5|");
+  @ParameterizedTest(name = "[{index}] {0}")
+  @MethodSource("feePaidTypeDataProvider")
+  @DisplayName("parse_parameterized_currencyType")
+  void parse_parameterized_feeType(@SuppressWarnings("unused") String name,
+      String sipMessage, FeeType feeType) {
+    var parser = new FeePaidMessageParser('|', TestUtils.UTCTimeZone);
+    var transactionDate = TestUtils.getOffsetDateTimeUtc().truncatedTo(SECONDS);
+    var transactionDateStr = DATE_TIME_FORMATTER.format(transactionDate);
 
-    assertEquals(transactionDate, feePaid.getTransactionDate());
-    assertEquals(DAMAGE, feePaid.getFeeType());
-    assertEquals(CASH, feePaid.getPaymentType());
-    assertNull(feePaid.getCurrencyType());
-    assertEquals("100.25", feePaid.getFeeAmount());
-    assertEquals("university_id", feePaid.getInstitutionId());
-    assertEquals("patron_id", feePaid.getPatronIdentifier());
-    assertEquals("", feePaid.getTerminalPassword());
-    assertEquals("1234", feePaid.getPatronPassword());
-    assertEquals("Torn page", feePaid.getFeeIdentifier());
-    assertEquals("a1b2c3d4e5", feePaid.getTransactionId());
+    var result = parser.parse(transactionDateStr + sipMessage);
+
+    var expectedValue = feePaid(CASH, USD, feeType);
+    assertEquals(transactionDate, result.getTransactionDate());
+    verifyParsedValue(expectedValue, result);
+  }
+
+  @ParameterizedTest(name = "[{index}] {0}")
+  @MethodSource("feePaymentTypeDataProvider")
+  @DisplayName("parse_parameterized_paymentType")
+  void parse_parameterized_paymentType(@SuppressWarnings("unused") String name,
+      String sipMessage, PaymentType paymentType) {
+    var parser = new FeePaidMessageParser('|', TestUtils.UTCTimeZone);
+    var transactionDate = TestUtils.getOffsetDateTimeUtc().truncatedTo(SECONDS);
+    var transactionDateStr = DATE_TIME_FORMATTER.format(transactionDate);
+
+    var result = parser.parse(transactionDateStr + sipMessage);
+
+    var expectedValue = feePaid(paymentType, USD, DAMAGE);
+    assertEquals(transactionDate, result.getTransactionDate());
+    verifyParsedValue(expectedValue, result);
+  }
+
+  private static Stream<Arguments> currencyVarDataProvider() {
+    return Stream.of(
+        arguments("USD", sipMsgCurrency("USD"), USD),
+        arguments("MYR", sipMsgCurrency("MYR"), MYR),
+        arguments("unknown currency", sipMsgCurrency("ZZZ"), null)
+    );
+  }
+
+  private static Stream<Arguments> feePaidTypeDataProvider() {
+    return Stream.of(
+        arguments("OTHER_UNKNOWN", sipMsgFeeType("01"), FeeType.OTHER_UNKNOWN),
+        arguments("ADMINISTRATIVE", sipMsgFeeType("02"), FeeType.ADMINISTRATIVE),
+        arguments("DAMAGE", sipMsgFeeType("03"), FeeType.DAMAGE),
+        arguments("OVERDUE", sipMsgFeeType("04"), FeeType.OVERDUE),
+        arguments("PROCESSING", sipMsgFeeType("05"), FeeType.PROCESSING),
+        arguments("RENTAL", sipMsgFeeType("06"), FeeType.RENTAL),
+        arguments("REPLACEMENT", sipMsgFeeType("07"), FeeType.REPLACEMENT),
+        arguments("COMPUTER_ACCESS_CHARGE", sipMsgFeeType("08"), FeeType.COMPUTER_ACCESS_CHARGE),
+        arguments("HOLD_FEE", sipMsgFeeType("09"), FeeType.HOLD_FEE),
+        arguments("UnknownValue", sipMsgFeeType("99"), FeeType.OTHER_UNKNOWN)
+    );
+  }
+
+  private static Stream<Arguments> feePaymentTypeDataProvider() {
+    return Stream.of(
+        arguments("CASH", sipMsgPaymentType("01"), CASH),
+        arguments("VIS", sipMsgPaymentType("02"), PaymentType.VISA),
+        arguments("CREDIT_CARD", sipMsgPaymentType("03"), PaymentType.CREDIT_CARD),
+        arguments("Unknown Value", sipMsgPaymentType("99"), null)
+    );
+  }
+
+  private static void verifyParsedValue(FeePaid expected, FeePaid actual) {
+    assertEquals(expected.getFeeType(), actual.getFeeType());
+    assertEquals(expected.getPatronIdentifier(), actual.getPatronIdentifier());
+    assertEquals(expected.getCurrencyType(), actual.getCurrencyType());
+    assertEquals(expected.getFeeAmount(), actual.getFeeAmount());
+    assertEquals(expected.getInstitutionId(), actual.getInstitutionId());
+    assertEquals(expected.getPatronIdentifier(), actual.getPatronIdentifier());
+    assertEquals(expected.getTerminalPassword(), actual.getTerminalPassword());
+    assertEquals(expected.getPatronPassword(), actual.getPatronPassword());
+    assertEquals(expected.getFeeIdentifier(), actual.getFeeIdentifier());
+    assertEquals(expected.getTransactionId(), actual.getTransactionId());
+  }
+
+  private static String sipMsgCurrency(String currency) {
+    return sipMessage(currency, "03", "01");
+  }
+
+  private static String sipMsgFeeType(String feeType) {
+    return sipMessage(USD.name(), feeType, "01");
+  }
+
+  private static String sipMsgPaymentType(String paymentType) {
+    return sipMessage(USD.name(), "03", paymentType);
+  }
+
+  private static String sipMessage(String currency, String feeType, String paymentType) {
+    var feeAmount = "100.25";
+    var universityId = "university_id";
+    var patronIdentifier = "patron_id";
+    return feeType
+        + paymentType
+        + (currency != null ? currency : "")
+        + "BV" + feeAmount
+        + "|AA" + patronIdentifier
+        + "|AD1234"
+        + "|AC"
+        + "|AO" + universityId
+        + "|CGTorn page"
+        + "|BKa1b2c3d4e5|";
+  }
+
+  private static FeePaid feePaid(PaymentType paymentType, CurrencyType currency, FeeType feeType) {
+    var feeAmount = "100.25";
+    var universityId = "university_id";
+    var patronIdentifier = "patron_id";
+    return FeePaid.builder()
+        .feeType(feeType)
+        .currencyType(currency)
+        .paymentType(paymentType)
+        .feeAmount(feeAmount)
+        .patronIdentifier(patronIdentifier)
+        .institutionId(universityId)
+        .terminalPassword("")
+        .patronPassword("1234")
+        .feeIdentifier("Torn page")
+        .transactionId("a1b2c3d4e5")
+        .build();
   }
 }


### PR DESCRIPTION
### Purpose
Add an ability to parse new currency types in FeePaidMessageParser

### Approach
- Replace switch manual currency iteration with more robust implementation

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[SIP2-XXX](https://folio-org.atlassian.net/browse/SIP2-XXX)
_List any Jira issues related to this pull request._

### Learning and Resources (if applicable)
_Discuss any research conducted during the development of this pull request. Include links to relevant blog posts, patterns, libraries, or addons that were used to solve the problem._

### Screenshots (if applicable)
_If this pull request involves any visual changes or new features, consider including screenshots or GIFs to illustrate the changes._
