### PR TITLE
SIP2-294 Replace com.github.mikelee2082:vertx-config-s3 with folio-s3-client configuration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * [SIP2-291](https://folio-org.atlassian.net/browse/SIP2-291): Implement a single login operation per session
 * [SIP2-296](https://folio-org.atlassian.net/browse/SIP2-296): Update hard-coded currency list
 * [SIP2-242](https://folio-org.atlassian.net/browse/SIP2-242): Skip null barcodes in PatronInformation response
+* [SIP2-294](https://folio-org.atlassian.net/browse/SIP2-294): Replace com.github.mikelee2082:vertx-config-s3 with folio-s3-client configuration
 
 
 ## 3.4.0 2025-03-14

--- a/pom.xml
+++ b/pom.xml
@@ -49,15 +49,15 @@
     <java.version>21</java.version>
     <okapi-common.version>6.2.3</okapi-common.version>
     <raml-module-builder-version>35.4.0</raml-module-builder-version>
+    <folio-s3-client.version>2.3.0</folio-s3-client.version>
 
     <!-- 3rd party library versions  -->
     <ipaddress.version>5.5.1</ipaddress.version>
     <lombok.version>1.18.38</lombok.version>
-    <awssdk.version>2.32.30</awssdk.version>
 
     <!-- Testing library versions-->
     <folio-backed-testing.version>3.0.3</folio-backed-testing.version>
-    <wiremock.version>3.12.1</wiremock.version>
+    <wiremock.version>3.13.1</wiremock.version>
     <rest-assured.version>5.5.6</rest-assured.version>
     <testcontainers-bom.version>1.21.3</testcontainers-bom.version>
     <junit-bom.version>5.13.4</junit-bom.version>
@@ -195,6 +195,17 @@
       <version>${ipaddress.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-s3-client</artifactId>
+      <version>${folio-s3-client.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk18on</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>${lombok.version}</version>
@@ -242,6 +253,11 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>minio</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -303,32 +319,6 @@
           <scope>runtime</scope>
         </dependency>
       </dependencies>
-    </profile>
-    <profile>
-      <id>vertx-config-s3</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>com.github.mikelee2082</groupId>
-          <artifactId>vertx-config-s3</artifactId>
-          <version>0.2.0</version>
-          <scope>runtime</scope>
-        </dependency>
-        <dependency>
-          <groupId>software.amazon.awssdk</groupId>
-          <artifactId>s3</artifactId>
-          <version>${awssdk.version}</version>
-          <scope>runtime</scope>
-        </dependency>
-      </dependencies>
-      <repositories>
-        <repository>
-          <id>jitpack.io</id>
-          <url>https://jitpack.io</url>
-        </repository>
-      </repositories>
     </profile>
   </profiles>
 

--- a/src/main/java/org/folio/edge/sip2/integration/s3/S3ConfigStore.java
+++ b/src/main/java/org/folio/edge/sip2/integration/s3/S3ConfigStore.java
@@ -4,13 +4,12 @@ import io.vertx.config.spi.ConfigStore;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.JsonObject;
+import org.folio.edge.sip2.utils.Sip2LogAdapter;
 import org.folio.s3.client.FolioS3Client;
-import org.folio.s3.client.S3ClientFactory;
-import org.folio.s3.client.S3ClientProperties;
 
 public class S3ConfigStore implements ConfigStore {
 
+  private final Sip2LogAdapter log = Sip2LogAdapter.getLogger(S3ConfigStore.class);
   private final String key;
   private final Vertx vertx;
   private final FolioS3Client s3;
@@ -18,50 +17,28 @@ public class S3ConfigStore implements ConfigStore {
   /**
    * Constructs a new {@link S3ConfigStore} instance.
    *
-   * @param vertx  - the Vertx instance to use for asynchronous operations
-   * @param config - the configuration object containing S3 connection properties
-   * @throws Error - if the S3 client cannot be created due to invalid configuration
+   * @param vertx    - the Vertx instance to use for asynchronous operations
+   * @param s3Client - the FolioS3Client to interact with S3
+   * @param key      - the S3 object key where the configuration is stored
+   * @throws IllegalStateException - if the S3 client cannot be created due to invalid configuration
    */
-  public S3ConfigStore(Vertx vertx, JsonObject config) {
-    try {
-      this.vertx = vertx;
-      this.key = config.getString("key");
-
-      s3 = createFolioS3Client(config);
-    } catch (Exception e) {
-      throw new Error(e);
-    }
+  public S3ConfigStore(Vertx vertx, FolioS3Client s3Client, String key) {
+    this.key = key;
+    this.vertx = vertx;
+    this.s3 = s3Client;
   }
 
   @Override
   public Future<Buffer> get() {
     return vertx.executeBlocking(() -> {
       try (var getRequest = s3.read(key)) {
-        return Buffer.buffer(getRequest.readAllBytes());
+        var resultBuffer = Buffer.buffer(getRequest.readAllBytes());
+        log.debug("S3 configuration loaded successfully from key: {}", key);
+        return resultBuffer;
       } catch (Exception e) {
+        log.error("Failed to load tenant configuration from S3 for key: {}", key, e);
         throw new IllegalStateException("Failed to load tenant configuration from S3", e);
       }
     });
-  }
-
-  private FolioS3Client createFolioS3Client(JsonObject conf) {
-    var configuration = S3ClientProperties.builder()
-        .endpoint(conf.getString("endpoint_url"))
-        .accessKey(getRequiredValue(conf, "access_key"))
-        .secretKey(getRequiredValue(conf, "secret_access_key"))
-        .bucket(getRequiredValue(conf, "bucket"))
-        .region(getRequiredValue(conf, "region"))
-        .build();
-    return S3ClientFactory.getS3Client(
-        configuration
-    );
-  }
-
-  private static String getRequiredValue(JsonObject conf, String key) {
-    var configValue = conf.getString(key);
-    if (configValue == null) {
-      throw new IllegalArgumentException("'" + key + "' is required for s3 configuration");
-    }
-    return configValue;
   }
 }

--- a/src/main/java/org/folio/edge/sip2/integration/s3/S3ConfigStore.java
+++ b/src/main/java/org/folio/edge/sip2/integration/s3/S3ConfigStore.java
@@ -1,0 +1,67 @@
+package org.folio.edge.sip2.integration.s3;
+
+import io.vertx.config.spi.ConfigStore;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import org.folio.s3.client.FolioS3Client;
+import org.folio.s3.client.S3ClientFactory;
+import org.folio.s3.client.S3ClientProperties;
+
+public class S3ConfigStore implements ConfigStore {
+
+  private final String key;
+  private final Vertx vertx;
+  private final FolioS3Client s3;
+
+  /**
+   * Constructs a new {@link S3ConfigStore} instance.
+   *
+   * @param vertx  - the Vertx instance to use for asynchronous operations
+   * @param config - the configuration object containing S3 connection properties
+   * @throws Error - if the S3 client cannot be created due to invalid configuration
+   */
+  public S3ConfigStore(Vertx vertx, JsonObject config) {
+    try {
+      this.vertx = vertx;
+      this.key = config.getString("key");
+
+      s3 = createFolioS3Client(config);
+    } catch (Exception e) {
+      throw new Error(e);
+    }
+  }
+
+  @Override
+  public Future<Buffer> get() {
+    return vertx.executeBlocking(() -> {
+      try (var getRequest = s3.read(key)) {
+        return Buffer.buffer(getRequest.readAllBytes());
+      } catch (Exception e) {
+        throw new IllegalStateException("Failed to load tenant configuration from S3", e);
+      }
+    });
+  }
+
+  private FolioS3Client createFolioS3Client(JsonObject conf) {
+    var configuration = S3ClientProperties.builder()
+        .endpoint(conf.getString("endpoint_url"))
+        .accessKey(getRequiredValue(conf, "access_key"))
+        .secretKey(getRequiredValue(conf, "secret_access_key"))
+        .bucket(getRequiredValue(conf, "bucket"))
+        .region(getRequiredValue(conf, "region"))
+        .build();
+    return S3ClientFactory.getS3Client(
+        configuration
+    );
+  }
+
+  private static String getRequiredValue(JsonObject conf, String key) {
+    var configValue = conf.getString(key);
+    if (configValue == null) {
+      throw new IllegalArgumentException("'" + key + "' is required for s3 configuration");
+    }
+    return configValue;
+  }
+}

--- a/src/main/java/org/folio/edge/sip2/integration/s3/S3ConfigStoreFactory.java
+++ b/src/main/java/org/folio/edge/sip2/integration/s3/S3ConfigStoreFactory.java
@@ -1,0 +1,21 @@
+package org.folio.edge.sip2.integration.s3;
+
+import io.vertx.config.spi.ConfigStore;
+import io.vertx.config.spi.ConfigStoreFactory;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+public class S3ConfigStoreFactory implements ConfigStoreFactory {
+
+  private static final String NAME = "s3";
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public ConfigStore create(Vertx vertx, JsonObject configuration) {
+    return new S3ConfigStore(vertx, configuration);
+  }
+}

--- a/src/main/java/org/folio/edge/sip2/integration/s3/S3ConfigStoreFactory.java
+++ b/src/main/java/org/folio/edge/sip2/integration/s3/S3ConfigStoreFactory.java
@@ -4,9 +4,15 @@ import io.vertx.config.spi.ConfigStore;
 import io.vertx.config.spi.ConfigStoreFactory;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.edge.sip2.utils.Sip2LogAdapter;
+import org.folio.s3.client.FolioS3Client;
+import org.folio.s3.client.S3ClientFactory;
+import org.folio.s3.client.S3ClientProperties;
 
 public class S3ConfigStoreFactory implements ConfigStoreFactory {
 
+  private final Sip2LogAdapter log = Sip2LogAdapter.getLogger(S3ConfigStoreFactory.class);
   private static final String NAME = "s3";
 
   @Override
@@ -16,6 +22,46 @@ public class S3ConfigStoreFactory implements ConfigStoreFactory {
 
   @Override
   public ConfigStore create(Vertx vertx, JsonObject configuration) {
-    return new S3ConfigStore(vertx, configuration);
+    try {
+      var s3ObjectKey = getRequiredValue(configuration, "key");
+      var s3ConfigStore = new S3ConfigStore(vertx, createFolioS3Client(configuration), s3ObjectKey);
+      log.debug("S3ConfigStore created for s3 object key: {}", s3ObjectKey);
+      return s3ConfigStore;
+    } catch (Exception e) {
+      log.error("Failed to create S3ConfigStore", e);
+      throw new IllegalStateException("Failed to create S3ConfigStore", e);
+    }
+  }
+
+  private FolioS3Client createFolioS3Client(JsonObject conf) {
+    var region = getRequiredValue(conf, "region");
+    var endpointUrl = getEndpointUrl(conf, region);
+
+    var configuration = S3ClientProperties.builder()
+        .endpoint(endpointUrl)
+        .accessKey(getRequiredValue(conf, "access_key"))
+        .secretKey(getRequiredValue(conf, "secret_access_key"))
+        .bucket(getRequiredValue(conf, "bucket"))
+        .region(region)
+        .awsSdk(true)
+        .build();
+
+    return S3ClientFactory.getS3Client(configuration);
+  }
+
+  private static String getEndpointUrl(JsonObject conf, String region) {
+    var configEndpointUrl = conf.getString("endpoint_url");
+    return StringUtils.isNotBlank(configEndpointUrl)
+        ? configEndpointUrl.trim()
+        : String.format("https://s3.%s.amazonaws.com", region);
+  }
+
+  private static String getRequiredValue(JsonObject conf, String key) {
+    var configValue = conf.getString(key);
+    if (configValue == null) {
+      throw new IllegalArgumentException("'" + key + "' is required for s3 configuration");
+    }
+
+    return configValue;
   }
 }

--- a/src/main/resources/META-INF/services/io.vertx.config.spi.ConfigStoreFactory
+++ b/src/main/resources/META-INF/services/io.vertx.config.spi.ConfigStoreFactory
@@ -1,0 +1,1 @@
+org.folio.edge.sip2.integration.s3.S3ConfigStoreFactory

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -2,8 +2,7 @@
 <Configuration>
   <Appenders>
     <Console name="STDOUT" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{HH:mm:ss} [%X{requestid}] [%X{edgesip2}] [%X{tenantid}] [edge-sip2] %-5p %-20.20c{1} %m%n"/>
-      -->
+      <PatternLayout pattern="%d{HH:mm:ss} [%X{requestid}] [%X{tenantid}] [%X{userid}] [%X{moduleid}] %-5p %-20.20c{1} %m%n"/>
     </Console>
   </Appenders>
   <Loggers>

--- a/src/test/java/org/folio/edge/sip2/api/CheckInIT.java
+++ b/src/test/java/org/folio/edge/sip2/api/CheckInIT.java
@@ -1,0 +1,84 @@
+package org.folio.edge.sip2.api;
+
+import static org.folio.edge.sip2.support.Sip2TestCommand.sip2Exchange;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.matchesRegex;
+import static org.hamcrest.Matchers.startsWith;
+
+import org.folio.edge.sip2.api.support.AbstractErrorDetectionEnabledTest;
+import org.folio.edge.sip2.support.Sip2Commands;
+import org.folio.edge.sip2.support.tags.IntegrationTest;
+import org.folio.edge.sip2.support.wiremock.WiremockStubs;
+import org.junit.jupiter.api.Test;
+
+@IntegrationTest
+@WiremockStubs({
+    "wiremock/stubs/mod-login/201-post-acs-login.json",
+    "wiremock/stubs/mod-configuration/200-get-configuration.json"
+})
+public class CheckInIT extends AbstractErrorDetectionEnabledTest {
+
+  private static final String ITEM_BARCODE = "test123456789";
+
+  @Test
+  @WiremockStubs({
+      "wiremock/stubs/mod-inventory/200-items-by-barcode.json",
+      "wiremock/stubs/mod-circulation/201-check-in-by-barcode.json",
+      "wiremock/stubs/mod-circulation/200-get-open-circulation-requests-by-item-id.json",
+  })
+  void performCheckin_positive_holdSummaryType() throws Throwable {
+    executeInSession(
+        successLoginExchange(),
+        sip2Exchange(
+            Sip2Commands.checkIn(ITEM_BARCODE),
+            sip2Result -> {
+              assertSuccessfulExchange(sip2Result);
+
+              var respMsg = sip2Result.getResponseMessage();
+              assertThat(respMsg, startsWith("10"));
+              validateCheckinCommandResponse(respMsg);
+            }
+        ));
+  }
+
+  private static void validateCheckinCommandResponse(String message) {
+    assertThat(message.charAt(2), is('1')); // completed successfully
+    assertThat(message.charAt(3), is('Y')); // item is magnetic
+    assertThat(message.charAt(4), is('U')); // is library only use
+    assertThat(message.charAt(5), is('Y')); // alert supported
+    assertThat(message.substring(6, 24), matchesRegex("\\d{8}\\s{4}\\d{6}")); // Transaction date
+
+    // empty The institution ID
+    assertThat(message.substring(24, 26), is("AO"));
+    assertThat(message.charAt(26), is('|'));
+
+    // item identifier (AB)
+    assertThat(message.substring(27, 29), is("AB"));
+    assertThat(message.substring(29, 42), is(ITEM_BARCODE));
+
+    // The name of the item’s permanent location (AQ)
+    assertThat(message.substring(43, 45), is("AQ"));
+    assertThat(message.substring(45, 57), is("Main Library"));
+
+    // The item’s title (AJ)
+    assertThat(message.substring(58, 60), is("AJ"));
+    assertThat(message.substring(60, 81), is("A semantic web primer"));
+
+    // Media Type - physical material type (CK)
+    assertThat(message.substring(82, 84), is("CK"));
+    assertThat(message.substring(84, 87), is("001"));
+
+    // Item Call Number (CS)
+    assertThat(message.substring(88, 90), is("CS"));
+    assertThat(message.substring(90, 122), is("TK5105.88815 . A58 2004 FT MEADE"));
+
+    // Alert Type (CV)
+    assertThat(message.substring(123, 125), is("CV"));
+    assertThat(message.substring(125, 127), is("04"));
+
+    // Pickup Service Point Name (CT)
+    assertThat(message.substring(128, 130), is("CT"));
+    assertThat(message.substring(130, 141), is("Circ Desk 1"));
+  }
+}

--- a/src/test/java/org/folio/edge/sip2/api/CheckInIT.java
+++ b/src/test/java/org/folio/edge/sip2/api/CheckInIT.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
     "wiremock/stubs/mod-login/201-post-acs-login.json",
     "wiremock/stubs/mod-configuration/200-get-configuration.json"
 })
-public class CheckInIT extends AbstractErrorDetectionEnabledTest {
+class CheckInIT extends AbstractErrorDetectionEnabledTest {
 
   private static final String ITEM_BARCODE = "test123456789";
 

--- a/src/test/java/org/folio/edge/sip2/api/EdgeSip2IT.java
+++ b/src/test/java/org/folio/edge/sip2/api/EdgeSip2IT.java
@@ -22,6 +22,7 @@ import io.vertx.core.json.JsonObject;
 import java.nio.file.Path;
 import org.folio.edge.sip2.support.Sip2Commands;
 import org.folio.edge.sip2.support.Sip2SessionConfiguration;
+import org.folio.edge.sip2.support.tags.IntegrationTest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -41,6 +42,7 @@ import org.testcontainers.utility.MountableFile;
  * <p>It checks the Dockerfile (this is not tested in "mvn test" unit tests).
  */
 @Testcontainers
+@IntegrationTest
 @WireMockTest(httpPort = 9130)
 class EdgeSip2IT {
   private static final Logger LOGGER = LoggerFactory.getLogger(EdgeSip2IT.class);

--- a/src/test/java/org/folio/edge/sip2/api/S3ConfigIT.java
+++ b/src/test/java/org/folio/edge/sip2/api/S3ConfigIT.java
@@ -1,0 +1,183 @@
+package org.folio.edge.sip2.api;
+
+import static java.lang.System.getProperty;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static org.folio.edge.sip2.api.support.TestUtils.executeInSession;
+import static org.folio.edge.sip2.api.support.TestUtils.getRandomPort;
+import static org.folio.edge.sip2.api.support.TestUtils.withDeployedModule;
+import static org.folio.edge.sip2.support.Sip2TestCommand.sip2Exchange;
+import static org.folio.edge.sip2.support.minio.MinioContainerExtension.TEST_AWS_REGION;
+import static org.folio.edge.sip2.support.minio.MinioContainerExtension.TEST_BUCKET_NAME;
+import static org.folio.edge.sip2.support.wiremock.WiremockContainerExtension.WM_URL_PROPERTY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import org.folio.edge.sip2.support.Sip2Commands;
+import org.folio.edge.sip2.support.Sip2SessionConfiguration;
+import org.folio.edge.sip2.support.Sip2TestCommand;
+import org.folio.edge.sip2.support.minio.EnableMinio;
+import org.folio.edge.sip2.support.minio.MinioContainerExtension;
+import org.folio.edge.sip2.support.tags.IntegrationTest;
+import org.folio.edge.sip2.support.vertx.VertxModule;
+import org.folio.edge.sip2.support.wiremock.EnableWiremock;
+import org.folio.edge.sip2.support.wiremock.WiremockStubs;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@EnableMinio
+@EnableWiremock
+@IntegrationTest
+@ExtendWith({ VertxExtension.class, MockitoExtension.class })
+class S3ConfigIT {
+
+  private static final String TENANT_ID = "testtenant";
+
+  @AfterEach
+  void tearDown() {
+    var s3Client = MinioContainerExtension.getS3Client();
+    var existingObjects = s3Client.list("sip2/");
+    existingObjects.forEach(s3Client::remove);
+  }
+
+  @Test
+  @WiremockStubs({
+      "wiremock/stubs/mod-login/201-post-acs-login.json",
+      "wiremock/stubs/mod-login/401-post-invalid-login.json",
+      "wiremock/stubs/mod-configuration/200-get-configuration.json",
+  })
+  void deployVerticle_positive_configurationFound(Vertx vertx, VertxTestContext testContext) {
+    var port = getRandomPort();
+    var sip2Configuration = s3Configuration(port, s3TenantStoreConfig());
+    var s3Client = MinioContainerExtension.getS3Client();
+    var tenantConfig = new ByteArrayInputStream(getScTenantConfContent(port).getBytes(UTF_8));
+    s3Client.write("sip2/sip2-tenants.conf", tenantConfig);
+
+    withDeployedModule(vertx, testContext, sip2Configuration, () ->
+        executeInSession(getSessionConfig(port), successLogin(), successStatus()));
+  }
+
+  @Test
+  void deployVerticle_negative_configurationNotFound(Vertx vertx, VertxTestContext testContext) {
+    var port = getRandomPort();
+    var sip2Configuration = s3Configuration(port, s3TenantStoreConfig());
+    new VertxModule(vertx, sip2Configuration)
+        .deployModule()
+        .onComplete(testContext.failing(err -> {
+          assertThat(err, instanceOf(IllegalStateException.class));
+          assertThat(err.getMessage(), is("Failed to load tenant configuration from S3"));
+          testContext.completeNow();
+        }));
+  }
+
+  @Test
+  void deployVerticle_negative_configurationNotFull(Vertx vertx, VertxTestContext testContext) {
+    var port = getRandomPort();
+    var s3StoreConfig = new JsonObject().put("endpoint_url", getProperty("AWS_URL"));
+    var sip2Configuration = s3Configuration(port, s3StoreConfig);
+
+    new VertxModule(vertx, sip2Configuration)
+        .deployModule()
+        .onComplete(testContext.failing(err -> {
+          assertThat(err, instanceOf(Error.class));
+          assertThat(err.getCause(), instanceOf(IllegalArgumentException.class));
+          var expectedErrorMsg = "java.lang.IllegalArgumentException: "
+              + "'access_key' is required for s3 configuration";
+          assertThat(err.getMessage(), is(expectedErrorMsg));
+          testContext.completeNow();
+        }));
+  }
+
+  private static Sip2TestCommand successStatus() {
+    return sip2Exchange(
+        Sip2Commands.status(),
+        sip2Result -> {
+          assertThat(sip2Result.getResponseMessage(), startsWith("98"));
+          assertThat(sip2Result.getResponseMessage(), containsString("BXYYYNYNYYYYYNNNYY"));
+        }
+    );
+  }
+
+  private static Sip2TestCommand successLogin() {
+    var locationCode = "1a62fa88-e887-4454-a345-24b4a01095fa";
+    return sip2Exchange(
+        Sip2Commands.login("test_username", "test_password", locationCode),
+        sip2Result -> {
+          assertTrue(sip2Result.isSuccessfulExchange());
+          assertTrue(sip2Result.isChecksumValid());
+          assertThat(sip2Result.getResponseMessage(), startsWith("941"));
+        });
+  }
+
+  private static JsonObject s3Configuration(Object portConfig, JsonObject s3StoreConfig) {
+    var storesConfiguration = new JsonObject()
+        .put("type", "s3")
+        .put("format", "json")
+        .put("config", s3StoreConfig);
+
+    var tenantConfigRetrieverOptions = new JsonObject()
+        .put("scanPeriod", 10000)
+        .put("stores", new JsonArray(List.of(storesConfiguration)))
+        .put("optional", true);
+
+    return new JsonObject()
+        .put("okapiUrl", requireNonNull(getProperty(WM_URL_PROPERTY)))
+        .put("port", portConfig)
+        .put("tenantConfigRetrieverOptions", tenantConfigRetrieverOptions);
+  }
+
+  private static JsonObject s3TenantStoreConfig() {
+    var endpointUrl = System.getProperty("AWS_URL");
+    var accessKey = System.getProperty("AWS_ACCESS_KEY_ID");
+    var secretAccessKey = System.getProperty("AWS_SECRET_ACCESS_KEY");
+
+    return new JsonObject()
+        .put("region", TEST_AWS_REGION)
+        .put("bucket", TEST_BUCKET_NAME)
+        .put("access_key", accessKey)
+        .put("secret_access_key", secretAccessKey)
+        .put("endpoint_url", endpointUrl)
+        .put("key", "sip2/sip2-tenants.conf");
+  }
+
+  protected static Sip2SessionConfiguration getSessionConfig(int port) {
+    return Sip2SessionConfiguration.builder()
+        .port(port)
+        .hostname("localhost")
+        .useSsl(false)
+        .socketTimeout(Duration.ofSeconds(5))
+        .charset(StandardCharsets.ISO_8859_1)
+        .errorProtectionEnabled(true)
+        .build();
+  }
+
+  private static String getScTenantConfContent(int port) {
+    var scTenantObject = new JsonObject()
+        .put("port", port)
+        .put("scSubnet", "0.0.0.0/0")
+        .put("tenant", TENANT_ID)
+        .put("errorDetectionEnabled", true)
+        .put("messageDelimiter", "\r")
+        .put("fieldDelimiter", "|")
+        .put("charset", "ISO-8859-1");
+
+    return new JsonObject()
+        .put("scTenants", new JsonArray(List.of(scTenantObject)))
+        .encodePrettily();
+  }
+}

--- a/src/test/java/org/folio/edge/sip2/api/SipTlsEnabledIT.java
+++ b/src/test/java/org/folio/edge/sip2/api/SipTlsEnabledIT.java
@@ -16,10 +16,12 @@ import org.folio.edge.sip2.support.Sip2Commands;
 import org.folio.edge.sip2.support.Sip2SessionConfiguration;
 import org.folio.edge.sip2.support.Sip2TestConfig;
 import org.folio.edge.sip2.support.tags.EnableTls;
+import org.folio.edge.sip2.support.tags.IntegrationTest;
 import org.folio.edge.sip2.support.wiremock.WiremockStubs;
 import org.junit.jupiter.api.Test;
 
 @EnableTls
+@IntegrationTest
 @Sip2TestConfig("sip2-checksum-verification-enabled.conf")
 class SipTlsEnabledIT extends BaseIntegrationTest {
 

--- a/src/test/java/org/folio/edge/sip2/api/support/TestUtils.java
+++ b/src/test/java/org/folio/edge/sip2/api/support/TestUtils.java
@@ -26,7 +26,6 @@ import org.folio.edge.sip2.support.Sip2SessionConfiguration;
 import org.folio.edge.sip2.support.Sip2TestCommand;
 import org.folio.edge.sip2.support.vertx.VertxModule;
 import org.junit.function.ThrowingRunnable;
-import software.amazon.awssdk.services.s3.endpoints.internal.Value;
 
 public class TestUtils {
   private TestUtils() {

--- a/src/test/java/org/folio/edge/sip2/integration/s3/S3ConfigStoreFactoryTest.java
+++ b/src/test/java/org/folio/edge/sip2/integration/s3/S3ConfigStoreFactoryTest.java
@@ -1,0 +1,58 @@
+package org.folio.edge.sip2.integration.s3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import java.util.Objects;
+import org.folio.edge.sip2.support.tags.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class S3ConfigStoreFactoryTest {
+
+  @InjectMocks private S3ConfigStoreFactory s3ConfigStoreFactory;
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "",
+      "null",
+      "http://localhost:4566",
+      "https://s3.us-west-2.amazonaws.com"
+  })
+  void create_positive(String endpointUrl) {
+    var configuration = s3ConfigStoreConfiguration(endpointUrl);
+    var result = s3ConfigStoreFactory.create(Vertx.vertx(), configuration);
+    assertNotNull(result);
+  }
+
+  @Test
+  void create_negative() {
+    var configuration = s3ConfigStoreConfiguration(null);
+    configuration.put("bucket", null);
+    var exception = assertThrows(IllegalStateException.class,
+        () -> s3ConfigStoreFactory.create(Vertx.vertx(), configuration));
+    assertEquals("Failed to create S3ConfigStore", exception.getMessage());
+    assertInstanceOf(IllegalArgumentException.class, exception.getCause());
+    assertEquals("'bucket' is required for s3 configuration", exception.getCause().getMessage());
+  }
+
+  private static JsonObject s3ConfigStoreConfiguration(String endpointUrl) {
+    return new JsonObject()
+        .put("key", "sip2/sip2-tenant.json")
+        .put("endpoint_url", Objects.equals(endpointUrl, "null") ? null : endpointUrl)
+        .put("access_key", "accessKey")
+        .put("secret_access_key", "secretAccessKey")
+        .put("bucket", "test-bucket")
+        .put("region", "us-east-1");
+  }
+}

--- a/src/test/java/org/folio/edge/sip2/integration/s3/S3ConfigStoreFactoryTest.java
+++ b/src/test/java/org/folio/edge/sip2/integration/s3/S3ConfigStoreFactoryTest.java
@@ -39,8 +39,9 @@ class S3ConfigStoreFactoryTest {
   void create_negative() {
     var configuration = s3ConfigStoreConfiguration(null);
     configuration.put("bucket", null);
+    var vertx = Vertx.vertx();
     var exception = assertThrows(IllegalStateException.class,
-        () -> s3ConfigStoreFactory.create(Vertx.vertx(), configuration));
+        () -> s3ConfigStoreFactory.create(vertx, configuration));
     assertEquals("Failed to create S3ConfigStore", exception.getMessage());
     assertInstanceOf(IllegalArgumentException.class, exception.getCause());
     assertEquals("'bucket' is required for s3 configuration", exception.getCause().getMessage());

--- a/src/test/java/org/folio/edge/sip2/integration/s3/S3ConfigStoreTest.java
+++ b/src/test/java/org/folio/edge/sip2/integration/s3/S3ConfigStoreTest.java
@@ -1,14 +1,11 @@
 package org.folio.edge.sip2.integration.s3;
 
-
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.when;
 
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;

--- a/src/test/java/org/folio/edge/sip2/integration/s3/S3ConfigStoreTest.java
+++ b/src/test/java/org/folio/edge/sip2/integration/s3/S3ConfigStoreTest.java
@@ -1,0 +1,81 @@
+package org.folio.edge.sip2.integration.s3;
+
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.when;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import org.folio.edge.sip2.support.tags.UnitTest;
+import org.folio.s3.client.FolioS3Client;
+import org.folio.s3.exception.S3ClientException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith({ VertxExtension.class, MockitoExtension.class })
+class S3ConfigStoreTest {
+
+  private static final String TENANT_CONF_FILE_KEY = "sip2/sip2-tenant.json";
+  private S3ConfigStore s3ConfigStore;
+  @Mock private FolioS3Client folioS3Client;
+
+  @BeforeEach
+  void setUp(Vertx vertx) {
+    s3ConfigStore = new S3ConfigStore(vertx, folioS3Client, TENANT_CONF_FILE_KEY);
+  }
+
+  @Test
+  void get_positive(VertxTestContext testContext) {
+    var fileContent = new ByteArrayInputStream(scTenantsContent().getBytes(UTF_8));
+
+    when(folioS3Client.read(TENANT_CONF_FILE_KEY)).thenReturn(fileContent);
+    var resultFuture = s3ConfigStore.get();
+    resultFuture.onComplete(testContext.succeeding(ar -> {
+      var parsedContent = new JsonObject(ar);
+      assertEquals(scTenantsContent(), parsedContent.encode());
+      testContext.completeNow();
+    }));
+  }
+
+  @Test
+  void get_negative_s3ClientException(VertxTestContext testContext) {
+    var exception = new S3ClientException("Simulated S3 failure");
+    when(folioS3Client.read(TENANT_CONF_FILE_KEY)).thenThrow(exception);
+
+    var resultFuture = s3ConfigStore.get();
+    resultFuture.onComplete(testContext.failing(error -> {
+      assertInstanceOf(IllegalStateException.class, error);
+      assertEquals("Failed to load tenant configuration from S3", error.getMessage());
+      assertInstanceOf(S3ClientException.class, error.getCause());
+      testContext.completeNow();
+    }));
+  }
+
+  private static String scTenantsContent() {
+    var scTenantObject = new JsonObject()
+        .put("port", 6443)
+        .put("scSubnet", "0.0.0.0/0")
+        .put("tenant", "testtenant")
+        .put("errorDetectionEnabled", true)
+        .put("messageDelimiter", "\r")
+        .put("fieldDelimiter", "|")
+        .put("charset", "ISO-8859-1");
+
+    return new JsonObject()
+        .put("scTenants", new JsonArray(List.of(scTenantObject)))
+        .encode();
+  }
+}

--- a/src/test/java/org/folio/edge/sip2/support/Sip2Commands.java
+++ b/src/test/java/org/folio/edge/sip2/support/Sip2Commands.java
@@ -1,6 +1,7 @@
 package org.folio.edge.sip2.support;
 
 import org.folio.edge.sip2.parser.LanguageMapper;
+import org.folio.edge.sip2.support.model.CheckInCommand;
 import org.folio.edge.sip2.support.model.EndSessionCommand;
 import org.folio.edge.sip2.support.model.LoginCommand;
 import org.folio.edge.sip2.support.model.PatronInformationCommand;
@@ -60,6 +61,18 @@ public interface Sip2Commands {
         .patronIdentifier(patronIdentifier)
         .languageCode(LanguageMapper.ENGLISH)
         .summary(summary)
+        .build();
+  }
+
+  /**
+   * Creates a {@link CheckInCommand} with the specified item identifier.
+   *
+   * @param itemIdentifier - the identifier of the item to check in
+   * @return a new {@link CheckInCommand} instance
+   */
+  static Sip2Command checkIn(String itemIdentifier) {
+    return CheckInCommand.builder()
+        .itemIdentifier(itemIdentifier)
         .build();
   }
 

--- a/src/test/java/org/folio/edge/sip2/support/minio/EnableMinio.java
+++ b/src/test/java/org/folio/edge/sip2/support/minio/EnableMinio.java
@@ -1,0 +1,13 @@
+package org.folio.edge.sip2.support.minio;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith({ MinioContainerExtension.class })
+public @interface EnableMinio {
+}

--- a/src/test/java/org/folio/edge/sip2/support/minio/MinioContainerExtension.java
+++ b/src/test/java/org/folio/edge/sip2/support/minio/MinioContainerExtension.java
@@ -1,0 +1,63 @@
+package org.folio.edge.sip2.support.minio;
+
+import lombok.Getter;
+import org.folio.s3.client.FolioS3Client;
+import org.folio.s3.client.S3ClientFactory;
+import org.folio.s3.client.S3ClientProperties;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testcontainers.containers.MinIOContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.utility.DockerImageName;
+
+public class MinioContainerExtension implements BeforeAllCallback, AfterAllCallback {
+
+  public static final String TEST_AWS_REGION = "us-west-1";
+  public static final String TEST_BUCKET_NAME = "test-sip2";
+  private static final DockerImageName IMAGE_NAME =
+      DockerImageName.parse("minio/minio:RELEASE.2023-09-04T19-57-37Z");
+
+  @Container
+  private static final MinIOContainer MINIO_CONTAINER = new MinIOContainer(IMAGE_NAME)
+      .withStartupAttempts(3)
+      .withUserName("minio_admin")
+      .withPassword("minio_password");
+
+  @Getter
+  private static FolioS3Client s3Client;
+
+  @Override
+  public void beforeAll(ExtensionContext context) {
+    if (!MINIO_CONTAINER.isRunning()) {
+      MINIO_CONTAINER.start();
+    }
+
+    System.setProperty("AWS_URL", MINIO_CONTAINER.getS3URL());
+    System.setProperty("AWS_REGION", TEST_AWS_REGION);
+    System.setProperty("AWS_ACCESS_KEY_ID", MINIO_CONTAINER.getUserName());
+    System.setProperty("AWS_SECRET_ACCESS_KEY", MINIO_CONTAINER.getPassword());
+    System.setProperty("AWS_BUCKET", TEST_BUCKET_NAME);
+
+    var s3ClientProperties = S3ClientProperties
+        .builder()
+        .endpoint(MINIO_CONTAINER.getS3URL())
+        .accessKey(MINIO_CONTAINER.getUserName())
+        .secretKey(MINIO_CONTAINER.getPassword())
+        .bucket(TEST_BUCKET_NAME)
+        .region(TEST_AWS_REGION)
+        .build();
+
+    s3Client = S3ClientFactory.getS3Client(s3ClientProperties);
+    s3Client.createBucketIfNotExists();
+  }
+
+  @Override
+  public void afterAll(ExtensionContext context) {
+    System.clearProperty("AWS_URL");
+    System.clearProperty("AWS_REGION");
+    System.clearProperty("AWS_ACCESS_KEY_ID");
+    System.clearProperty("AWS_SECRET_ACCESS_KEY");
+    System.clearProperty("AWS_BUCKET");
+  }
+}

--- a/src/test/java/org/folio/edge/sip2/support/model/CheckInCommand.java
+++ b/src/test/java/org/folio/edge/sip2/support/model/CheckInCommand.java
@@ -7,9 +7,6 @@ import static org.folio.edge.sip2.api.support.TestUtils.getUtcFixedClock;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.folio.edge.sip2.parser.LanguageMapper;
 
 @Data
 @Builder

--- a/src/test/java/org/folio/edge/sip2/support/model/CheckInCommand.java
+++ b/src/test/java/org/folio/edge/sip2/support/model/CheckInCommand.java
@@ -1,0 +1,44 @@
+package org.folio.edge.sip2.support.model;
+
+import static java.time.OffsetDateTime.now;
+import static org.folio.edge.sip2.api.support.TestUtils.getFormattedLocalDateTime;
+import static org.folio.edge.sip2.api.support.TestUtils.getUtcFixedClock;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.folio.edge.sip2.parser.LanguageMapper;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class CheckInCommand implements Sip2Command {
+
+  @Builder.Default
+  private final Boolean noBlock = false;
+
+  private final String locationCode;
+  private final String institutionId;
+  private final String itemIdentifier;
+  private final String patronIdentifier;
+  private final String terminalPassword;
+  private final String itemProperties;
+  private final Boolean cancel;
+
+  @Override
+  public String getMessage(char fieldDelimiter) {
+    return new Sip2MessageBuilder(9, fieldDelimiter)
+        .withValue(noBlock) // No block
+        .withValue(getFormattedLocalDateTime(now(getUtcFixedClock()))) // transaction date
+        .withValue(getFormattedLocalDateTime(now(getUtcFixedClock()).plusDays(1))) // return date
+        .withFieldValue("AP", locationCode) // current location (not supported)
+        .withFieldValue("AO", institutionId, true) // institution id
+        .withFieldValue("AB", itemIdentifier, true) // item identifier (e.g. barcode)
+        .withOptFieldValue("AC", terminalPassword, true) // terminal password
+        .withOptFieldValue("CH", itemProperties, true) // Number of the first item to be sent to SC
+        .withOptFieldValue("BI", cancel, true)  // transaction is used to cancel failed checkout
+        .build();
+  }
+}

--- a/src/test/java/org/folio/edge/sip2/support/model/Sip2MessageBuilder.java
+++ b/src/test/java/org/folio/edge/sip2/support/model/Sip2MessageBuilder.java
@@ -3,7 +3,6 @@ package org.folio.edge.sip2.support.model;
 import static java.util.Objects.requireNonNullElse;
 
 import com.networknt.schema.utils.StringUtils;
-import java.util.Objects;
 
 public class Sip2MessageBuilder {
 

--- a/src/test/java/org/folio/edge/sip2/support/model/Sip2MessageBuilder.java
+++ b/src/test/java/org/folio/edge/sip2/support/model/Sip2MessageBuilder.java
@@ -3,6 +3,7 @@ package org.folio.edge.sip2.support.model;
 import static java.util.Objects.requireNonNullElse;
 
 import com.networknt.schema.utils.StringUtils;
+import java.util.Objects;
 
 public class Sip2MessageBuilder {
 
@@ -18,7 +19,7 @@ public class Sip2MessageBuilder {
   public Sip2MessageBuilder(int commandCode, char fieldDelimiter) {
     this.fieldDelimiter = fieldDelimiter;
     this.builder = new StringBuilder()
-        .append(commandCode);
+        .append(String.format("%02d", commandCode));
   }
 
   /**
@@ -29,6 +30,11 @@ public class Sip2MessageBuilder {
    */
   public Sip2MessageBuilder withValue(Object messagePart) {
     if (messagePart == null) {
+      return this;
+    }
+
+    if (messagePart instanceof Boolean booleanMsgPart) {
+      this.builder.append(booleanMsgPart ? "Y" : "N");
       return this;
     }
 
@@ -50,8 +56,8 @@ public class Sip2MessageBuilder {
   /**
    * Appends a field code and its value to the message with an optional delimiter.
    *
-   * @param code          - field code
-   * @param value         - field value
+   * @param code              - field code
+   * @param value             - field value
    * @param withLeadDelimiter - whether to prepend the field with a delimiter
    * @return the current Sip2MessageBuilder instance for method chaining
    */
@@ -60,18 +66,22 @@ public class Sip2MessageBuilder {
       this.builder.append(fieldDelimiter);
     }
 
-    this.builder
-        .append(requireNonNullElse(code, ""))
-        .append(requireNonNullElse(value, ""));
+    this.builder.append(requireNonNullElse(code, ""));
 
+    if (value instanceof Boolean boolValue) {
+      this.builder.append(boolValue ? "Y" : "N");
+      return this;
+    }
+
+    this.builder.append(requireNonNullElse(value, ""));
     return this;
   }
 
   /**
    * Appends a field code and its value to the message with an optional delimiter.
    *
-   * @param code          - field code
-   * @param value         - field value
+   * @param code  - field code
+   * @param value - field value
    * @return the current Sip2MessageBuilder instance for method chaining
    */
   public Sip2MessageBuilder withOptFieldValue(String code, Object value) {

--- a/src/test/java/org/folio/edge/sip2/support/wiremock/WiremockContainerExtension.java
+++ b/src/test/java/org/folio/edge/sip2/support/wiremock/WiremockContainerExtension.java
@@ -26,7 +26,7 @@ public class WiremockContainerExtension implements BeforeAllCallback, AfterAllCa
   public static final String WM_NETWORK_ALIAS = UUID.randomUUID().toString();
   public static final String WM_URL_PROPERTY = "wm.url";
 
-  private static final DockerImageName WM_IMAGE = DockerImageName.parse("wiremock/wiremock:2.35.0");
+  private static final DockerImageName WM_IMAGE = DockerImageName.parse("wiremock/wiremock:3.13.1");
   private static final String WM_URL_VARS_FILE = "wiremock-url.vars";
 
   private static Admin adminClient;

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration>
   <Appenders>
     <Console name="STDOUT" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{HH:mm:ss} [%X{requestid}] [%X{edgesip2}] [%X{tenantid}] [edge-sip2] %-5p %-20.20c{1} %m%n"/>
+      <PatternLayout pattern="%d{HH:mm:ss} [%X{requestid}] [%X{tenantid}] [%X{userid}] [%X{moduleid}] %-5p %-20.20c{1} %m%n"/>
     </Console>
   </Appenders>
   <Loggers>

--- a/src/test/resources/wiremock/stubs/mod-circulation/200-get-open-circulation-requests-by-item-id.json
+++ b/src/test/resources/wiremock/stubs/mod-circulation/200-get-open-circulation-requests-by-item-id.json
@@ -1,0 +1,29 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/circulation/requests",
+    "headers": {
+      "x-okapi-tenant": {
+        "equalTo": "testtenant"
+      },
+      "x-okapi-token": {
+        "equalTo": "test-jwt"
+      }
+    },
+    "queryParameters": {
+      "query": {
+        "equalTo": "itemId==\"7212ba6a-8dcf-45a1-be9a-ffaa847c4423\" and status=\"Open\""
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "requests": [],
+      "totalRecords": 0
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/src/test/resources/wiremock/stubs/mod-circulation/201-check-in-by-barcode.json
+++ b/src/test/resources/wiremock/stubs/mod-circulation/201-check-in-by-barcode.json
@@ -1,0 +1,114 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/circulation/check-in-by-barcode",
+    "headers": {
+      "x-okapi-tenant": {
+        "equalTo": "testtenant"
+      },
+      "x-okapi-token": {
+        "equalTo": "test-jwt"
+      }
+    },
+    "bodyPatterns": [
+      {
+        "matchesJsonPath": "$[?(@.itemBarcode == 'test123456789')]"
+      },
+      {
+        "matchesJsonPath": "$[?(@.servicePointId == '1a62fa88-e887-4454-a345-24b4a01095fa')]"
+      }
+    ]
+  },
+  "response": {
+    "status": 201,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "item": {
+        "id": "7212ba6a-8dcf-45a1-be9a-ffaa847c4423",
+        "holdingsRecordId": "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19",
+        "instanceId": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39",
+        "instanceHrid": "inst000000000022",
+        "title": "A semantic web primer",
+        "barcode": "test123456789",
+        "contributors": [
+          {
+            "name": "Antoniou, Grigoris"
+          },
+          {
+            "name": "Van Harmelen, Frank"
+          }
+        ],
+        "callNumber": "TK5105.88815 . A58 2004 FT MEADE",
+        "copyNumber": "Copy 2",
+        "seriesStatements": [
+          "Cooperative information systems"
+        ],
+        "datesOfPublication": [
+          "c2004"
+        ],
+        "physicalDescriptions": [
+          "xx, 238 p. : ill. ; 24 cm."
+        ],
+        "callNumberComponents": {
+          "callNumber": "TK5105.88815 . A58 2004 FT MEADE"
+        },
+        "status": {
+          "name": "In transit"
+        },
+        "inTransitDestinationServicePointId": "3a40852d-49fd-4df2-a1f9-6e2641a6e91f",
+        "inTransitDestinationServicePoint": {
+          "id": "3a40852d-49fd-4df2-a1f9-6e2641a6e91f",
+          "name": "Circ Desk 1"
+        },
+        "location": {
+          "name": "Main Library"
+        },
+        "materialType": {
+          "name": "book"
+        }
+      },
+      "staffSlipContext": {
+        "item": {
+          "title": "A semantic web primer",
+          "instanceHrid": "inst000000000022",
+          "primaryContributor": null,
+          "allContributors": "Antoniou, Grigoris; Van Harmelen, Frank",
+          "datesOfPublication": "c2004",
+          "editions": "",
+          "seriesStatements": "Cooperative information systems",
+          "physicalDescriptions": "xx, 238 p. : ill. ; 24 cm.",
+          "barcode": "test123456789",
+          "status": "In transit",
+          "enumeration": "",
+          "volume": null,
+          "chronology": "",
+          "yearCaption": "",
+          "materialType": "book",
+          "loanType": "Can circulate",
+          "copy": "Copy 2",
+          "numberOfPieces": null,
+          "displaySummary": null,
+          "descriptionOfPieces": null,
+          "accessionNumber": null,
+          "administrativeNotes": "",
+          "effectiveLocationSpecific": "Main Library",
+          "effectiveLocationLibrary": "Datalogisk Institut",
+          "effectiveLocationCampus": "City Campus",
+          "effectiveLocationInstitution": "Københavns Universitet",
+          "effectiveLocationDiscoveryDisplayName": null,
+          "effectiveLocationPrimaryServicePointName": "Circ Desk 1",
+          "callNumber": "TK5105.88815 . A58 2004 FT MEADE",
+          "callNumberPrefix": null,
+          "callNumberSuffix": null,
+          "lastCheckedInDateTime": "2025-09-19T14:19:57.682Z",
+          "toServicePoint": "Circ Desk 1",
+          "fromServicePoint": "Circ Desk 2"
+        },
+        "currentDateTime": "2025-09-19T14:19:57.682Z"
+      },
+      "inHouseUse": false
+    }
+  }
+}

--- a/src/test/resources/wiremock/stubs/mod-inventory/200-items-by-barcode.json
+++ b/src/test/resources/wiremock/stubs/mod-inventory/200-items-by-barcode.json
@@ -1,0 +1,112 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/inventory/items",
+    "headers": {
+      "x-okapi-tenant": {
+        "equalTo": "testtenant"
+      },
+      "x-okapi-token": {
+        "equalTo": "test-jwt"
+      }
+    },
+    "queryParameters": {
+      "query": {
+        "equalTo": "barcode==\"test123456789\""
+      },
+      "limit": {
+        "equalTo": "1"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "items": [
+        {
+          "id": "43bd226b-0a1b-4e91-92f0-aaedc078b469",
+          "_version": "2",
+          "status": {
+            "name": "Available",
+            "date": "2025-09-19T01:29:28.860+00:00"
+          },
+          "administrativeNotes": [],
+          "title": "A semantic web primer",
+          "callNumber": "TK5105.88815 . A58 2004 FT MEADE",
+          "hrid": "item000000000014",
+          "contributorNames": [
+            {
+              "name": "Antoniou, Grigoris"
+            },
+            {
+              "name": "Van Harmelen, Frank"
+            }
+          ],
+          "formerIds": [],
+          "discoverySuppress": true,
+          "holdingsRecordId": "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19",
+          "barcode": "test123456789",
+          "itemLevelCallNumber": "TK5105.88815 . A58 2004 FT MEADE",
+          "additionalCallNumbers": [],
+          "enumeration": "",
+          "chronology": "",
+          "copyNumber": "Copy 2",
+          "notes": [],
+          "circulationNotes": [],
+          "tags": {
+            "tagList": []
+          },
+          "yearCaption": [],
+          "order": 1,
+          "electronicAccess": [
+            {
+              "uri": "http://www.loc.gov/catdir/toc/ecip0718/2007020429.html",
+              "linkText": "Links available",
+              "materialsSpecification": "Table of contents",
+              "publicNote": "Table of contents only",
+              "relationshipId": "3b430592-2e09-4b48-9a0c-0636d66b9fb3"
+            }
+          ],
+          "statisticalCodeIds": [
+            "b5968c9e-cddc-4576-99e3-8e60aed8b0dd"
+          ],
+          "purchaseOrderLineIdentifier": null,
+          "materialType": {
+            "id": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+            "name": "book"
+          },
+          "permanentLoanType": {
+            "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+            "name": "Can circulate"
+          },
+          "permanentLocation": {
+            "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+            "name": "Main Library"
+          },
+          "metadata": {
+            "createdDate": "2025-09-19T01:29:28.860+00:00",
+            "updatedDate": "2025-09-19T10:42:37.792+00:00",
+            "updatedByUserId": "e182a266-adea-43b1-a98d-8920227c19f4"
+          },
+          "effectiveCallNumberComponents": {
+            "callNumber": "TK5105.88815 . A58 2004 FT MEADE",
+            "prefix": null,
+            "suffix": null,
+            "typeId": "512173a7-bd09-490e-b773-17d83f2b63fe"
+          },
+          "effectiveShelvingOrder": "TK5105.88815 . A58 2004 FT MEADE Copy 2",
+          "isBoundWith": false,
+          "effectiveLocation": {
+            "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+            "name": "Main Library"
+          }
+        }
+      ],
+      "totalRecords": 1
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}


### PR DESCRIPTION
### Purpose
Replace the non-supported library with a folio-compliant `folio-s3-client` based configuration provider

### Approach
- Replace non-supported library with a folio-compliant implementation
- Add integration test for config fetching from s3-compatible storage (MinIO)
- Extend integration tests from CheckIn command

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [x] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[SIP2-294](https://folio-org.atlassian.net/browse/SIP2-294)
