### PR TITLE
SIP2-311 Add fee creation date to PatronAccountInfo

### DIFF
--- a/src/main/java/org/folio/edge/sip2/repositories/FeeFinesRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/FeeFinesRepository.java
@@ -453,6 +453,9 @@ public class FeeFinesRepository {
                 patronAccountInfo.setItemBarcode(accountJson.getString("barcode"));
                 patronAccountInfo.setFeeFineId(accountJson.getString("feeFineId"));
                 patronAccountInfo.setFeeFineAmount(accountJson.getDouble("amount"));
+                String accountDate = getDateFromAccountJson(accountJson);
+                patronAccountInfo.setFeeCreationDate(accountDate != null
+                    ? OffsetDateTime.parse(accountDate) : null);
                 patronAccountInfoList.add(patronAccountInfo);
               }
 
@@ -467,7 +470,7 @@ public class FeeFinesRepository {
                   acctIdList,
                   headers,
                   sessionData);
-              
+
               feePaymentRequestData.setUserName(sessionData.getUsername());
 
               log.debug(sessionData, "Json for payment request is {}",
@@ -585,5 +588,18 @@ public class FeeFinesRepository {
 
   private static String cqlUserId(String userId) {
     return "userId==" + StringUtil.cqlEncode(userId);
+  }
+
+  private String getDateFromAccountJson(JsonObject accountJson) {
+    if (accountJson == null) {
+      return null;
+    }
+    if (accountJson.getString("dateCreated") != null) {
+      return accountJson.getString("dateCreated");
+    }
+    if (accountJson.getJsonObject("metadata") != null) {
+      return accountJson.getJsonObject("metadata").getString("createdDate");
+    }
+    return null;
   }
 }


### PR DESCRIPTION
### Purpose
This pull request adds the fee creation date to the `PatronAccountInfo` by parsing the account JSON. This enhancement adds the missing fee creation date to SIP2 fee paid response (38) field FC.

### Approach
The implementation involves extracting the fee creation date from the account JSON and updating the `PatronAccountInfo` object accordingly.

### Changes Checklist
Everything had already been prepared. Only setting the values was missing. This was now completed.

### Related Issues
[SIP2-311](https://folio-org.atlassian.net/browse/SIP2-311)
[SIP2-160](https://folio-org.atlassian.net/browse/SIP2-160)
