### PR TITLE
SIP2-309: Fix doPinCheck failing when FOLIO returns 200 without Content-Type header

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Fix manual patron blocks not reflected in SIP2 Patron Status Response (24) ([SIP2-310](https://folio-org.atlassian.net/browse/SIP2-310))
 * Use GitHub Workflows for Maven ([SIP2-307](https://folio-org.atlassian.net/browse/SIP2-307))
 * Fix misleading log messages when token refresh fails and recovery login is used([SIP2-316](https://folio-org.atlassian.net/browse/SIP2-316))
+* Fix doPinCheck failing when FOLIO returns 200 without Content-Type header([SIP2-309](https://folio-org.atlassian.net/browse/SIP2-309))
 
 ---
 

--- a/src/main/java/org/folio/edge/sip2/repositories/FolioResourceProvider.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/FolioResourceProvider.java
@@ -83,7 +83,8 @@ public class FolioResourceProvider implements IResourceProvider<IRequestData> {
     log.debug(sessionData, "Doing pin verification at {}", requestData::getPath);
     return initHttpRequest(POST, requestData)
         .flatMap(request -> request.sendJsonObject(requestData.getBody()))
-        .expecting(getHttpRequestExpectations(sessionData, SC_SUCCESS))
+        .expecting(SC_SUCCESS.wrappingFailure(
+            (head, err) -> getHttpRequestError(sessionData, head, err)))
         .map(Boolean.TRUE)
         .onFailure(e -> log.error(sessionData, "Pin check failed", e));
   }

--- a/src/test/java/org/folio/edge/sip2/api/PatronInformationIT.java
+++ b/src/test/java/org/folio/edge/sip2/api/PatronInformationIT.java
@@ -179,6 +179,84 @@ class PatronInformationIT extends AbstractErrorDetectionEnabledTest {
         ));
   }
 
+  @Test
+  @WiremockStubs({
+      "/wiremock/stubs/mod-settings/200-get-locale.json",
+      "/wiremock/stubs/mod-settings/200-get-settings(pin-validation).json",
+      "/wiremock/stubs/mod-login/201-post-acs-login.json",
+      "/wiremock/stubs/mod-users/200-get-user-by-patron-identifier.json",
+      "/wiremock/stubs/mod-users/200-post-patron-pin.json",
+      "/wiremock/stubs/mod-users-bl/200-get-user-by-id.json",
+      "/wiremock/stubs/mod-circulation/200-get-circulation-open-loans.json",
+      "/wiremock/stubs/mod-circulation/200-get-circulation-open-loans-by-due-date.json",
+      "/wiremock/stubs/mod-circulation/200-get-circulation-requests-hold.json",
+      "/wiremock/stubs/mod-circulation/200-get-circulation-requests-recall.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-accounts.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-manualblocks.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-feefines-empty.json",
+  })
+  void getPatronInformation_positive_pinVerificationEnabled() throws Throwable {
+    executeInSession(
+        successLoginExchange(),
+        sip2Exchange(
+            PatronInformationCommand.builder()
+                .patronIdentifier(PATRON_BARCODE)
+                .languageCode(LanguageMapper.ENGLISH)
+                .summary(HOLD_ITEMS)
+                .patronPassword("132456")
+                .build(),
+            sip2Result -> {
+              assertSuccessfulExchange(sip2Result);
+
+              var respMsg = sip2Result.getResponseMessage();
+              assertThat(respMsg).startsWith("64");
+
+              var patronInfo = parseResponse(respMsg);
+              assertThat(patronInfo.getValidPatron()).isTrue();
+              assertThat(patronInfo.getValidPatronPassword()).isTrue();
+            }
+        ));
+  }
+
+  @Test
+  @WiremockStubs({
+      "/wiremock/stubs/mod-settings/200-get-locale.json",
+      "/wiremock/stubs/mod-settings/200-get-settings(pin-validation).json",
+      "/wiremock/stubs/mod-login/201-post-acs-login.json",
+      "/wiremock/stubs/mod-users/200-get-user-by-patron-identifier.json",
+      "/wiremock/stubs/mod-users/422-post-patron-pin.json",
+      "/wiremock/stubs/mod-users-bl/200-get-user-by-id.json",
+      "/wiremock/stubs/mod-circulation/200-get-circulation-open-loans.json",
+      "/wiremock/stubs/mod-circulation/200-get-circulation-open-loans-by-due-date.json",
+      "/wiremock/stubs/mod-circulation/200-get-circulation-requests-hold.json",
+      "/wiremock/stubs/mod-circulation/200-get-circulation-requests-recall.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-accounts.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-manualblocks.json",
+      "/wiremock/stubs/mod-fee-fines/200-get-feefines-empty.json",
+  })
+  void getPatronInformation_negative_pinVerificationEnabledWithInvalidPin() throws Throwable {
+    executeInSession(
+        successLoginExchange(),
+        sip2Exchange(
+            PatronInformationCommand.builder()
+                .patronIdentifier(PATRON_BARCODE)
+                .languageCode(LanguageMapper.ENGLISH)
+                .summary(HOLD_ITEMS)
+                .patronPassword("132456")
+                .build(),
+            sip2Result -> {
+              assertSuccessfulExchange(sip2Result);
+
+              var respMsg = sip2Result.getResponseMessage();
+              assertThat(respMsg).startsWith("64");
+
+              var patronInfo = parseResponse(respMsg);
+              assertThat(patronInfo.getValidPatron()).isTrue();
+              assertThat(patronInfo.getValidPatronPassword()).isFalse();
+            }
+        ));
+  }
+
   private static PatronInformationResponse parseResponse(String respMsg) {
     return new PatronInformationResponseParser(delimiter, TIMEZONE).parse(respMsg);
   }

--- a/src/test/java/org/folio/edge/sip2/repositories/FolioResourceProviderTest.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/FolioResourceProviderTest.java
@@ -230,10 +230,10 @@ class FolioResourceProviderTest {
   }
 
   @Test
-  void doPinCheck_positive_noContentResponse(VertxTestContext testContext) {
+  void doPinCheck_positive_missingContentTypeHeader(VertxTestContext testContext) {
     var requestData = testRequestDataWithBody("/patron-pin/verify",
         new JsonObject().put("pin", "1234"));
-    var httpResponse = httpResponseNoBody(204, "No Content");
+    var httpResponse = httpResponseNoBody(200, "OK");
 
     prepareRequestMocks(POST, requestData);
     when(jsonRequest.sendJsonObject(any())).thenReturn(succeededFuture(httpResponse));
@@ -249,19 +249,19 @@ class FolioResourceProviderTest {
   }
 
   @Test
-  void doPinCheck_realHttp_204NoContent(Vertx vertx, VertxTestContext testContext) {
-    var webClient = WebClient.create(vertx);
+  void doPinCheck_realHttp_200WithoutContentType(Vertx vertx, VertxTestContext testContext) {
+    var realClient = WebClient.create(vertx);
     var requestData = testRequestDataWithBody("/patron-pin/verify",
         new JsonObject().put("id", "user-id").put("pin", "1234"));
     when(loginRepository.getSessionAccessToken(any(SessionData.class)))
         .thenReturn(succeededFuture(ACCESS_TOKEN));
 
     vertx.createHttpServer()
-        .requestHandler(req -> req.response().setStatusCode(204).end())
+        .requestHandler(req -> req.response().setStatusCode(200).end())
         .listen(0)
         .compose(server -> {
           var realProvider = new FolioResourceProvider(
-              loginRepository, "http://localhost:" + server.actualPort(), webClient);
+              loginRepository, "http://localhost:" + server.actualPort(), realClient);
           return realProvider.doPinCheck(requestData)
               .compose(result -> server.close().map(result));
         })

--- a/src/test/java/org/folio/edge/sip2/repositories/FolioResourceProviderTest.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/FolioResourceProviderTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
@@ -229,6 +230,48 @@ class FolioResourceProviderTest {
   }
 
   @Test
+  void doPinCheck_positive_noContentResponse(VertxTestContext testContext) {
+    var requestData = testRequestDataWithBody("/patron-pin/verify",
+        new JsonObject().put("pin", "1234"));
+    var httpResponse = httpResponseNoBody(204, "No Content");
+
+    prepareRequestMocks(POST, requestData);
+    when(jsonRequest.sendJsonObject(any())).thenReturn(succeededFuture(httpResponse));
+    when(loginRepository.getSessionAccessToken(any(SessionData.class)))
+        .thenReturn(succeededFuture(ACCESS_TOKEN));
+
+    var resultFuture = provider.doPinCheck(requestData);
+
+    resultFuture.onComplete(testContext.succeeding(result -> {
+      assertTrue(result);
+      testContext.completeNow();
+    }));
+  }
+
+  @Test
+  void doPinCheck_realHttp_204NoContent(Vertx vertx, VertxTestContext testContext) {
+    var webClient = WebClient.create(vertx);
+    var requestData = testRequestDataWithBody("/patron-pin/verify",
+        new JsonObject().put("id", "user-id").put("pin", "1234"));
+    when(loginRepository.getSessionAccessToken(any(SessionData.class)))
+        .thenReturn(succeededFuture(ACCESS_TOKEN));
+
+    vertx.createHttpServer()
+        .requestHandler(req -> req.response().setStatusCode(204).end())
+        .listen(0)
+        .compose(server -> {
+          var realProvider = new FolioResourceProvider(
+              loginRepository, "http://localhost:" + server.actualPort(), webClient);
+          return realProvider.doPinCheck(requestData)
+              .compose(result -> server.close().map(result));
+        })
+        .onComplete(testContext.succeeding(result -> {
+          assertTrue(result);
+          testContext.completeNow();
+        }));
+  }
+
+  @Test
   void doPinCheck_negative_accessTokenMissing(VertxTestContext testContext) {
     var requestData = testRequestDataWithBody("/pin-verify", new JsonObject());
 
@@ -304,6 +347,11 @@ class FolioResourceProviderTest {
     headers.add("content-type", "application/json");
     return new HttpResponseImpl<>(HTTP_1_1, statusCode, statusMessage,
         headers, caseInsensitiveMultiMap(), emptyList(), body, emptyList());
+  }
+
+  private static HttpResponse<JsonObject> httpResponseNoBody(int statusCode, String statusMessage) {
+    return new HttpResponseImpl<>(HTTP_1_1, statusCode, statusMessage,
+        httpHeaders(), caseInsensitiveMultiMap(), emptyList(), null, emptyList());
   }
 
   private static class TestRequestData implements IRequestData {

--- a/src/test/resources/wiremock/stubs/mod-users/200-post-patron-pin.json
+++ b/src/test/resources/wiremock/stubs/mod-users/200-post-patron-pin.json
@@ -22,9 +22,6 @@
   },
   "response": {
     "status": 200,
-    "body": "",
-    "headers": {
-      "Content-Type": "application/json"
-    }
+    "body": ""
   }
 }


### PR DESCRIPTION
### Purpose
After the Vert.x 5 migration, doPinCheck incorrectly inherited a Content-Type response header check via the shared getHttpRequestExpectations helper. The /patron-pin/verify endpoint returns 200 OK without a Content-Type header, causing SIP2 patron PIN verification to fail.

### Approach
Restored the pre-migration behavior of doPinCheck — status-only check (SC_SUCCESS) without Content-Type validation, since the response body is not used. Updated the WireMock stub to reflect real FOLIO behavior (200 without Content-Type). Added two tests: a unit test reproducing the bug with a mocked 200 response without Content-Type, and a real embedded HTTP server test confirming end-to-end correctness.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [x] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[SIP2-309](https://folio-org.atlassian.net/browse/SIP2-309)

### Learning and Resources (if applicable)
_Discuss any research conducted during the development of this pull request. Include links to relevant blog posts, patterns, libraries, or addons that were used to solve the problem._

### Screenshots (if applicable)
_If this pull request involves any visual changes or new features, consider including screenshots or GIFs to illustrate the changes._
