### PR TITLE
SIP2-313: Add automated patron blocks support to patron status/information response

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Fix manual patron blocks not reflected in SIP2 Patron Status Response (24) ([SIP2-310](https://folio-org.atlassian.net/browse/SIP2-310))
 * Use GitHub Workflows for Maven ([SIP2-307](https://folio-org.atlassian.net/browse/SIP2-307))
 * Fix misleading log messages when token refresh fails and recovery login is used([SIP2-316](https://folio-org.atlassian.net/browse/SIP2-316))
+* Add automated patron blocks support to patron status/information response ([SIP2-313](https://folio-org.atlassian.net/browse/SIP2-313))
 
 ---
 

--- a/src/main/java/org/folio/edge/sip2/repositories/FeeFinesRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/FeeFinesRepository.java
@@ -26,7 +26,6 @@ import org.folio.edge.sip2.domain.messages.requests.FeePaid;
 import org.folio.edge.sip2.domain.messages.responses.FeePaidResponse;
 import org.folio.edge.sip2.repositories.domain.User;
 import org.folio.edge.sip2.session.SessionData;
-import org.folio.edge.sip2.utils.CqlQuery;
 import org.folio.edge.sip2.utils.Sip2LogAdapter;
 import org.folio.edge.sip2.utils.Utils;
 import org.folio.util.PercentCodec;
@@ -223,7 +222,7 @@ public class FeeFinesRepository {
 
     @Override
     public String getPath() {
-      return "/automated-patron-blocks?query=" + CqlQuery.exactMatch("userId", userId).toText();
+      return "/automated-patron-blocks/" + userId;
     }
 
     @Override

--- a/src/main/java/org/folio/edge/sip2/repositories/FeeFinesRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/FeeFinesRepository.java
@@ -26,6 +26,7 @@ import org.folio.edge.sip2.domain.messages.requests.FeePaid;
 import org.folio.edge.sip2.domain.messages.responses.FeePaidResponse;
 import org.folio.edge.sip2.repositories.domain.User;
 import org.folio.edge.sip2.session.SessionData;
+import org.folio.edge.sip2.utils.CqlQuery;
 import org.folio.edge.sip2.utils.Sip2LogAdapter;
 import org.folio.edge.sip2.utils.Utils;
 import org.folio.util.PercentCodec;
@@ -197,12 +198,15 @@ public class FeeFinesRepository {
         new GetAutomatedBlocksByUserIdRequestData(userId, headers, sessionData);
 
     return resourceProvider.retrieveResource(requestData)
-        .otherwise(t -> {
-          log.warn(sessionData,
-              "Failed to retrieve automated patron blocks for user {}: {}", userId, t.getMessage());
-          return () -> null;
-        })
+        .onFailure(t -> logAutomatedPatronBlocksFetchError(userId, sessionData, t))
+        .otherwise(() -> null)
         .map(IResource::getResource);
+  }
+
+  private void logAutomatedPatronBlocksFetchError(String userId, SessionData sessionData,
+      Throwable t) {
+    log.warn(sessionData,
+        "Failed to retrieve automated patron blocks for user {}: {}", userId, t.getMessage());
   }
 
   protected static class GetAutomatedBlocksByUserIdRequestData implements IRequestData {
@@ -219,7 +223,7 @@ public class FeeFinesRepository {
 
     @Override
     public String getPath() {
-      return "/automated-patron-blocks?query=" + PercentCodec.encode(cqlUserId(userId));
+      return "/automated-patron-blocks?query=" + CqlQuery.exactMatch("userId", userId).toText();
     }
 
     @Override

--- a/src/main/java/org/folio/edge/sip2/repositories/FeeFinesRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/FeeFinesRepository.java
@@ -179,6 +179,60 @@ public class FeeFinesRepository {
       .map(IResource::getResource);
   }
 
+  /**
+   * Get a patron's automated patron blocks.
+   *
+   * @param userId the user's ID
+   * @param sessionData session data
+   * @return the automated patron blocks list in raw JSON or {@code null} if there was an error
+   */
+  public Future<JsonObject> getAutomatedBlocksByUserId(String userId, SessionData sessionData) {
+    Objects.requireNonNull(userId, "userId cannot be null");
+    Objects.requireNonNull(sessionData, "sessionData cannot be null");
+
+    final Map<String, String> headers = new HashMap<>();
+    headers.put(HEADER_ACCEPT, MIMETYPE_JSON);
+
+    final GetAutomatedBlocksByUserIdRequestData requestData =
+        new GetAutomatedBlocksByUserIdRequestData(userId, headers, sessionData);
+
+    return resourceProvider.retrieveResource(requestData)
+        .otherwise(t -> {
+          log.warn(sessionData,
+              "Failed to retrieve automated patron blocks for user {}: {}", userId, t.getMessage());
+          return () -> null;
+        })
+        .map(IResource::getResource);
+  }
+
+  protected static class GetAutomatedBlocksByUserIdRequestData implements IRequestData {
+    private final String userId;
+    private final Map<String, String> headers;
+    private final SessionData sessionData;
+
+    protected GetAutomatedBlocksByUserIdRequestData(String userId, Map<String, String> headers,
+        SessionData sessionData) {
+      this.userId = userId;
+      this.headers = Map.copyOf(headers);
+      this.sessionData = sessionData;
+    }
+
+    @Override
+    public String getPath() {
+      return "/automated-patron-blocks?query=" + PercentCodec.encode(cqlUserId(userId));
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+      return headers;
+    }
+
+    @Override
+    public SessionData getSessionData() {
+      return sessionData;
+    }
+  }
+
   protected static class GetManualBlocksByUserIdRequestData implements IRequestData {
     private final String userId;
     private final Map<String, String> headers;

--- a/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
@@ -354,13 +354,12 @@ public class PatronRepository {
         feeFinesRepository.getManualBlocksByUserId(userId, sessionData),
         feeFinesRepository.getAutomatedBlocksByUserId(userId, sessionData))
         .map(cf -> {
-          final JsonObject manualBlocks = cf.resultAt(0);
-          final JsonObject automatedBlocks = cf.resultAt(1);
-          final EnumSet<PatronStatus> patronStatusFlags =
-              extractPatronStatusFromBlocks(manualBlocks);
+          var manualBlocks = (JsonObject) cf.resultAt(0);
+          var automatedBlocks = (JsonObject) cf.resultAt(1);
+          var patronStatusFlags = extractPatronStatusFromBlocks(manualBlocks);
           patronStatusFlags.addAll(extractPatronStatusFromAutomatedBlocks(automatedBlocks));
           builder.patronStatus(patronStatusFlags);
-          final List<String> messages = new ArrayList<>(extractBlockMessages(manualBlocks));
+          var messages = new ArrayList<>(extractBlockMessages(manualBlocks));
           messages.addAll(extractAutomatedBlockMessages(automatedBlocks));
           if (!messages.isEmpty()) {
             builder.screenMessage(messages);
@@ -485,11 +484,11 @@ public class PatronRepository {
   private PatronInformationResponseBuilder buildPatronStatus(JsonObject manualBlocks,
       JsonObject automatedBlocks,
       PatronInformationResponseBuilder builder) {
-    final EnumSet<PatronStatus> patronStatus = extractPatronStatusFromBlocks(manualBlocks);
+    var patronStatus = extractPatronStatusFromBlocks(manualBlocks);
     patronStatus.addAll(extractPatronStatusFromAutomatedBlocks(automatedBlocks));
 
     if (!patronStatus.isEmpty()) {
-      final List<String> messages = new ArrayList<>(extractBlockMessages(manualBlocks));
+      var messages = new ArrayList<>(extractBlockMessages(manualBlocks));
       messages.addAll(extractAutomatedBlockMessages(automatedBlocks));
       builder.screenMessage(messages);
     }
@@ -498,24 +497,16 @@ public class PatronRepository {
   }
 
   private static EnumSet<PatronStatus> extractPatronStatusFromAutomatedBlocks(JsonObject blocks) {
-    final EnumSet<PatronStatus> patronStatus = EnumSet.noneOf(PatronStatus.class);
+    final var patronStatus = EnumSet.noneOf(PatronStatus.class);
 
     if (blocks != null && blocks.getInteger(FIELD_TOTAL_RECORDS, 0) > 0) {
       blocks.getJsonArray("automatedPatronBlocks", new JsonArray()).stream()
           .map(o -> (JsonObject) o)
-          .forEach(jo -> {
-            if (TRUE.equals(jo.getBoolean("blockBorrowing", FALSE))) {
-              patronStatus.addAll(EnumSet.allOf(PatronStatus.class));
-            } else {
-              if (TRUE.equals(jo.getBoolean("blockRenewals", FALSE))) {
-                patronStatus.add(RENEWAL_PRIVILEGES_DENIED);
-              }
-              if (TRUE.equals(jo.getBoolean("blockRequests", FALSE))) {
-                patronStatus.add(HOLD_PRIVILEGES_DENIED);
-                patronStatus.add(RECALL_PRIVILEGES_DENIED);
-              }
-            }
-          });
+          .map(jo -> toBlockStatusFlags(
+              jo.getBoolean("blockBorrowing", FALSE),
+              jo.getBoolean("blockRenewals", FALSE),
+              jo.getBoolean("blockRequests", FALSE)))
+          .forEach(patronStatus::addAll);
     }
 
     return patronStatus;
@@ -528,41 +519,53 @@ public class PatronRepository {
 
     return blocks.getJsonArray("automatedPatronBlocks", new JsonArray()).stream()
         .map(o -> (JsonObject) o)
-        .filter(jo -> jo.getBoolean("blockBorrowing", FALSE)
-            || jo.getBoolean("blockRenewals", FALSE)
-            || jo.getBoolean("blockRequests", FALSE))
-        .map(jo -> {
-          final String message = jo.getString("message");
-          if (StringUtils.isNotBlank(message)) {
-            return message;
-          }
-          return MESSAGE_BLOCKED_PATRON;
-        })
+        .filter(PatronRepository::hasAnyAutomatedBlock)
+        .map(PatronRepository::resolveAutomatedBlockMessage)
         .toList();
   }
 
+  private static boolean hasAnyAutomatedBlock(JsonObject jo) {
+    return jo.getBoolean("blockBorrowing", FALSE)
+        || jo.getBoolean("blockRenewals", FALSE)
+        || jo.getBoolean("blockRequests", FALSE);
+  }
+
+  private static String resolveAutomatedBlockMessage(JsonObject jo) {
+    var message = jo.getString("message");
+    return StringUtils.isNotBlank(message) ? message : MESSAGE_BLOCKED_PATRON;
+  }
+
   private static EnumSet<PatronStatus> extractPatronStatusFromBlocks(JsonObject blocks) {
-    final EnumSet<PatronStatus> patronStatus = EnumSet.noneOf(PatronStatus.class);
+    final var patronStatus = EnumSet.noneOf(PatronStatus.class);
 
     if (blocks != null && blocks.getInteger(FIELD_TOTAL_RECORDS, 0) > 0) {
       blocks.getJsonArray("manualblocks", new JsonArray()).stream()
           .map(o -> (JsonObject) o)
-          .forEach(jo -> {
-            if (jo.getBoolean("borrowing", FALSE)) {
-              patronStatus.addAll(EnumSet.allOf(PatronStatus.class));
-            } else {
-              if (jo.getBoolean("renewals", FALSE)) {
-                patronStatus.add(RENEWAL_PRIVILEGES_DENIED);
-              }
-              if (jo.getBoolean(FIELD_REQUESTS, FALSE)) {
-                patronStatus.add(HOLD_PRIVILEGES_DENIED);
-                patronStatus.add(RECALL_PRIVILEGES_DENIED);
-              }
-            }
-          });
+          .map(jo -> toBlockStatusFlags(
+              jo.getBoolean("borrowing", FALSE),
+              jo.getBoolean("renewals", FALSE),
+              jo.getBoolean(FIELD_REQUESTS, FALSE)))
+          .forEach(patronStatus::addAll);
     }
 
     return patronStatus;
+  }
+
+  private static EnumSet<PatronStatus> toBlockStatusFlags(
+      boolean borrowing, boolean renewals, boolean requests) {
+    var flags = EnumSet.noneOf(PatronStatus.class);
+    if (borrowing) {
+      flags.addAll(EnumSet.allOf(PatronStatus.class));
+    } else {
+      if (renewals) {
+        flags.add(RENEWAL_PRIVILEGES_DENIED);
+      }
+      if (requests) {
+        flags.add(HOLD_PRIVILEGES_DENIED);
+        flags.add(RECALL_PRIVILEGES_DENIED);
+      }
+    }
+    return flags;
   }
 
   protected static List<String> extractBlockMessages(JsonObject blocks) {
@@ -576,11 +579,11 @@ public class PatronRepository {
             || jo.getBoolean("renewals", FALSE)
             || jo.getBoolean(FIELD_REQUESTS, FALSE))
         .map(jo -> {
-          final String patronMessage = jo.getString("patronMessage");
+          var patronMessage = jo.getString("patronMessage");
           if (StringUtils.isNotBlank(patronMessage)) {
             return patronMessage;
           }
-          final String desc = jo.getString("desc");
+          var desc = jo.getString("desc");
           if (StringUtils.isNotBlank(desc)) {
             return desc;
           }

--- a/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
@@ -499,7 +499,7 @@ public class PatronRepository {
   private static EnumSet<PatronStatus> extractPatronStatusFromAutomatedBlocks(JsonObject blocks) {
     final var patronStatus = EnumSet.noneOf(PatronStatus.class);
 
-    if (blocks != null && blocks.getInteger(FIELD_TOTAL_RECORDS, 0) > 0) {
+    if (blocks != null) {
       blocks.getJsonArray("automatedPatronBlocks", new JsonArray()).stream()
           .map(o -> (JsonObject) o)
           .map(jo -> toBlockStatusFlags(
@@ -513,7 +513,7 @@ public class PatronRepository {
   }
 
   protected static List<String> extractAutomatedBlockMessages(JsonObject blocks) {
-    if (blocks == null || blocks.getInteger(FIELD_TOTAL_RECORDS, 0) == 0) {
+    if (blocks == null) {
       return Collections.emptyList();
     }
 

--- a/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
@@ -504,13 +504,13 @@ public class PatronRepository {
       blocks.getJsonArray("automatedPatronBlocks", new JsonArray()).stream()
           .map(o -> (JsonObject) o)
           .forEach(jo -> {
-            if (jo.getBoolean("blockBorrowing", FALSE)) {
+            if (TRUE.equals(jo.getBoolean("blockBorrowing", FALSE))) {
               patronStatus.addAll(EnumSet.allOf(PatronStatus.class));
             } else {
-              if (jo.getBoolean("blockRenewals", FALSE)) {
+              if (TRUE.equals(jo.getBoolean("blockRenewals", FALSE))) {
                 patronStatus.add(RENEWAL_PRIVILEGES_DENIED);
               }
-              if (jo.getBoolean("blockRequests", FALSE)) {
+              if (TRUE.equals(jo.getBoolean("blockRequests", FALSE))) {
                 patronStatus.add(HOLD_PRIVILEGES_DENIED);
                 patronStatus.add(RECALL_PRIVILEGES_DENIED);
               }

--- a/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
@@ -263,10 +263,11 @@ public class PatronRepository {
     addPersonalData(personal, patronInformation.getPatronIdentifier(), builder);
     final Integer startItem = patronInformation.getStartItem();
     final Integer endItem = patronInformation.getEndItem();
-    // Get manual blocks data to build patron status
-    final Future<PatronInformationResponseBuilder> manualBlocksFuture = feeFinesRepository
-        .getManualBlocksByUserId(userId, sessionData)
-        .map(blocks -> buildPatronStatus(blocks, builder));
+    // Get manual and automated blocks data to build patron status
+    final Future<PatronInformationResponseBuilder> patronStatusFuture = Future.all(
+        feeFinesRepository.getManualBlocksByUserId(userId, sessionData),
+        feeFinesRepository.getAutomatedBlocksByUserId(userId, sessionData))
+        .map(cf -> buildPatronStatus(cf.resultAt(0), cf.resultAt(1), builder));
     // Add fine count
     final Future<PatronInformationResponseBuilder> accountFuture = feeFinesRepository
         .getAccountDataByUserId(userId, sessionData)
@@ -306,7 +307,7 @@ public class PatronRepository {
         getRecalls(userId, sessionData).compose(recalls -> addRecalls(recalls, startItem, endItem,
             patronInformation.getSummary() == RECALL_ITEMS, builder));
     // When all operations complete, build and return the final PatronInformationResponse
-    return Future.all(manualBlocksFuture, accountFuture, holdsFuture,
+    return Future.all(patronStatusFuture, accountFuture, holdsFuture,
         overdueFuture, recallsFuture, loansFuture)
         .map(result -> {
           log.info(sessionData, "validPatron language:{} institutionId:{}",
@@ -349,18 +350,25 @@ public class PatronRepository {
         .getFeeAmountByUserId(userId, sessionData)
         .map(accounts -> totalAmount(sessionData, accounts, builder));
 
-    final Future<PatronStatusResponseBuilder> manualBlocksFuture = feeFinesRepository
-        .getManualBlocksByUserId(userId, sessionData)
-        .map(blocks -> {
-          builder.patronStatus(extractPatronStatusFromBlocks(blocks));
-          final List<String> messages = extractBlockMessages(blocks);
+    final Future<PatronStatusResponseBuilder> blocksFuture = Future.all(
+        feeFinesRepository.getManualBlocksByUserId(userId, sessionData),
+        feeFinesRepository.getAutomatedBlocksByUserId(userId, sessionData))
+        .map(cf -> {
+          final JsonObject manualBlocks = cf.resultAt(0);
+          final JsonObject automatedBlocks = cf.resultAt(1);
+          final EnumSet<PatronStatus> patronStatusFlags =
+              extractPatronStatusFromBlocks(manualBlocks);
+          patronStatusFlags.addAll(extractPatronStatusFromAutomatedBlocks(automatedBlocks));
+          builder.patronStatus(patronStatusFlags);
+          final List<String> messages = new ArrayList<>(extractBlockMessages(manualBlocks));
+          messages.addAll(extractAutomatedBlockMessages(automatedBlocks));
           if (!messages.isEmpty()) {
             builder.screenMessage(messages);
           }
           return builder;
         });
 
-    return Future.all(getFeeAmountFuture, manualBlocksFuture).map(cf -> builder
+    return Future.all(getFeeAmountFuture, blocksFuture).map(cf -> builder
             .language(patronStatus.getLanguage())
             .transactionDate(OffsetDateTime.now(clock))
             .institutionId(patronStatus.getInstitutionId())
@@ -474,15 +482,63 @@ public class PatronRepository {
   }
 
 
-  private PatronInformationResponseBuilder buildPatronStatus(JsonObject blocks,
+  private PatronInformationResponseBuilder buildPatronStatus(JsonObject manualBlocks,
+      JsonObject automatedBlocks,
       PatronInformationResponseBuilder builder) {
-    final EnumSet<PatronStatus> patronStatus = extractPatronStatusFromBlocks(blocks);
+    final EnumSet<PatronStatus> patronStatus = extractPatronStatusFromBlocks(manualBlocks);
+    patronStatus.addAll(extractPatronStatusFromAutomatedBlocks(automatedBlocks));
 
     if (!patronStatus.isEmpty()) {
-      builder.screenMessage(extractBlockMessages(blocks));
+      final List<String> messages = new ArrayList<>(extractBlockMessages(manualBlocks));
+      messages.addAll(extractAutomatedBlockMessages(automatedBlocks));
+      builder.screenMessage(messages);
     }
 
     return builder.patronStatus(patronStatus);
+  }
+
+  private static EnumSet<PatronStatus> extractPatronStatusFromAutomatedBlocks(JsonObject blocks) {
+    final EnumSet<PatronStatus> patronStatus = EnumSet.noneOf(PatronStatus.class);
+
+    if (blocks != null && blocks.getInteger(FIELD_TOTAL_RECORDS, 0) > 0) {
+      blocks.getJsonArray("automatedPatronBlocks", new JsonArray()).stream()
+          .map(o -> (JsonObject) o)
+          .forEach(jo -> {
+            if (jo.getBoolean("blockBorrowing", FALSE)) {
+              patronStatus.addAll(EnumSet.allOf(PatronStatus.class));
+            } else {
+              if (jo.getBoolean("blockRenewals", FALSE)) {
+                patronStatus.add(RENEWAL_PRIVILEGES_DENIED);
+              }
+              if (jo.getBoolean("blockRequests", FALSE)) {
+                patronStatus.add(HOLD_PRIVILEGES_DENIED);
+                patronStatus.add(RECALL_PRIVILEGES_DENIED);
+              }
+            }
+          });
+    }
+
+    return patronStatus;
+  }
+
+  protected static List<String> extractAutomatedBlockMessages(JsonObject blocks) {
+    if (blocks == null || blocks.getInteger(FIELD_TOTAL_RECORDS, 0) == 0) {
+      return Collections.emptyList();
+    }
+
+    return blocks.getJsonArray("automatedPatronBlocks", new JsonArray()).stream()
+        .map(o -> (JsonObject) o)
+        .filter(jo -> jo.getBoolean("blockBorrowing", FALSE)
+            || jo.getBoolean("blockRenewals", FALSE)
+            || jo.getBoolean("blockRequests", FALSE))
+        .map(jo -> {
+          final String message = jo.getString("message");
+          if (StringUtils.isNotBlank(message)) {
+            return message;
+          }
+          return MESSAGE_BLOCKED_PATRON;
+        })
+        .toList();
   }
 
   private static EnumSet<PatronStatus> extractPatronStatusFromBlocks(JsonObject blocks) {

--- a/src/test/java/org/folio/edge/sip2/api/PatronInformationIT.java
+++ b/src/test/java/org/folio/edge/sip2/api/PatronInformationIT.java
@@ -39,6 +39,7 @@ class PatronInformationIT extends AbstractErrorDetectionEnabledTest {
       "/wiremock/stubs/mod-fee-fines/200-get-accounts.json",
       "/wiremock/stubs/mod-fee-fines/200-get-manualblocks.json",
       "/wiremock/stubs/mod-fee-fines/200-get-feefines-empty.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-automated-patron-blocks.json",
   })
   void getPatronInformation_positive_holdSummaryType() throws Throwable {
     var currentTs = OffsetDateTime.now().toInstant();
@@ -78,6 +79,7 @@ class PatronInformationIT extends AbstractErrorDetectionEnabledTest {
       "/wiremock/stubs/mod-fee-fines/200-get-accounts-empty.json",
       "/wiremock/stubs/mod-fee-fines/200-get-manualblocks.json",
       "/wiremock/stubs/mod-fee-fines/500-get-feefines-invalid-query.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-automated-patron-blocks.json",
   })
   void getPatronInformation_positive_holdSummaryTypeAndEmptyRequests() throws Throwable {
     executeInSession(
@@ -116,6 +118,7 @@ class PatronInformationIT extends AbstractErrorDetectionEnabledTest {
       "/wiremock/stubs/mod-fee-fines/200-get-accounts.json",
       "/wiremock/stubs/mod-fee-fines/200-get-manualblocks.json",
       "/wiremock/stubs/mod-fee-fines/200-get-feefines-empty.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-automated-patron-blocks.json",
   })
   void getPatronInformationWithPasswordVerificationRequired_invalidPassword() throws Throwable {
     executeInSession(
@@ -155,6 +158,7 @@ class PatronInformationIT extends AbstractErrorDetectionEnabledTest {
     "/wiremock/stubs/mod-fee-fines/200-get-accounts.json",
     "/wiremock/stubs/mod-fee-fines/200-get-manualblocks.json",
     "/wiremock/stubs/mod-fee-fines/200-get-feefines-empty.json",
+    "/wiremock/stubs/mod-fee-fines/200-get-automated-patron-blocks.json",
   })
   void getPatronInformationWithPasswordVerificationRequired_validPassword() throws Throwable {
     executeInSession(
@@ -175,6 +179,44 @@ class PatronInformationIT extends AbstractErrorDetectionEnabledTest {
               var patronInfo = parseResponse(respMsg);
               assertThat(patronInfo.getValidPatron()).isTrue();
               assertThat(patronInfo.getValidPatronPassword()).isTrue();
+            }
+        ));
+  }
+
+  @Test
+  @WiremockStubs({
+      "/wiremock/stubs/mod-settings/200-get-locale.json",
+      "/wiremock/stubs/mod-settings/200-get-settings.json",
+      "/wiremock/stubs/mod-login/201-post-acs-login.json",
+      "/wiremock/stubs/mod-users/200-get-user-by-patron-identifier.json",
+      "/wiremock/stubs/mod-users-bl/200-get-user-by-id.json",
+      "/wiremock/stubs/mod-circulation/200-get-circulation-open-loans.json",
+      "/wiremock/stubs/mod-circulation/200-get-circulation-open-loans-by-due-date.json",
+      "/wiremock/stubs/mod-circulation/200-get-circulation-requests-hold.json",
+      "/wiremock/stubs/mod-circulation/200-get-circulation-requests-recall.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-accounts.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-manualblocks.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-feefines-empty.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-automated-patron-blocks-with-borrowing-block.json",
+  })
+  void getPatronInformation_withAutomatedBorrowingBlock_allStatusFlagsSetAndMessageReturned()
+      throws Throwable {
+    executeInSession(
+        successLoginExchange(),
+        sip2Exchange(
+            Sip2Commands.patronInformation(PATRON_BARCODE, HOLD_ITEMS),
+            sip2Result -> {
+              assertSuccessfulExchange(sip2Result);
+
+              var respMsg = sip2Result.getResponseMessage();
+              assertThat(respMsg).startsWith("64");
+
+              var patronInfo = parseResponse(respMsg);
+              assertThat(patronInfo.getValidPatron()).isTrue();
+              assertThat(patronInfo.getPatronStatus())
+                  .isEqualTo(EnumSet.allOf(PatronStatus.class));
+              assertThat(patronInfo.getScreenMessage())
+                  .isEqualTo(List.of("Patron has too many items checked out"));
             }
         ));
   }

--- a/src/test/java/org/folio/edge/sip2/api/PatronStatusIT.java
+++ b/src/test/java/org/folio/edge/sip2/api/PatronStatusIT.java
@@ -28,6 +28,7 @@ class PatronStatusIT extends AbstractErrorDetectionEnabledTest {
       "/wiremock/stubs/mod-users-bl/200-get-user-by-id.json",
       "/wiremock/stubs/mod-fee-fines/200-get-accounts-open-status.json",
       "/wiremock/stubs/mod-fee-fines/200-get-manualblocks.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-automated-patron-blocks.json",
   })
   void getPatronStatus_noManualBlocks_patronStatusFlagsAreEmpty() throws Throwable {
     executeInSession(
@@ -57,6 +58,7 @@ class PatronStatusIT extends AbstractErrorDetectionEnabledTest {
       "/wiremock/stubs/mod-users-bl/200-get-user-by-id.json",
       "/wiremock/stubs/mod-fee-fines/200-get-accounts-open-status.json",
       "/wiremock/stubs/mod-fee-fines/200-get-manualblocks-with-borrowing-block.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-automated-patron-blocks.json",
   })
   void getPatronStatus_withManualBorrowingBlock_allStatusFlagsSetAndMessageReturned()
       throws Throwable {
@@ -77,6 +79,39 @@ class PatronStatusIT extends AbstractErrorDetectionEnabledTest {
               assertThat(response.getScreenMessage())
                   .isEqualTo(List.of(
                       "Your account is blocked. Please contact the library."));
+            }
+        ));
+  }
+
+  @Test
+  @WiremockStubs({
+      "/wiremock/stubs/mod-settings/200-get-locale.json",
+      "/wiremock/stubs/mod-settings/200-get-settings.json",
+      "/wiremock/stubs/mod-login/201-post-acs-login.json",
+      "/wiremock/stubs/mod-users/200-get-user-by-patron-identifier.json",
+      "/wiremock/stubs/mod-users-bl/200-get-user-by-id.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-accounts-open-status.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-manualblocks.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-automated-patron-blocks-with-borrowing-block.json",
+  })
+  void getPatronStatus_withAutomatedBorrowingBlock_allStatusFlagsSetAndMessageReturned()
+      throws Throwable {
+    executeInSession(
+        successLoginExchange(),
+        sip2Exchange(
+            Sip2Commands.patronStatus(PATRON_BARCODE),
+            sip2Result -> {
+              assertSuccessfulExchange(sip2Result);
+
+              var respMsg = sip2Result.getResponseMessage();
+              assertThat(respMsg).startsWith("24");
+
+              var response = parseResponse(respMsg);
+              assertThat(response.getValidPatron()).isTrue();
+              assertThat(response.getPatronStatus())
+                  .isEqualTo(EnumSet.allOf(PatronStatus.class));
+              assertThat(response.getScreenMessage())
+                  .isEqualTo(List.of("Patron has too many items checked out"));
             }
         ));
   }

--- a/src/test/java/org/folio/edge/sip2/repositories/FeeFinesRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/FeeFinesRepositoryTests.java
@@ -677,8 +677,7 @@ class FeeFinesRepositoryTests {
       @Mock Clock clock) {
 
     final JsonObject emptyBlocksResponse = new JsonObject()
-        .put("automatedPatronBlocks", new JsonArray())
-        .put("totalRecords", 0);
+        .put("automatedPatronBlocks", new JsonArray());
 
     when(mockFolioProvider.retrieveResource(any()))
         .thenReturn(Future.succeededFuture(new FolioResource(emptyBlocksResponse,
@@ -694,7 +693,6 @@ class FeeFinesRepositoryTests {
               assertNotNull(blocks);
               assertNotNull(blocks.getJsonArray("automatedPatronBlocks"));
               assertEquals(0, blocks.getJsonArray("automatedPatronBlocks").size());
-              assertEquals(0, blocks.getInteger(FIELD_TOTAL_RECORDS));
 
               testContext.completeNow();
             })));
@@ -737,11 +735,10 @@ class FeeFinesRepositoryTests {
                 .put("blockRenewals", true)
                 .put("blockRequests", true)
                 .put("message", "Too many items checked out")
-                .put("userId", userId)))
-        .put("totalRecords", 1);
+                .put("userId", userId)));
 
     when(mockFolioProvider.retrieveResource(
-        argThat(arg -> arg.getPath().endsWith(encode("userId==\"" + userId + "\"").toString()))))
+        argThat(arg -> arg.getPath().equals("/automated-patron-blocks/" + userId))))
         .thenReturn(Future.succeededFuture(new FolioResource(blocksResponse,
             MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
 
@@ -752,7 +749,6 @@ class FeeFinesRepositoryTests {
     feeFinesRepository.getAutomatedBlocksByUserId(userId, sessionData).onComplete(
         testContext.succeeding(blocks -> testContext.verify(() -> {
           assertNotNull(blocks);
-          assertEquals(1, blocks.getInteger(FIELD_TOTAL_RECORDS));
 
           final JsonArray blocksArray = blocks.getJsonArray("automatedPatronBlocks");
           assertNotNull(blocksArray);

--- a/src/test/java/org/folio/edge/sip2/repositories/FeeFinesRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/FeeFinesRepositoryTests.java
@@ -669,4 +669,104 @@ class FeeFinesRepositoryTests {
     );
   }
 
+  @Test
+  void canGetAutomatedBlocksByUserIdWithNoBlocksApplied(Vertx vertx,
+      VertxTestContext testContext,
+      @Mock IResourceProvider<IRequestData> mockFolioProvider,
+      @Mock UsersRepository mockUsersRepository,
+      @Mock Clock clock) {
+
+    final JsonObject emptyBlocksResponse = new JsonObject()
+        .put("automatedPatronBlocks", new JsonArray())
+        .put("totalRecords", 0);
+
+    when(mockFolioProvider.retrieveResource(any()))
+        .thenReturn(Future.succeededFuture(new FolioResource(emptyBlocksResponse,
+            MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
+
+    final SessionData sessionData = TestUtils.getMockedSessionData();
+
+    final FeeFinesRepository feeFinesRepository =
+        new FeeFinesRepository(mockFolioProvider, mockUsersRepository, clock);
+    feeFinesRepository.getAutomatedBlocksByUserId(UUID.randomUUID().toString(),
+        sessionData).onComplete(
+            testContext.succeeding(blocks -> testContext.verify(() -> {
+              assertNotNull(blocks);
+              assertNotNull(blocks.getJsonArray("automatedPatronBlocks"));
+              assertEquals(0, blocks.getJsonArray("automatedPatronBlocks").size());
+              assertEquals(0, blocks.getInteger(FIELD_TOTAL_RECORDS));
+
+              testContext.completeNow();
+            })));
+  }
+
+  @Test
+  void cannotGetAutomatedBlocksByUserId(Vertx vertx,
+      VertxTestContext testContext,
+      @Mock IResourceProvider<IRequestData> mockFolioProvider,
+      @Mock UsersRepository mockUsersRepository,
+      @Mock Clock clock) {
+    when(mockFolioProvider.retrieveResource(any()))
+        .thenReturn(Future.failedFuture(new VertxException("Test failure", true)));
+
+    final SessionData sessionData = TestUtils.getMockedSessionData();
+
+    final FeeFinesRepository feeFinesRepository =
+        new FeeFinesRepository(mockFolioProvider, mockUsersRepository, clock);
+    feeFinesRepository.getAutomatedBlocksByUserId(UUID.randomUUID().toString(),
+        sessionData).onComplete(
+            testContext.succeeding(blocks -> testContext.verify(() -> {
+              assertNull(blocks);
+
+              testContext.completeNow();
+            })));
+  }
+
+  @Test
+  void canGetAutomatedBlocksByUserIdWithBlocksApplied(Vertx vertx,
+      VertxTestContext testContext,
+      @Mock IResourceProvider<IRequestData> mockFolioProvider,
+      @Mock UsersRepository mockUsersRepository,
+      @Mock Clock clock) {
+
+    final String userId = "a23eac4b-955e-451c-b4ff-6ec2f5e63e23";
+    final JsonObject blocksResponse = new JsonObject()
+        .put("automatedPatronBlocks", new JsonArray()
+            .add(new JsonObject()
+                .put("blockBorrowing", true)
+                .put("blockRenewals", true)
+                .put("blockRequests", true)
+                .put("message", "Too many items checked out")
+                .put("userId", userId)))
+        .put("totalRecords", 1);
+
+    when(mockFolioProvider.retrieveResource(
+        argThat(arg -> arg.getPath().endsWith(encode("userId==\"" + userId + "\"").toString()))))
+        .thenReturn(Future.succeededFuture(new FolioResource(blocksResponse,
+            MultiMap.caseInsensitiveMultiMap().add("x-okapi-token", "1234"))));
+
+    final SessionData sessionData = TestUtils.getMockedSessionData();
+
+    final FeeFinesRepository feeFinesRepository =
+        new FeeFinesRepository(mockFolioProvider, mockUsersRepository, clock);
+    feeFinesRepository.getAutomatedBlocksByUserId(userId, sessionData).onComplete(
+        testContext.succeeding(blocks -> testContext.verify(() -> {
+          assertNotNull(blocks);
+          assertEquals(1, blocks.getInteger(FIELD_TOTAL_RECORDS));
+
+          final JsonArray blocksArray = blocks.getJsonArray("automatedPatronBlocks");
+          assertNotNull(blocksArray);
+          assertEquals(1, blocksArray.size());
+
+          final JsonObject block = blocksArray.getJsonObject(0);
+          assertNotNull(block);
+          assertTrue(block.getBoolean("blockBorrowing"));
+          assertTrue(block.getBoolean("blockRenewals"));
+          assertTrue(block.getBoolean("blockRequests"));
+          assertEquals("Too many items checked out", block.getString("message"));
+
+          testContext.completeNow();
+        })));
+  }
+
 }

--- a/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
@@ -174,6 +174,8 @@ public class PatronRepositoryTests {
 
     when(mockFeeFinesRepository.getManualBlocksByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(manualBlocksResponse));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(any(), any()))
+        .thenReturn(Future.succeededFuture(null));
     when(mockFeeFinesRepository.getAccountDataByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(accountResponse));
     when(mockCirculationRepository.getOverdueLoansByUserId(any(), any(), any(), any(), any()))
@@ -289,6 +291,8 @@ public class PatronRepositoryTests {
 
     when(mockFeeFinesRepository.getManualBlocksByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(manualBlocksResponse));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(any(), any()))
+        .thenReturn(Future.succeededFuture(null));
     when(mockFeeFinesRepository.getAccountDataByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(accountResponse));
     when(mockCirculationRepository.getOverdueLoansByUserId(any(), any(), any(), any(), any()))
@@ -364,6 +368,8 @@ public class PatronRepositoryTests {
 
     when(mockFeeFinesRepository.getManualBlocksByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(manualBlocksResponse));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(any(), any()))
+        .thenReturn(Future.succeededFuture(null));
     when(mockFeeFinesRepository.getAccountDataByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(accountResponse));
     when(mockCirculationRepository.getOverdueLoansByUserId(any(), any(), any(), any(), any()))
@@ -480,6 +486,8 @@ public class PatronRepositoryTests {
 
     when(mockFeeFinesRepository.getManualBlocksByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(manualBlocksResponse));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(any(), any()))
+        .thenReturn(Future.succeededFuture(null));
     when(mockFeeFinesRepository.getAccountDataByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(accountResponse));
     when(mockCirculationRepository.getOverdueLoansByUserId(any(), any(), any(), any(), any()))
@@ -594,6 +602,8 @@ public class PatronRepositoryTests {
 
     when(mockFeeFinesRepository.getManualBlocksByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(manualBlocksResponse));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(any(), any()))
+        .thenReturn(Future.succeededFuture(null));
 
     when(mockFeeFinesRepository.getAccountDataByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(accountResponse));
@@ -690,6 +700,8 @@ public class PatronRepositoryTests {
 
     when(mockFeeFinesRepository.getManualBlocksByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(manualBlocksResponse));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(any(), any()))
+        .thenReturn(Future.succeededFuture(null));
     when(mockFeeFinesRepository.getAccountDataByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(accountResponse));
     when(mockCirculationRepository.getOverdueLoansByUserId(any(), any(), any(), any(), any()))
@@ -802,6 +814,8 @@ public class PatronRepositoryTests {
 
     when(mockFeeFinesRepository.getManualBlocksByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(manualBlocksResponse));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(any(), any()))
+        .thenReturn(Future.succeededFuture(null));
     when(mockFeeFinesRepository.getAccountDataByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(accountResponse));
     when(mockCirculationRepository.getOverdueLoansByUserId(any(), any(), any(), any(), any()))
@@ -912,6 +926,8 @@ public class PatronRepositoryTests {
 
     when(mockFeeFinesRepository.getManualBlocksByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(manualBlocksResponse));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(any(), any()))
+        .thenReturn(Future.succeededFuture(null));
     when(mockFeeFinesRepository.getAccountDataByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(accountResponse));
     when(mockCirculationRepository.getOverdueLoansByUserId(any(), any(), any(), any(), any()))
@@ -1043,6 +1059,8 @@ public class PatronRepositoryTests {
     when(mockFeeFinesRepository.getManualBlocksByUserId(eq(userId), any()))
         .thenReturn(Future.succeededFuture(new JsonObject()
             .put("manualblocks", new JsonArray()).put("totalRecords", 0)));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(null));
 
     PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
         mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier,
@@ -1117,6 +1135,8 @@ public class PatronRepositoryTests {
     when(mockFeeFinesRepository.getManualBlocksByUserId(eq(userId), any()))
         .thenReturn(Future.succeededFuture(new JsonObject()
             .put("manualblocks", new JsonArray()).put("totalRecords", 0)));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(null));
 
     PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
         mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier,
@@ -1242,6 +1262,8 @@ public class PatronRepositoryTests {
         .thenReturn(Future.succeededFuture(queryAccountResponse));
     when(mockFeeFinesRepository.getManualBlocksByUserId(eq(userId), any()))
         .thenReturn(Future.succeededFuture(manualBlocksResponse));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(null));
 
     final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
         mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
@@ -1331,6 +1353,8 @@ public class PatronRepositoryTests {
 
     when(mockFeeFinesRepository.getManualBlocksByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(manualBlocksResponse));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(any(), any()))
+        .thenReturn(Future.succeededFuture(null));
     when(mockFeeFinesRepository.getAccountDataByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(accountResponse));
     when(mockCirculationRepository.getOverdueLoansByUserId(any(), any(), any(), any(), any()))
@@ -1446,6 +1470,8 @@ public class PatronRepositoryTests {
 
     when(mockFeeFinesRepository.getManualBlocksByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(manualBlocksResponse));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(any(), any()))
+        .thenReturn(Future.succeededFuture(null));
     when(mockFeeFinesRepository.getAccountDataByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(accountResponse));
     when(mockCirculationRepository.getOverdueLoansByUserId(any(), any(), any(), any(), any()))
@@ -1532,6 +1558,8 @@ public class PatronRepositoryTests {
 
     when(mockFeeFinesRepository.getManualBlocksByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(manualBlocksResponse));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(any(), any()))
+        .thenReturn(Future.succeededFuture(null));
     when(mockFeeFinesRepository.getAccountDataByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(accountResponse));
     when(mockCirculationRepository.getOverdueLoansByUserId(any(), any(), any(), any(), any()))
@@ -1610,6 +1638,8 @@ public class PatronRepositoryTests {
 
     when(mockFeeFinesRepository.getManualBlocksByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(manualBlocksResponse));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(any(), any()))
+        .thenReturn(Future.succeededFuture(null));
     when(mockFeeFinesRepository.getAccountDataByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(accountResponse));
     when(mockCirculationRepository.getOverdueLoansByUserId(any(), any(), any(), any(), any()))
@@ -1983,6 +2013,8 @@ public class PatronRepositoryTests {
     final JsonObject manualBlocksResponse = new JsonObject(manualBlocksResponseJson);
     when(mockFeeFinesRepository.getManualBlocksByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(manualBlocksResponse));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(any(), any()))
+        .thenReturn(Future.succeededFuture(null));
     when(mockFeeFinesRepository.getAccountDataByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(null));
     when(mockCirculationRepository.getOverdueLoansByUserId(any(), any(), any(), any(), any()))
@@ -2076,6 +2108,8 @@ public class PatronRepositoryTests {
 
     when(mockFeeFinesRepository.getManualBlocksByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(manualBlocksResponse));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(any(), any()))
+        .thenReturn(Future.succeededFuture(null));
     when(mockFeeFinesRepository.getAccountDataByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(null));
     when(mockCirculationRepository.getOverdueLoansByUserId(any(), any(), any(), any(), any()))
@@ -2176,6 +2210,8 @@ public class PatronRepositoryTests {
 
     when(mockFeeFinesRepository.getManualBlocksByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(manualBlocksResponse));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(any(), any()))
+        .thenReturn(Future.succeededFuture(null));
     final String accountResponseJson = getJsonFromFile("json/account_request_response.json");
     final JsonObject accountResponse = new JsonObject(accountResponseJson);
     when(mockFeeFinesRepository.getAccountDataByUserId(any(), any()))
@@ -2593,6 +2629,8 @@ public class PatronRepositoryTests {
 
     when(mockFeeFinesRepository.getManualBlocksByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(manualBlocksResponse));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(any(), any()))
+        .thenReturn(Future.succeededFuture(null));
     when(mockFeeFinesRepository.getAccountDataByUserId(any(), any()))
         .thenReturn(Future.succeededFuture(accountResponse));
     when(mockCirculationRepository.getOverdueLoansByUserId(any(), any(), any(), any(), any()))
@@ -2662,6 +2700,422 @@ public class PatronRepositoryTests {
 
           testContext.completeNow();
         })));
+  }
+
+  @Test
+  void canPerformPatronStatusWithAutomatedBlocks(Vertx vertx,
+      VertxTestContext testContext,
+      @Mock PasswordVerifier mockPasswordVerifier,
+      @Mock FeeFinesRepository mockFeeFinesRepository,
+      @Mock CirculationRepository mockCirculationRepository,
+      @Mock UsersRepository mockUsersRepository) {
+    final String patronIdentifier = "1029384756";
+    final String patronPassword = "1234";
+    final String institutionId = "diku";
+    final String userId = "99a81cee-d439-42c8-9860-2bd1de881c4a";
+    final String userBarcode = "2349871212";
+    final Clock clock = TestUtils.getUtcFixedClock();
+    final Float feeAmount = 34.50f;
+    final Personal personal = new Personal.Builder()
+        .firstName("Joe")
+        .middleName("Zee")
+        .lastName("Blow")
+        .build();
+    final User user = new User.Builder()
+        .id(userId)
+        .barcode(userBarcode)
+        .personal(personal)
+        .build();
+
+    final ExtendedUser extendedUser = new ExtendedUser();
+    extendedUser.setUser(user);
+    extendedUser.setPatronGroup("patrons", "The Library Patrons", "12335");
+
+    final PatronStatusRequest patronStatus = PatronStatusRequest.builder()
+        .patronIdentifier(patronIdentifier)
+        .patronPassword(patronPassword)
+        .institutionId(institutionId)
+        .transactionDate(OffsetDateTime.now())
+        .build();
+
+    final JsonObject queryAccountResponse = new JsonObject()
+        .put("accounts", new JsonArray()
+            .add(new JsonObject()
+                .put("remaining", feeAmount)
+                .put("id", "2345")));
+
+    final JsonObject automatedBlocksResponse = new JsonObject()
+        .put("automatedPatronBlocks", new JsonArray()
+            .add(new JsonObject()
+                .put("blockBorrowing", true)
+                .put("blockRenewals", true)
+                .put("blockRequests", true)
+                .put("message", "Patron has too many items checked out")))
+        .put("totalRecords", 1);
+
+    when(mockPasswordVerifier.verifyPatronPassword(anyString(), anyString(), any()))
+        .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder()
+            .extendedUser(extendedUser).build()));
+    when(mockFeeFinesRepository.getFeeAmountByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(queryAccountResponse));
+    when(mockFeeFinesRepository.getManualBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(new JsonObject()
+            .put("manualblocks", new JsonArray()).put("totalRecords", 0)));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(automatedBlocksResponse));
+
+    final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
+        mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
+    final SessionData sessionData = TestUtils.getMockedSessionData();
+
+    patronRepository.performPatronStatusCommand(patronStatus, sessionData).onComplete(
+        testContext.succeeding(patronStatusResponse -> testContext.verify(() -> {
+          assertNotNull(patronStatusResponse);
+          assertEquals(true, patronStatusResponse.getValidPatron());
+          assertEquals(feeAmount.toString(), patronStatusResponse.getFeeAmount());
+          assertEquals("Joe Zee Blow", patronStatusResponse.getPersonalName());
+          assertEquals(EnumSet.allOf(PatronStatus.class), patronStatusResponse.getPatronStatus());
+          assertEquals(Collections.singletonList("Patron has too many items checked out"),
+              patronStatusResponse.getScreenMessage());
+          testContext.completeNow();
+        }))
+    );
+  }
+
+  @Test
+  void canPerformPatronStatusWithAutomatedBlocksApiUnavailable(Vertx vertx,
+      VertxTestContext testContext,
+      @Mock PasswordVerifier mockPasswordVerifier,
+      @Mock FeeFinesRepository mockFeeFinesRepository,
+      @Mock CirculationRepository mockCirculationRepository,
+      @Mock UsersRepository mockUsersRepository) {
+    final String patronIdentifier = "1029384756";
+    final String patronPassword = "1234";
+    final String institutionId = "diku";
+    final String userId = "99a81cee-d439-42c8-9860-2bd1de881c4a";
+    final String userBarcode = "2349871212";
+    final Clock clock = TestUtils.getUtcFixedClock();
+    final Float feeAmount = 34.50f;
+    final Personal personal = new Personal.Builder()
+        .firstName("Joe")
+        .middleName("Zee")
+        .lastName("Blow")
+        .build();
+    final User user = new User.Builder()
+        .id(userId)
+        .barcode(userBarcode)
+        .personal(personal)
+        .build();
+
+    final ExtendedUser extendedUser = new ExtendedUser();
+    extendedUser.setUser(user);
+    extendedUser.setPatronGroup("patrons", "The Library Patrons", "12335");
+
+    final PatronStatusRequest patronStatus = PatronStatusRequest.builder()
+        .patronIdentifier(patronIdentifier)
+        .patronPassword(patronPassword)
+        .institutionId(institutionId)
+        .transactionDate(OffsetDateTime.now())
+        .build();
+
+    final JsonObject queryAccountResponse = new JsonObject()
+        .put("accounts", new JsonArray()
+            .add(new JsonObject()
+                .put("remaining", feeAmount)
+                .put("id", "2345")));
+
+    when(mockPasswordVerifier.verifyPatronPassword(anyString(), anyString(), any()))
+        .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder()
+            .extendedUser(extendedUser).build()));
+    when(mockFeeFinesRepository.getFeeAmountByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(queryAccountResponse));
+    when(mockFeeFinesRepository.getManualBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(new JsonObject()
+            .put("manualblocks", new JsonArray()).put("totalRecords", 0)));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(null));
+
+    final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
+        mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
+    final SessionData sessionData = TestUtils.getMockedSessionData();
+
+    patronRepository.performPatronStatusCommand(patronStatus, sessionData).onComplete(
+        testContext.succeeding(patronStatusResponse -> testContext.verify(() -> {
+          assertNotNull(patronStatusResponse);
+          assertEquals(true, patronStatusResponse.getValidPatron());
+          assertTrue(patronStatusResponse.getPatronStatus().isEmpty());
+          assertNull(patronStatusResponse.getScreenMessage());
+          testContext.completeNow();
+        }))
+    );
+  }
+
+  @Test
+  void extractAutomatedBlockMessagesReturnsMessageField() {
+    final JsonObject blocks = new JsonObject()
+        .put("totalRecords", 1)
+        .put("automatedPatronBlocks", new JsonArray().add(new JsonObject()
+            .put("blockBorrowing", true)
+            .put("blockRenewals", false)
+            .put("blockRequests", false)
+            .put("message", "Too many checked out")));
+    assertEquals(Collections.singletonList("Too many checked out"),
+        PatronRepository.extractAutomatedBlockMessages(blocks));
+  }
+
+  @Test
+  void extractAutomatedBlockMessagesFallsBackToDefaultMessage() {
+    final JsonObject blocks = new JsonObject()
+        .put("totalRecords", 1)
+        .put("automatedPatronBlocks", new JsonArray().add(new JsonObject()
+            .put("blockBorrowing", false)
+            .put("blockRenewals", true)
+            .put("blockRequests", false)));
+    assertEquals(Collections.singletonList(PatronRepository.MESSAGE_BLOCKED_PATRON),
+        PatronRepository.extractAutomatedBlockMessages(blocks));
+  }
+
+  @Test
+  void canPerformPatronStatusWithOnlyAutomatedRenewalBlock(Vertx vertx,
+      VertxTestContext testContext,
+      @Mock PasswordVerifier mockPasswordVerifier,
+      @Mock FeeFinesRepository mockFeeFinesRepository,
+      @Mock CirculationRepository mockCirculationRepository,
+      @Mock UsersRepository mockUsersRepository) {
+    final String userId = "99a81cee-d439-42c8-9860-2bd1de881c4a";
+    final Clock clock = TestUtils.getUtcFixedClock();
+    final ExtendedUser extendedUser = buildExtendedUser(userId);
+    final PatronStatusRequest patronStatus = buildPatronStatusRequest();
+
+    when(mockPasswordVerifier.verifyPatronPassword(anyString(), anyString(), any()))
+        .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder()
+            .extendedUser(extendedUser).build()));
+    when(mockFeeFinesRepository.getFeeAmountByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(new JsonObject()
+            .put("accounts", new JsonArray()).put("totalRecords", 0)));
+    when(mockFeeFinesRepository.getManualBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(new JsonObject()
+            .put("manualblocks", new JsonArray()).put("totalRecords", 0)));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(new JsonObject()
+            .put("totalRecords", 1)
+            .put("automatedPatronBlocks", new JsonArray().add(new JsonObject()
+                .put("blockBorrowing", false)
+                .put("blockRenewals", true)
+                .put("blockRequests", false)
+                .put("message", "Too many renewals")))));
+
+    final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
+        mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
+    final SessionData sessionData = TestUtils.getMockedSessionData();
+
+    patronRepository.performPatronStatusCommand(patronStatus, sessionData).onComplete(
+        testContext.succeeding(patronStatusResponse -> testContext.verify(() -> {
+          assertNotNull(patronStatusResponse);
+          assertEquals(true, patronStatusResponse.getValidPatron());
+          assertEquals(EnumSet.of(RENEWAL_PRIVILEGES_DENIED),
+              patronStatusResponse.getPatronStatus());
+          assertEquals(Collections.singletonList("Too many renewals"),
+              patronStatusResponse.getScreenMessage());
+          testContext.completeNow();
+        }))
+    );
+  }
+
+  @Test
+  void canPerformPatronStatusWithOnlyAutomatedRequestBlock(Vertx vertx,
+      VertxTestContext testContext,
+      @Mock PasswordVerifier mockPasswordVerifier,
+      @Mock FeeFinesRepository mockFeeFinesRepository,
+      @Mock CirculationRepository mockCirculationRepository,
+      @Mock UsersRepository mockUsersRepository) {
+    final String userId = "99a81cee-d439-42c8-9860-2bd1de881c4a";
+    final Clock clock = TestUtils.getUtcFixedClock();
+    final ExtendedUser extendedUser = buildExtendedUser(userId);
+    final PatronStatusRequest patronStatus = buildPatronStatusRequest();
+
+    when(mockPasswordVerifier.verifyPatronPassword(anyString(), anyString(), any()))
+        .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder()
+            .extendedUser(extendedUser).build()));
+    when(mockFeeFinesRepository.getFeeAmountByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(new JsonObject()
+            .put("accounts", new JsonArray()).put("totalRecords", 0)));
+    when(mockFeeFinesRepository.getManualBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(new JsonObject()
+            .put("manualblocks", new JsonArray()).put("totalRecords", 0)));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(new JsonObject()
+            .put("totalRecords", 1)
+            .put("automatedPatronBlocks", new JsonArray().add(new JsonObject()
+                .put("blockBorrowing", false)
+                .put("blockRenewals", false)
+                .put("blockRequests", true)
+                .put("message", "Too many requests")))));
+
+    final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
+        mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
+    final SessionData sessionData = TestUtils.getMockedSessionData();
+
+    patronRepository.performPatronStatusCommand(patronStatus, sessionData).onComplete(
+        testContext.succeeding(patronStatusResponse -> testContext.verify(() -> {
+          assertNotNull(patronStatusResponse);
+          assertEquals(true, patronStatusResponse.getValidPatron());
+          assertEquals(EnumSet.of(HOLD_PRIVILEGES_DENIED, RECALL_PRIVILEGES_DENIED),
+              patronStatusResponse.getPatronStatus());
+          assertEquals(Collections.singletonList("Too many requests"),
+              patronStatusResponse.getScreenMessage());
+          testContext.completeNow();
+        }))
+    );
+  }
+
+  @Test
+  void canPerformPatronStatusWithManualAndAutomatedBlocksMerged(Vertx vertx,
+      VertxTestContext testContext,
+      @Mock PasswordVerifier mockPasswordVerifier,
+      @Mock FeeFinesRepository mockFeeFinesRepository,
+      @Mock CirculationRepository mockCirculationRepository,
+      @Mock UsersRepository mockUsersRepository) {
+    final String userId = "99a81cee-d439-42c8-9860-2bd1de881c4a";
+    final Clock clock = TestUtils.getUtcFixedClock();
+    final ExtendedUser extendedUser = buildExtendedUser(userId);
+    final PatronStatusRequest patronStatus = buildPatronStatusRequest();
+
+    when(mockPasswordVerifier.verifyPatronPassword(anyString(), anyString(), any()))
+        .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder()
+            .extendedUser(extendedUser).build()));
+    when(mockFeeFinesRepository.getFeeAmountByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(new JsonObject()
+            .put("accounts", new JsonArray()).put("totalRecords", 0)));
+    when(mockFeeFinesRepository.getManualBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(getManualBlockJsonObject(false, true, false)));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(new JsonObject()
+            .put("totalRecords", 1)
+            .put("automatedPatronBlocks", new JsonArray().add(new JsonObject()
+                .put("blockBorrowing", false)
+                .put("blockRenewals", false)
+                .put("blockRequests", true)
+                .put("message", "Too many requests")))));
+
+    final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
+        mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
+    final SessionData sessionData = TestUtils.getMockedSessionData();
+
+    patronRepository.performPatronStatusCommand(patronStatus, sessionData).onComplete(
+        testContext.succeeding(patronStatusResponse -> testContext.verify(() -> {
+          assertNotNull(patronStatusResponse);
+          assertEquals(true, patronStatusResponse.getValidPatron());
+          assertEquals(
+              EnumSet.of(RENEWAL_PRIVILEGES_DENIED, HOLD_PRIVILEGES_DENIED,
+                  RECALL_PRIVILEGES_DENIED),
+              patronStatusResponse.getPatronStatus());
+          assertEquals(List.of("Pay your fines!", "Too many requests"),
+              patronStatusResponse.getScreenMessage());
+          testContext.completeNow();
+        }))
+    );
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void canPerformPatronInformationWithAutomatedBlocks(Vertx vertx,
+      VertxTestContext testContext,
+      @Mock UsersRepository mockUsersRepository,
+      @Mock CirculationRepository mockCirculationRepository,
+      @Mock FeeFinesRepository mockFeeFinesRepository,
+      @Mock PasswordVerifier mockPasswordVerifier) {
+    final Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+    final String patronIdentifier = "1234567890";
+    final PatronInformation patronInformation = PatronInformation.builder()
+        .language(ENGLISH)
+        .transactionDate(OffsetDateTime.now())
+        .summary(RECALL_ITEMS)
+        .institutionId("diku")
+        .patronIdentifier(patronIdentifier)
+        .terminalPassword("1234")
+        .patronPassword("0989")
+        .startItem(Integer.valueOf(1))
+        .endItem(Integer.valueOf(10))
+        .build();
+
+    final String userResponseJson = getJsonFromFile("json/user_response.json");
+    final User userResponse = Json.decodeValue(userResponseJson, User.class);
+    final String userId = userResponse.getId();
+
+    final ExtendedUser extendedUser = new ExtendedUser();
+    extendedUser.setUser(userResponse);
+    extendedUser.setPatronGroup("patrons", "The Library Patrons", "12335");
+
+    final JsonObject automatedBlocksResponse = new JsonObject()
+        .put("totalRecords", 1)
+        .put("automatedPatronBlocks", new JsonArray().add(new JsonObject()
+            .put("blockBorrowing", true)
+            .put("blockRenewals", true)
+            .put("blockRequests", true)
+            .put("message", "Patron has too many items checked out")));
+
+    final JsonObject emptyCircResponse = new JsonObject()
+        .put("loans", new JsonArray()).put("totalRecords", 0);
+    final JsonObject emptyRequestsResponse = new JsonObject()
+        .put("requests", new JsonArray()).put("totalRecords", 0);
+    final JsonObject emptyAccountResponse = new JsonObject()
+        .put("accounts", new JsonArray()).put("feesfines", new JsonArray())
+        .put("totalRecords", 0);
+
+    when(mockPasswordVerifier.verifyPatronPassword(eq(patronIdentifier), anyString(), any()))
+        .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder()
+            .extendedUser(extendedUser).build()));
+    when(mockFeeFinesRepository.getManualBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(new JsonObject()
+            .put("manualblocks", new JsonArray()).put("totalRecords", 0)));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(automatedBlocksResponse));
+    when(mockFeeFinesRepository.getAccountDataByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(emptyAccountResponse));
+    when(mockCirculationRepository.getLoansByUserId(eq(userId), any(), any(), any()))
+        .thenReturn(Future.succeededFuture(emptyCircResponse));
+    when(mockCirculationRepository.getOverdueLoansByUserId(
+        eq(userId), any(), any(), any(), any()))
+        .thenReturn(Future.succeededFuture(emptyCircResponse));
+    when(mockCirculationRepository.getRequestsByUserId(
+        eq(userId), eq("Hold"), any(), any(), any()))
+        .thenReturn(Future.succeededFuture(emptyRequestsResponse));
+
+    final SessionData sessionData = TestUtils.getMockedSessionData();
+
+    final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
+        mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
+    patronRepository.performPatronInformationCommand(patronInformation, sessionData).onComplete(
+        testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
+          assertNotNull(patronInformationResponse);
+          assertTrue(patronInformationResponse.getValidPatron());
+          assertEquals(EnumSet.allOf(PatronStatus.class),
+              patronInformationResponse.getPatronStatus());
+          assertEquals(Collections.singletonList("Patron has too many items checked out"),
+              patronInformationResponse.getScreenMessage());
+          testContext.completeNow();
+        })));
+  }
+
+  private static ExtendedUser buildExtendedUser(String userId) {
+    final Personal personal = new Personal.Builder()
+        .firstName("Joe").middleName("Zee").lastName("Blow").build();
+    final User user = new User.Builder()
+        .id(userId).barcode("2349871212").personal(personal).build();
+    final ExtendedUser extendedUser = new ExtendedUser();
+    extendedUser.setUser(user);
+    extendedUser.setPatronGroup("patrons", "The Library Patrons", "12335");
+    return extendedUser;
+  }
+
+  private static PatronStatusRequest buildPatronStatusRequest() {
+    return PatronStatusRequest.builder()
+        .patronIdentifier("1029384756")
+        .patronPassword("1234")
+        .institutionId("diku")
+        .transactionDate(OffsetDateTime.now())
+        .build();
   }
 
   private static Stream<String> provideBlankPasswords() {

--- a/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
@@ -2853,7 +2853,6 @@ public class PatronRepositoryTests {
   @Test
   void extractAutomatedBlockMessagesReturnsMessageField() {
     final JsonObject blocks = new JsonObject()
-        .put("totalRecords", 1)
         .put("automatedPatronBlocks", new JsonArray().add(new JsonObject()
             .put("blockBorrowing", true)
             .put("blockRenewals", false)
@@ -2866,7 +2865,6 @@ public class PatronRepositoryTests {
   @Test
   void extractAutomatedBlockMessagesFallsBackToDefaultMessage() {
     final JsonObject blocks = new JsonObject()
-        .put("totalRecords", 1)
         .put("automatedPatronBlocks", new JsonArray().add(new JsonObject()
             .put("blockBorrowing", false)
             .put("blockRenewals", true)
@@ -2898,7 +2896,6 @@ public class PatronRepositoryTests {
             .put("manualblocks", new JsonArray()).put("totalRecords", 0)));
     when(mockFeeFinesRepository.getAutomatedBlocksByUserId(eq(userId), any()))
         .thenReturn(Future.succeededFuture(new JsonObject()
-            .put("totalRecords", 1)
             .put("automatedPatronBlocks", new JsonArray().add(new JsonObject()
                 .put("blockBorrowing", false)
                 .put("blockRenewals", true)

--- a/src/test/resources/json/automated_patron_blocks_response.json
+++ b/src/test/resources/json/automated_patron_blocks_response.json
@@ -1,0 +1,12 @@
+{
+  "automatedPatronBlocks" : [ {
+    "patronBlockConditionId" : "1a72f2de-5dd4-4543-a880-e0df97f9e9ad",
+    "blockBorrowing" : true,
+    "blockRenewals" : true,
+    "blockRequests" : true,
+    "message" : "Patron has too many items checked out",
+    "code" : "MAX_NUMBER_OF_ITEMS_CHARGED_OUT",
+    "userId" : "a23eac4b-955e-451c-b4ff-6ec2f5e63e23"
+  } ],
+  "totalRecords" : 1
+}

--- a/src/test/resources/json/automated_patron_blocks_response.json
+++ b/src/test/resources/json/automated_patron_blocks_response.json
@@ -7,6 +7,5 @@
     "message" : "Patron has too many items checked out",
     "code" : "MAX_NUMBER_OF_ITEMS_CHARGED_OUT",
     "userId" : "a23eac4b-955e-451c-b4ff-6ec2f5e63e23"
-  } ],
-  "totalRecords" : 1
+  } ]
 }

--- a/src/test/resources/wiremock/stubs/mod-fee-fines/200-get-automated-patron-blocks-with-borrowing-block.json
+++ b/src/test/resources/wiremock/stubs/mod-fee-fines/200-get-automated-patron-blocks-with-borrowing-block.json
@@ -2,18 +2,13 @@
   "priority": 2,
   "request": {
     "method": "GET",
-    "urlPath": "/automated-patron-blocks",
+    "urlPath": "/automated-patron-blocks/bec20636-fb68-41fd-84ea-2cf910673599",
     "headers": {
       "x-okapi-tenant": {
         "equalTo": "testtenant"
       },
       "x-okapi-token": {
         "equalTo": "test-jwt"
-      }
-    },
-    "queryParameters": {
-      "query": {
-        "equalTo": "userId==\"bec20636-fb68-41fd-84ea-2cf910673599\""
       }
     }
   },
@@ -30,8 +25,7 @@
           "code": "MAX_NUMBER_OF_ITEMS_CHARGED_OUT",
           "userId": "bec20636-fb68-41fd-84ea-2cf910673599"
         }
-      ],
-      "totalRecords": 1
+      ]
     },
     "headers": {
       "Content-Type": "application/json"

--- a/src/test/resources/wiremock/stubs/mod-fee-fines/200-get-automated-patron-blocks-with-borrowing-block.json
+++ b/src/test/resources/wiremock/stubs/mod-fee-fines/200-get-automated-patron-blocks-with-borrowing-block.json
@@ -1,0 +1,40 @@
+{
+  "priority": 2,
+  "request": {
+    "method": "GET",
+    "urlPath": "/automated-patron-blocks",
+    "headers": {
+      "x-okapi-tenant": {
+        "equalTo": "testtenant"
+      },
+      "x-okapi-token": {
+        "equalTo": "test-jwt"
+      }
+    },
+    "queryParameters": {
+      "query": {
+        "equalTo": "userId==\"bec20636-fb68-41fd-84ea-2cf910673599\""
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "automatedPatronBlocks": [
+        {
+          "patronBlockConditionId": "1a72f2de-5dd4-4543-a880-e0df97f9e9ad",
+          "blockBorrowing": true,
+          "blockRenewals": false,
+          "blockRequests": false,
+          "message": "Patron has too many items checked out",
+          "code": "MAX_NUMBER_OF_ITEMS_CHARGED_OUT",
+          "userId": "bec20636-fb68-41fd-84ea-2cf910673599"
+        }
+      ],
+      "totalRecords": 1
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/src/test/resources/wiremock/stubs/mod-fee-fines/200-get-automated-patron-blocks.json
+++ b/src/test/resources/wiremock/stubs/mod-fee-fines/200-get-automated-patron-blocks.json
@@ -2,7 +2,7 @@
   "priority": 1,
   "request": {
     "method": "GET",
-    "urlPath": "/automated-patron-blocks",
+    "urlPath": "/automated-patron-blocks/bec20636-fb68-41fd-84ea-2cf910673599",
     "headers": {
       "x-okapi-tenant": {
         "equalTo": "testtenant"
@@ -10,18 +10,12 @@
       "x-okapi-token": {
         "equalTo": "test-jwt"
       }
-    },
-    "queryParameters": {
-      "query": {
-        "equalTo": "userId==\"bec20636-fb68-41fd-84ea-2cf910673599\""
-      }
     }
   },
   "response": {
     "status": 200,
     "jsonBody": {
-      "automatedPatronBlocks": [],
-      "totalRecords": 0
+      "automatedPatronBlocks": []
     },
     "headers": {
       "Content-Type": "application/json"

--- a/src/test/resources/wiremock/stubs/mod-fee-fines/200-get-automated-patron-blocks.json
+++ b/src/test/resources/wiremock/stubs/mod-fee-fines/200-get-automated-patron-blocks.json
@@ -1,0 +1,30 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/automated-patron-blocks",
+    "headers": {
+      "x-okapi-tenant": {
+        "equalTo": "testtenant"
+      },
+      "x-okapi-token": {
+        "equalTo": "test-jwt"
+      }
+    },
+    "queryParameters": {
+      "query": {
+        "equalTo": "userId==\"bec20636-fb68-41fd-84ea-2cf910673599\""
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "automatedPatronBlocks": [],
+      "totalRecords": 0
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}


### PR DESCRIPTION
### Purpose
Patron status and patron information responses now reflect automated patron blocks (from /automated-patron-blocks) alongside existing manual blocks. Previously only manual blocks affected SIP2 patron status flags and screen messages

### Approach
  - Added getAutomatedBlocksByUserId() to FeeFinesRepository — fetches /automated-patron-blocks?query=userId==...; logs a warning and gracefully returns null on failure so a down endpoint never surfaces as a SIP2 error                                                                                                                                           
  - Both validPatron(PatronStatusRequest) and validPatron(PatronInformation) in PatronRepository now fetch manual and automated blocks in parallel via Future.all(), then merge the resulting EnumSet<PatronStatus> flags (union) and concatenate screen messages                                                                                                     
  - Block-to-flag mapping mirrors manual block logic: blockBorrowing → all 14 flags, blockRenewals → RENEWAL_PRIVILEGES_DENIED, blockRequests → HOLD_PRIVILEGES_DENIED + RECALL_PRIVILEGES_DENIED                                                                                                                                                          
  - Tests: 3 new FeeFinesRepositoryTests, 7 new PatronRepositoryTests (including partial-block and merge scenarios), 1 new PatronStatusIT, 1 new PatronInformationIT

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [x] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[SIP2-313](https://folio-org.atlassian.net/browse/SIP2-313)

### Learning and Resources (if applicable)
_Discuss any research conducted during the development of this pull request. Include links to relevant blog posts, patterns, libraries, or addons that were used to solve the problem._

### Screenshots (if applicable)
_If this pull request involves any visual changes or new features, consider including screenshots or GIFs to illustrate the changes._
