### PR TITLE
SIP2-310: Fix manual patron blocks not reflected in SIP2 Patron Status Response (24)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## 4.1.0-SNAPSHOT In progress
+
+## Bug fixes
+* Fix manual patron blocks not reflected in SIP2 Patron Status Response (24) ([SIP2-310](https://folio-org.atlassian.net/browse/SIP2-310))
+
 ## 4.0.0 2026-04-16
 
 ### Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 * Fix manual patron blocks not reflected in SIP2 Patron Status Response (24) ([SIP2-310](https://folio-org.atlassian.net/browse/SIP2-310))
 
+
 ## 4.0.0 2026-04-16
 
 ### Breaking changes

--- a/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.edge.sip2.domain.messages.PatronAccountInfo;
 import org.folio.edge.sip2.domain.messages.enumerations.CurrencyType;
 import org.folio.edge.sip2.domain.messages.enumerations.PatronStatus;
@@ -520,11 +521,11 @@ public class PatronRepository {
             || jo.getBoolean(FIELD_REQUESTS, FALSE))
         .map(jo -> {
           final String patronMessage = jo.getString("patronMessage");
-          if (patronMessage != null && !patronMessage.isBlank()) {
+          if (StringUtils.isNotBlank(patronMessage)) {
             return patronMessage;
           }
           final String desc = jo.getString("desc");
-          if (desc != null && !desc.isBlank()) {
+          if (StringUtils.isNotBlank(desc)) {
             return desc;
           }
           return MESSAGE_BLOCKED_PATRON;

--- a/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
@@ -478,12 +478,7 @@ public class PatronRepository {
     final EnumSet<PatronStatus> patronStatus = extractPatronStatusFromBlocks(blocks);
 
     if (!patronStatus.isEmpty()) {
-      final List<String> messages = extractBlockMessages(blocks);
-      if (!messages.isEmpty()) {
-        builder.screenMessage(messages);
-      } else {
-        builder.screenMessage(Collections.singletonList(MESSAGE_BLOCKED_PATRON));
-      }
+      builder.screenMessage(extractBlockMessages(blocks));
     }
 
     return builder.patronStatus(patronStatus);

--- a/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
@@ -348,8 +348,18 @@ public class PatronRepository {
         .getFeeAmountByUserId(userId, sessionData)
         .map(accounts -> totalAmount(sessionData, accounts, builder));
 
-    return getFeeAmountFuture.map(result -> builder
-            .patronStatus(EnumSet.noneOf(PatronStatus.class))
+    final Future<PatronStatusResponseBuilder> manualBlocksFuture = feeFinesRepository
+        .getManualBlocksByUserId(userId, sessionData)
+        .map(blocks -> {
+          builder.patronStatus(extractPatronStatusFromBlocks(blocks));
+          final List<String> messages = extractBlockMessages(blocks);
+          if (!messages.isEmpty()) {
+            builder.screenMessage(messages);
+          }
+          return builder;
+        });
+
+    return Future.all(getFeeAmountFuture, manualBlocksFuture).map(cf -> builder
             .language(patronStatus.getLanguage())
             .transactionDate(OffsetDateTime.now(clock))
             .institutionId(patronStatus.getInstitutionId())
@@ -357,7 +367,6 @@ public class PatronRepository {
             .validPatron(TRUE)
             .validPatronPassword(validPassword)
             .build()
-
     );
   }
 
@@ -466,14 +475,28 @@ public class PatronRepository {
 
   private PatronInformationResponseBuilder buildPatronStatus(JsonObject blocks,
       PatronInformationResponseBuilder builder) {
+    final EnumSet<PatronStatus> patronStatus = extractPatronStatusFromBlocks(blocks);
+
+    if (!patronStatus.isEmpty()) {
+      final List<String> messages = extractBlockMessages(blocks);
+      if (!messages.isEmpty()) {
+        builder.screenMessage(messages);
+      } else {
+        builder.screenMessage(Collections.singletonList(MESSAGE_BLOCKED_PATRON));
+      }
+    }
+
+    return builder.patronStatus(patronStatus);
+  }
+
+  private static EnumSet<PatronStatus> extractPatronStatusFromBlocks(JsonObject blocks) {
     final EnumSet<PatronStatus> patronStatus = EnumSet.noneOf(PatronStatus.class);
 
-    if (blocks != null && getTotalRecords(blocks) > 0) {
+    if (blocks != null && blocks.getInteger(FIELD_TOTAL_RECORDS, 0) > 0) {
       blocks.getJsonArray("manualblocks", new JsonArray()).stream()
           .map(o -> (JsonObject) o)
           .forEach(jo -> {
             if (jo.getBoolean("borrowing", FALSE)) {
-              // Block everything
               patronStatus.addAll(EnumSet.allOf(PatronStatus.class));
             } else {
               if (jo.getBoolean("renewals", FALSE)) {
@@ -487,11 +510,31 @@ public class PatronRepository {
           });
     }
 
-    if (!patronStatus.isEmpty()) {
-      builder.screenMessage(Collections.singletonList(MESSAGE_BLOCKED_PATRON));
+    return patronStatus;
+  }
+
+  protected static List<String> extractBlockMessages(JsonObject blocks) {
+    if (blocks == null || blocks.getInteger(FIELD_TOTAL_RECORDS, 0) == 0) {
+      return Collections.emptyList();
     }
 
-    return builder.patronStatus(patronStatus);
+    return blocks.getJsonArray("manualblocks", new JsonArray()).stream()
+        .map(o -> (JsonObject) o)
+        .filter(jo -> jo.getBoolean("borrowing", FALSE)
+            || jo.getBoolean("renewals", FALSE)
+            || jo.getBoolean(FIELD_REQUESTS, FALSE))
+        .map(jo -> {
+          final String patronMessage = jo.getString("patronMessage");
+          if (patronMessage != null && !patronMessage.isBlank()) {
+            return patronMessage;
+          }
+          final String desc = jo.getString("desc");
+          if (desc != null && !desc.isBlank()) {
+            return desc;
+          }
+          return MESSAGE_BLOCKED_PATRON;
+        })
+        .toList();
   }
 
   private int getTotalRecords(JsonObject records) {

--- a/src/test/java/org/folio/edge/sip2/api/PatronStatusIT.java
+++ b/src/test/java/org/folio/edge/sip2/api/PatronStatusIT.java
@@ -1,0 +1,87 @@
+package org.folio.edge.sip2.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.edge.sip2.support.Sip2TestCommand.sip2Exchange;
+
+import java.util.EnumSet;
+import java.util.List;
+import org.folio.edge.sip2.api.support.AbstractErrorDetectionEnabledTest;
+import org.folio.edge.sip2.domain.messages.enumerations.PatronStatus;
+import org.folio.edge.sip2.domain.messages.responses.PatronStatusResponse;
+import org.folio.edge.sip2.support.Sip2Commands;
+import org.folio.edge.sip2.support.response.PatronStatusResponseParser;
+import org.folio.edge.sip2.support.tags.IntegrationTest;
+import org.folio.edge.sip2.support.wiremock.WiremockStubs;
+import org.junit.jupiter.api.Test;
+
+@IntegrationTest
+class PatronStatusIT extends AbstractErrorDetectionEnabledTest {
+
+  private static final String TIMEZONE = "Europe/Paris";
+
+  @Test
+  @WiremockStubs({
+      "/wiremock/stubs/mod-settings/200-get-locale.json",
+      "/wiremock/stubs/mod-settings/200-get-settings.json",
+      "/wiremock/stubs/mod-login/201-post-acs-login.json",
+      "/wiremock/stubs/mod-users/200-get-user-by-patron-identifier.json",
+      "/wiremock/stubs/mod-users-bl/200-get-user-by-id.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-accounts-open-status.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-manualblocks.json",
+  })
+  void getPatronStatus_noManualBlocks_patronStatusFlagsAreEmpty() throws Throwable {
+    executeInSession(
+        successLoginExchange(),
+        sip2Exchange(
+            Sip2Commands.patronStatus(PATRON_BARCODE),
+            sip2Result -> {
+              assertSuccessfulExchange(sip2Result);
+
+              var respMsg = sip2Result.getResponseMessage();
+              assertThat(respMsg).startsWith("24");
+
+              var response = parseResponse(respMsg);
+              assertThat(response.getValidPatron()).isTrue();
+              assertThat(response.getPatronStatus()).isEmpty();
+              assertThat(response.getScreenMessage()).isNull();
+            }
+        ));
+  }
+
+  @Test
+  @WiremockStubs({
+      "/wiremock/stubs/mod-settings/200-get-locale.json",
+      "/wiremock/stubs/mod-settings/200-get-settings.json",
+      "/wiremock/stubs/mod-login/201-post-acs-login.json",
+      "/wiremock/stubs/mod-users/200-get-user-by-patron-identifier.json",
+      "/wiremock/stubs/mod-users-bl/200-get-user-by-id.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-accounts-open-status.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-manualblocks-with-borrowing-block.json",
+  })
+  void getPatronStatus_withManualBorrowingBlock_allStatusFlagsSetAndMessageReturned()
+      throws Throwable {
+    executeInSession(
+        successLoginExchange(),
+        sip2Exchange(
+            Sip2Commands.patronStatus(PATRON_BARCODE),
+            sip2Result -> {
+              assertSuccessfulExchange(sip2Result);
+
+              var respMsg = sip2Result.getResponseMessage();
+              assertThat(respMsg).startsWith("24");
+
+              var response = parseResponse(respMsg);
+              assertThat(response.getValidPatron()).isTrue();
+              assertThat(response.getPatronStatus())
+                  .isEqualTo(EnumSet.allOf(PatronStatus.class));
+              assertThat(response.getScreenMessage())
+                  .isEqualTo(List.of(
+                      "Your account is blocked. Please contact the library."));
+            }
+        ));
+  }
+
+  private PatronStatusResponse parseResponse(String respMsg) {
+    return new PatronStatusResponseParser(delimiter, TIMEZONE).parse(respMsg);
+  }
+}

--- a/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
@@ -9,7 +9,6 @@ import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.HOLD
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.RECALL_PRIVILEGES_DENIED;
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.RENEWAL_PRIVILEGES_DENIED;
 import static org.folio.edge.sip2.domain.messages.enumerations.Summary.RECALL_ITEMS;
-import static org.folio.edge.sip2.repositories.PatronRepository.MESSAGE_BLOCKED_PATRON;
 import static org.folio.edge.sip2.repositories.PatronRepository.MESSAGE_INVALID_PATRON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -2426,6 +2425,72 @@ public class PatronRepositoryTests {
     List<String> barcodeList
         = PatronRepository.getBarcodesForOpenAccounts(accountResponse.getJsonArray("accounts"));
     assertEquals(1, barcodeList.size());
+  }
+
+  @Test
+  void extractBlockMessagesReturnsEmptyWhenBlocksIsNull() {
+    assertEquals(Collections.emptyList(), PatronRepository.extractBlockMessages(null));
+  }
+
+  @Test
+  void extractBlockMessagesReturnsEmptyWhenTotalRecordsIsZero() {
+    final JsonObject blocks = new JsonObject()
+        .put("manualblocks", new JsonArray())
+        .put("totalRecords", 0);
+    assertEquals(Collections.emptyList(), PatronRepository.extractBlockMessages(blocks));
+  }
+
+  @Test
+  void extractBlockMessagesReturnsEmptyForNonActionableBlock() {
+    // block with all flags false — filtered out, contributes no message
+    final JsonObject blocks = new JsonObject()
+        .put("totalRecords", 1)
+        .put("manualblocks", new JsonArray().add(new JsonObject()
+            .put("borrowing", false)
+            .put("renewals", false)
+            .put("requests", false)
+            .put("patronMessage", "Pay your fines!")));
+    assertEquals(Collections.emptyList(), PatronRepository.extractBlockMessages(blocks));
+  }
+
+  @Test
+  void extractBlockMessagesUsesDescWhenPatronMessageIsBlank() {
+    final JsonObject blocks = new JsonObject()
+        .put("totalRecords", 1)
+        .put("manualblocks", new JsonArray().add(new JsonObject()
+            .put("borrowing", true)
+            .put("renewals", false)
+            .put("requests", false)
+            .put("patronMessage", "  ")
+            .put("desc", "Staff description")));
+    assertEquals(Collections.singletonList("Staff description"),
+        PatronRepository.extractBlockMessages(blocks));
+  }
+
+  @Test
+  void extractBlockMessagesUsesGenericFallbackWhenNoMessageOrDesc() {
+    final JsonObject blocks = new JsonObject()
+        .put("totalRecords", 1)
+        .put("manualblocks", new JsonArray().add(new JsonObject()
+            .put("borrowing", true)
+            .put("renewals", false)
+            .put("requests", false)));
+    assertEquals(Collections.singletonList(PatronRepository.MESSAGE_BLOCKED_PATRON),
+        PatronRepository.extractBlockMessages(blocks));
+  }
+
+  @Test
+  void extractBlockMessagesUsesPatronMessageOverDesc() {
+    final JsonObject blocks = new JsonObject()
+        .put("totalRecords", 1)
+        .put("manualblocks", new JsonArray().add(new JsonObject()
+            .put("borrowing", false)
+            .put("renewals", false)
+            .put("requests", true)
+            .put("patronMessage", "Contact the library")
+            .put("desc", "Staff description")));
+    assertEquals(Collections.singletonList("Contact the library"),
+        PatronRepository.extractBlockMessages(blocks));
   }
 
   private static JsonObject getManualBlockJsonObject(boolean borrowing, boolean renewals,

--- a/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
@@ -1041,6 +1041,10 @@ public class PatronRepositoryTests {
     when(mockFeeFinesRepository.getFeeAmountByUserId(eq(userId), any()))
         .thenReturn(Future.succeededFuture(queryAccountResponse));
 
+    when(mockFeeFinesRepository.getManualBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(new JsonObject()
+            .put("manualblocks", new JsonArray()).put("totalRecords", 0)));
+
     PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
         mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier,
         clock);
@@ -1111,6 +1115,10 @@ public class PatronRepositoryTests {
     when(mockFeeFinesRepository.getFeeAmountByUserId(eq(userId), any()))
         .thenReturn(Future.succeededFuture(queryAccountResponse));
 
+    when(mockFeeFinesRepository.getManualBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(new JsonObject()
+            .put("manualblocks", new JsonArray()).put("totalRecords", 0)));
+
     PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
         mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier,
         clock);
@@ -1179,6 +1187,76 @@ public class PatronRepositoryTests {
         testContext.succeeding(patronStatusResponse -> testContext.verify(() -> {
           assertNotNull(patronStatusResponse);
           assertEquals(false, patronStatusResponse.getValidPatron());
+          testContext.completeNow();
+        }))
+    );
+  }
+
+  @Test
+  void canPerformPatronStatusWithManualBlocks(Vertx vertx,
+      VertxTestContext testContext,
+      @Mock PasswordVerifier mockPasswordVerifier,
+      @Mock FeeFinesRepository mockFeeFinesRepository,
+      @Mock CirculationRepository mockCirculationRepository,
+      @Mock UsersRepository mockUsersRepository) {
+    final String patronIdentifier = "1029384756";
+    final String patronPassword = "1234";
+    final String institutionId = "diku";
+    final String userId = "99a81cee-d439-42c8-9860-2bd1de881c4a";
+    final String userBarcode = "2349871212";
+    final Clock clock = TestUtils.getUtcFixedClock();
+    final Float feeAmount = 34.50f;
+    final Personal personal = new Personal.Builder()
+        .firstName("Joe")
+        .middleName("Zee")
+        .lastName("Blow")
+        .build();
+    final User user = new User.Builder()
+        .id(userId)
+        .barcode(userBarcode)
+        .personal(personal)
+        .build();
+
+    final ExtendedUser extendedUser = new ExtendedUser();
+    extendedUser.setUser(user);
+    extendedUser.setPatronGroup("patrons", "The Library Patrons", "12335");
+
+    final PatronStatusRequest patronStatus = PatronStatusRequest.builder()
+        .patronIdentifier(patronIdentifier)
+        .patronPassword(patronPassword)
+        .institutionId(institutionId)
+        .transactionDate(OffsetDateTime.now())
+        .build();
+
+    final JsonObject queryAccountResponse = new JsonObject()
+        .put("accounts", new JsonArray()
+            .add(new JsonObject()
+                .put("remaining", feeAmount)
+                .put("id", "2345")));
+
+    final JsonObject manualBlocksResponse = getManualBlockJsonObject(true, true, true);
+
+    when(mockPasswordVerifier.verifyPatronPassword(anyString(), anyString(), any()))
+        .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder()
+            .extendedUser(extendedUser).build()));
+    when(mockFeeFinesRepository.getFeeAmountByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(queryAccountResponse));
+    when(mockFeeFinesRepository.getManualBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(manualBlocksResponse));
+
+    final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
+        mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
+    final SessionData sessionData = TestUtils.getMockedSessionData();
+
+    patronRepository.performPatronStatusCommand(patronStatus, sessionData).onComplete(
+        testContext.succeeding(patronStatusResponse -> testContext.verify(() -> {
+          assertNotNull(patronStatusResponse);
+          assertEquals(true, patronStatusResponse.getValidPatron());
+          assertEquals(feeAmount.toString(), patronStatusResponse.getFeeAmount());
+          assertEquals("Joe Zee Blow", patronStatusResponse.getPersonalName());
+          assertEquals(EnumSet.allOf(PatronStatus.class), patronStatusResponse.getPatronStatus());
+          assertEquals(Collections.singletonList("Pay your fines!"),
+              patronStatusResponse.getScreenMessage());
           testContext.completeNow();
         }))
     );
@@ -2379,28 +2457,28 @@ public class PatronRepositoryTests {
     return Stream.of(
         Arguments.of(getManualBlockJsonObject(true, true, true),
             EnumSet.allOf(PatronStatus.class),
-            Collections.singletonList(MESSAGE_BLOCKED_PATRON)),
+            Collections.singletonList("Pay your fines!")),
         Arguments.of(getManualBlockJsonObject(true, true, false),
             EnumSet.allOf(PatronStatus.class),
-            Collections.singletonList(MESSAGE_BLOCKED_PATRON)),
+            Collections.singletonList("Pay your fines!")),
         Arguments.of(getManualBlockJsonObject(false, true, true),
             EnumSet.of(RENEWAL_PRIVILEGES_DENIED,
                 HOLD_PRIVILEGES_DENIED,
                 RECALL_PRIVILEGES_DENIED),
-            Collections.singletonList(MESSAGE_BLOCKED_PATRON)),
+            Collections.singletonList("Pay your fines!")),
         Arguments.of(getManualBlockJsonObject(true, false, true),
             EnumSet.allOf(PatronStatus.class),
-            Collections.singletonList(MESSAGE_BLOCKED_PATRON)),
+            Collections.singletonList("Pay your fines!")),
         Arguments.of(getManualBlockJsonObject(true, false, false),
             EnumSet.allOf(PatronStatus.class),
-            Collections.singletonList(MESSAGE_BLOCKED_PATRON)),
+            Collections.singletonList("Pay your fines!")),
         Arguments.of(getManualBlockJsonObject(false, true, false),
             EnumSet.of(RENEWAL_PRIVILEGES_DENIED),
-            Collections.singletonList(MESSAGE_BLOCKED_PATRON)),
+            Collections.singletonList("Pay your fines!")),
         Arguments.of(getManualBlockJsonObject(false, false, true),
             EnumSet.of(HOLD_PRIVILEGES_DENIED,
                 RECALL_PRIVILEGES_DENIED),
-            Collections.singletonList(MESSAGE_BLOCKED_PATRON)),
+            Collections.singletonList("Pay your fines!")),
         Arguments.of(getManualBlockJsonObject(false, false, false),
             EnumSet.noneOf(PatronStatus.class),
             null));

--- a/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
@@ -2546,6 +2546,9 @@ public class PatronRepositoryTests {
             Collections.singletonList("Pay your fines!")),
         Arguments.of(getManualBlockJsonObject(false, false, false),
             EnumSet.noneOf(PatronStatus.class),
+            null),
+        Arguments.of(new JsonObject().put("totalRecords", 0).put("manualblocks", new JsonArray()),
+            EnumSet.noneOf(PatronStatus.class),
             null));
   }
 

--- a/src/test/java/org/folio/edge/sip2/support/Sip2Commands.java
+++ b/src/test/java/org/folio/edge/sip2/support/Sip2Commands.java
@@ -6,6 +6,7 @@ import org.folio.edge.sip2.support.model.EndSessionCommand;
 import org.folio.edge.sip2.support.model.LoginCommand;
 import org.folio.edge.sip2.support.model.PatronInformationCommand;
 import org.folio.edge.sip2.support.model.PatronInformationCommand.PatronInfoSummaryType;
+import org.folio.edge.sip2.support.model.PatronStatusCommand;
 import org.folio.edge.sip2.support.model.RawCommand;
 import org.folio.edge.sip2.support.model.ResendCommand;
 import org.folio.edge.sip2.support.model.Sip2Command;
@@ -47,6 +48,19 @@ public interface Sip2Commands {
    */
   static StatusCommand status() {
     return new StatusCommand();
+  }
+
+  /**
+   * Creates a {@link PatronStatusCommand} for the given patron identifier.
+   *
+   * @param patronIdentifier - the identifier of the patron
+   * @return a new {@link PatronStatusCommand} instance
+   */
+  static PatronStatusCommand patronStatus(String patronIdentifier) {
+    return PatronStatusCommand.builder()
+        .patronIdentifier(patronIdentifier)
+        .languageCode(LanguageMapper.ENGLISH)
+        .build();
   }
 
   /**

--- a/src/test/java/org/folio/edge/sip2/support/model/PatronStatusCommand.java
+++ b/src/test/java/org/folio/edge/sip2/support/model/PatronStatusCommand.java
@@ -1,0 +1,32 @@
+package org.folio.edge.sip2.support.model;
+
+import static java.time.OffsetDateTime.now;
+import static org.folio.edge.sip2.api.support.TestUtils.getFormattedLocalDateTime;
+import static org.folio.edge.sip2.api.support.TestUtils.getUtcFixedClock;
+
+import lombok.Builder;
+import lombok.Data;
+import org.folio.edge.sip2.parser.LanguageMapper;
+
+@Data
+@Builder
+public class PatronStatusCommand implements Sip2Command {
+
+  private final LanguageMapper languageCode;
+  private final String institutionId;
+  private final String patronIdentifier;
+  private final String terminalPassword;
+  private final String patronPassword;
+
+  @Override
+  public String getMessage(char fieldDelimiter) {
+    return new Sip2MessageBuilder(23, fieldDelimiter)
+        .withValue(languageCode.code())
+        .withValue(getFormattedLocalDateTime(now(getUtcFixedClock())))
+        .withFieldValue("AO", institutionId)
+        .withFieldValue("AA", patronIdentifier, true)
+        .withOptFieldValue("AC", terminalPassword, true)
+        .withOptFieldValue("AD", patronPassword, true)
+        .build();
+  }
+}

--- a/src/test/java/org/folio/edge/sip2/support/response/PatronStatusResponseParser.java
+++ b/src/test/java/org/folio/edge/sip2/support/response/PatronStatusResponseParser.java
@@ -1,0 +1,71 @@
+package org.folio.edge.sip2.support.response;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import org.folio.edge.sip2.domain.messages.enumerations.PatronStatus;
+import org.folio.edge.sip2.domain.messages.responses.PatronStatusResponse;
+
+public class PatronStatusResponseParser extends Sip2ResponseParser<PatronStatusResponse> {
+
+  public PatronStatusResponseParser(char delimiter, String timezone) {
+    super(delimiter, timezone);
+  }
+
+  @Override
+  public PatronStatusResponse parse(String responseMessage) {
+    if (responseMessage == null || responseMessage.length() < 2) {
+      throw new IllegalArgumentException("Invalid response message");
+    }
+
+    position = 0;
+    var messageChars = responseMessage.toCharArray();
+    var statusCode = parseString(messageChars, 2);
+    if (!"24".equals(statusCode)) {
+      throw new IllegalArgumentException("Invalid message type: expected 24, got: " + statusCode);
+    }
+
+    var builder = PatronStatusResponse.builder();
+    builder.patronStatus(parsePatronStatus(messageChars, 14));
+    parseString(messageChars, 3);
+    builder.transactionDate(parseDateTime(messageChars));
+
+    var screenMessages = new ArrayList<String>();
+
+    while (position < messageChars.length && messageChars[position] != delimiter) {
+      var fieldCode = parseFieldCode(messageChars);
+      var fieldValue = parseVariableLengthField(messageChars);
+
+      switch (fieldCode) {
+        case "AO" -> builder.institutionId(fieldValue);
+        case "AA" -> builder.patronIdentifier(fieldValue);
+        case "AE" -> builder.personalName(fieldValue);
+        case "AF" -> screenMessages.add(fieldValue);
+        case "BL" -> builder.validPatron(parseBoolean(fieldValue));
+        case "CQ" -> builder.validPatronPassword(parseBoolean(fieldValue));
+        case "BV" -> builder.feeAmount(fieldValue);
+        default -> {
+          // ignore unrecognized fields
+        }
+      }
+
+      if (position < messageChars.length && messageChars[position] == delimiter) {
+        position++;
+      }
+    }
+
+    builder.screenMessage(screenMessages.isEmpty() ? null : screenMessages);
+    return builder.build();
+  }
+
+  private EnumSet<PatronStatus> parsePatronStatus(char[] messageChars, int length) {
+    var statuses = EnumSet.noneOf(PatronStatus.class);
+    var statusValues = PatronStatus.values();
+    for (int i = 0; i < length && i < statusValues.length; i++) {
+      if (messageChars[position + i] == 'Y') {
+        statuses.add(statusValues[i]);
+      }
+    }
+    position += length;
+    return statuses;
+  }
+}

--- a/src/test/resources/wiremock/stubs/mod-fee-fines/200-get-accounts-open-status.json
+++ b/src/test/resources/wiremock/stubs/mod-fee-fines/200-get-accounts-open-status.json
@@ -1,0 +1,63 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/accounts",
+    "headers": {
+      "x-okapi-tenant": {
+        "equalTo": "testtenant"
+      },
+      "x-okapi-token": {
+        "equalTo": "test-jwt"
+      }
+    },
+    "queryParameters": {
+      "query": {
+        "equalTo": "userId==\"bec20636-fb68-41fd-84ea-2cf910673599\" and status.name==\"Open\""
+      },
+      "limit": {
+        "equalTo": "1000"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "accounts": [
+        {
+          "amount": 25.0,
+          "remaining": 25.0,
+          "status": {
+            "name": "Open"
+          },
+          "paymentStatus": {
+            "name": "Outstanding"
+          },
+          "feeFineType": "type",
+          "feeFineOwner": "owner",
+          "callNumber": "",
+          "metadata": {
+            "createdDate": "2025-09-09T15:19:58.439+00:00",
+            "createdByUserId": "94c8673f-1873-4c6c-a177-7b5858fd0641",
+            "updatedDate": "2025-09-09T15:19:58.439+00:00",
+            "updatedByUserId": "94c8673f-1873-4c6c-a177-7b5858fd0641"
+          },
+          "userId": "bec20636-fb68-41fd-84ea-2cf910673599",
+          "feeFineId": "3344e74e-8cb7-484b-ae33-f2644ed2b268",
+          "ownerId": "591d9d91-30d5-4781-bab1-06f081c04102",
+          "id": "cee0de04-533b-4e64-91c4-bbde19064709",
+          "contributors": []
+        }
+      ],
+      "totalRecords": 1,
+      "resultInfo": {
+        "totalRecords": 1,
+        "facets": [],
+        "diagnostics": []
+      }
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/src/test/resources/wiremock/stubs/mod-fee-fines/200-get-manualblocks-with-borrowing-block.json
+++ b/src/test/resources/wiremock/stubs/mod-fee-fines/200-get-manualblocks-with-borrowing-block.json
@@ -1,0 +1,41 @@
+{
+  "priority": 2,
+  "request": {
+    "method": "GET",
+    "urlPath": "/manualblocks",
+    "headers": {
+      "x-okapi-tenant": {
+        "equalTo": "testtenant"
+      },
+      "x-okapi-token": {
+        "equalTo": "test-jwt"
+      }
+    },
+    "queryParameters": {
+      "query": {
+        "equalTo": "userId==\"bec20636-fb68-41fd-84ea-2cf910673599\""
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "manualblocks": [
+        {
+          "type": "Manual",
+          "desc": "Pay your fines to restore access",
+          "patronMessage": "Your account is blocked. Please contact the library.",
+          "borrowing": true,
+          "renewals": true,
+          "requests": true,
+          "userId": "bec20636-fb68-41fd-84ea-2cf910673599",
+          "id": "43ec8e43-4a78-45b0-a46c-88426346d3df"
+        }
+      ],
+      "totalRecords": 1
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}


### PR DESCRIPTION
### Purpose
Manual patron blocks in FOLIO were ignored by SIP2 message 24 - patron status flags (position 0+) always returned blank, so self-check machines couldn't detect blocked patrons.

### Approach
   - Message 24: validPatron() never called getManualBlocksByUserId — hardcoded empty status. Fixed to fetch blocks in parallel and populate status flags + screen message.
   - Message 64: already fetched blocks correctly but returned a generic message instead of actual block reason. Fixed to use patronMessage/desc from FOLIO.
   - Shared logic extracted into extractPatronStatusFromBlocks() and extractBlockMessages() helpers.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[SIP2-310](https://folio-org.atlassian.net/browse/SIP2-310)

### Learning and Resources (if applicable)
_Discuss any research conducted during the development of this pull request. Include links to relevant blog posts, patterns, libraries, or addons that were used to solve the problem._

### Screenshots (if applicable)
_If this pull request involves any visual changes or new features, consider including screenshots or GIFs to illustrate the changes._
