### PR TITLE
SIP2-313: Update patron status handling to reflect automated block conditions

### DIFF
--- a/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
@@ -3,9 +3,18 @@ package org.folio.edge.sip2.repositories;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static org.folio.edge.sip2.domain.messages.enumerations.Language.UNKNOWN;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.CHARGE_PRIVILEGES_DENIED;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.EXCESSIVE_OUTSTANDING_FEES;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.EXCESSIVE_OUTSTANDING_FINES;
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.HOLD_PRIVILEGES_DENIED;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.RECALL_OVERDUE;
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.RECALL_PRIVILEGES_DENIED;
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.RENEWAL_PRIVILEGES_DENIED;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.TOO_MANY_CLAIMS_OF_ITEMS_RETURNED;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.TOO_MANY_ITEMS_BILLED;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.TOO_MANY_ITEMS_CHARGED;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.TOO_MANY_ITEMS_LOST;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.TOO_MANY_ITEMS_OVERDUE;
 import static org.folio.edge.sip2.domain.messages.enumerations.Summary.CHARGED_ITEMS;
 import static org.folio.edge.sip2.domain.messages.enumerations.Summary.EXTENDED_FEES;
 import static org.folio.edge.sip2.domain.messages.enumerations.Summary.FINE_ITEMS;
@@ -502,14 +511,38 @@ public class PatronRepository {
     if (blocks != null) {
       blocks.getJsonArray("automatedPatronBlocks", new JsonArray()).stream()
           .map(o -> (JsonObject) o)
-          .map(jo -> toBlockStatusFlags(
-              jo.getBoolean("blockBorrowing", FALSE),
-              jo.getBoolean("blockRenewals", FALSE),
-              jo.getBoolean("blockRequests", FALSE)))
+          .map(PatronRepository::toAutomatedBlockStatusFlags)
           .forEach(patronStatus::addAll);
     }
 
     return patronStatus;
+  }
+
+  private static EnumSet<PatronStatus> toAutomatedBlockStatusFlags(JsonObject jo) {
+    var flags = toBlockStatusFlags(
+        jo.getBoolean("blockBorrowing", FALSE),
+        jo.getBoolean("blockRenewals", FALSE),
+        jo.getBoolean("blockRequests", FALSE));
+    flags.addAll(toCodeStatusFlags(jo.getString("code")));
+    return flags;
+  }
+
+  private static EnumSet<PatronStatus> toCodeStatusFlags(String code) {
+    if (code == null) {
+      return EnumSet.noneOf(PatronStatus.class);
+    }
+    return switch (code) {
+      case "MAX_NUMBER_OF_ITEMS_CHARGED_OUT" -> EnumSet.of(TOO_MANY_ITEMS_CHARGED);
+      case "MAX_NUMBER_OF_OVERDUE_ITEMS" -> EnumSet.of(TOO_MANY_ITEMS_OVERDUE);
+      case "MAX_NUMBER_OF_OVERDUE_RECALLS",
+          "RECALL_OVERDUE_BY_MAX_NUMBER_OF_OVERDUE_DAYS" -> EnumSet.of(RECALL_OVERDUE);
+      case "MAX_NUMBER_OF_CLAIMS_RETURNED" -> EnumSet.of(TOO_MANY_CLAIMS_OF_ITEMS_RETURNED);
+      case "MAX_NUMBER_OF_LOST_ITEMS" -> EnumSet.of(TOO_MANY_ITEMS_LOST);
+      case "MAX_OUTSTANDING_FEE_FINE_BALANCE" ->
+          EnumSet.of(EXCESSIVE_OUTSTANDING_FINES, EXCESSIVE_OUTSTANDING_FEES);
+      case "MAX_NUMBER_OF_ITEMS_BILLED" -> EnumSet.of(TOO_MANY_ITEMS_BILLED);
+      default -> EnumSet.noneOf(PatronStatus.class);
+    };
   }
 
   protected static List<String> extractAutomatedBlockMessages(JsonObject blocks) {
@@ -555,15 +588,14 @@ public class PatronRepository {
       boolean borrowing, boolean renewals, boolean requests) {
     var flags = EnumSet.noneOf(PatronStatus.class);
     if (borrowing) {
-      flags.addAll(EnumSet.allOf(PatronStatus.class));
-    } else {
-      if (renewals) {
-        flags.add(RENEWAL_PRIVILEGES_DENIED);
-      }
-      if (requests) {
-        flags.add(HOLD_PRIVILEGES_DENIED);
-        flags.add(RECALL_PRIVILEGES_DENIED);
-      }
+      flags.add(CHARGE_PRIVILEGES_DENIED);
+    }
+    if (renewals) {
+      flags.add(RENEWAL_PRIVILEGES_DENIED);
+    }
+    if (requests) {
+      flags.add(HOLD_PRIVILEGES_DENIED);
+      flags.add(RECALL_PRIVILEGES_DENIED);
     }
     return flags;
   }

--- a/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
+++ b/src/main/java/org/folio/edge/sip2/repositories/PatronRepository.java
@@ -10,8 +10,6 @@ import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.HOLD
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.RECALL_OVERDUE;
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.RECALL_PRIVILEGES_DENIED;
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.RENEWAL_PRIVILEGES_DENIED;
-import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.TOO_MANY_CLAIMS_OF_ITEMS_RETURNED;
-import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.TOO_MANY_ITEMS_BILLED;
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.TOO_MANY_ITEMS_CHARGED;
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.TOO_MANY_ITEMS_LOST;
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.TOO_MANY_ITEMS_OVERDUE;
@@ -81,6 +79,21 @@ public class PatronRepository {
   private static final String FIELD_ITEM = "item";
   private static final String FIELD_LOANS = "loans";
   private static final String FIELD_BARCODE = "barcode";
+  // FOLIO mod-patron-blocks seed patron-block-condition ids. The automated-patron-block
+  // response only carries this id, so the informational SIP2
+  // status positions are derived from these stable seed UUIDs.
+  private static final String CONDITION_MAX_ITEMS_CHARGED_OUT =
+      "3d7c52dc-c732-4223-8bf8-e5917801386f";
+  private static final String CONDITION_MAX_OVERDUE_ITEMS =
+      "584fbd4f-6a34-4730-a6ca-73a6a6a9d845";
+  private static final String CONDITION_MAX_OVERDUE_RECALLS =
+      "e5b45031-a202-4abb-917b-e1df9346fe2c";
+  private static final String CONDITION_RECALL_OVERDUE_BY_MAX_DAYS =
+      "08530ac4-07f2-48e6-9dda-a97bc2bf7053";
+  private static final String CONDITION_MAX_LOST_ITEMS =
+      "72b67965-5b73-4840-bc0b-be8f3f6e047e";
+  private static final String CONDITION_MAX_FEE_FINE_BALANCE =
+      "cf7a0d5f-a327-4ca1-aa9e-dc55ec006b8a";
   private static final Sip2LogAdapter log = Sip2LogAdapter.getLogger(PatronRepository.class);
   // These really should come from FOLIO
   static final String MESSAGE_INVALID_PATRON =
@@ -523,24 +536,28 @@ public class PatronRepository {
         jo.getBoolean("blockBorrowing", FALSE),
         jo.getBoolean("blockRenewals", FALSE),
         jo.getBoolean("blockRequests", FALSE));
-    flags.addAll(toCodeStatusFlags(jo.getString("code")));
+    flags.addAll(toConditionStatusFlags(jo.getString("patronBlockConditionId")));
     return flags;
   }
 
-  private static EnumSet<PatronStatus> toCodeStatusFlags(String code) {
-    if (code == null) {
+  /**
+   * Maps a FOLIO patron-block-condition id to the informational SIP2 patron status
+   * positions. Only the six seed conditions defined by mod-patron-blocks have a mapping.
+   * SIP2 positions 7 (too many renewals), 8 (too many claims returned) and 13 (too many
+   * items billed) have no corresponding FOLIO automated-block condition and are never set.
+   */
+  private static EnumSet<PatronStatus> toConditionStatusFlags(String conditionId) {
+    if (conditionId == null) {
       return EnumSet.noneOf(PatronStatus.class);
     }
-    return switch (code) {
-      case "MAX_NUMBER_OF_ITEMS_CHARGED_OUT" -> EnumSet.of(TOO_MANY_ITEMS_CHARGED);
-      case "MAX_NUMBER_OF_OVERDUE_ITEMS" -> EnumSet.of(TOO_MANY_ITEMS_OVERDUE);
-      case "MAX_NUMBER_OF_OVERDUE_RECALLS",
-          "RECALL_OVERDUE_BY_MAX_NUMBER_OF_OVERDUE_DAYS" -> EnumSet.of(RECALL_OVERDUE);
-      case "MAX_NUMBER_OF_CLAIMS_RETURNED" -> EnumSet.of(TOO_MANY_CLAIMS_OF_ITEMS_RETURNED);
-      case "MAX_NUMBER_OF_LOST_ITEMS" -> EnumSet.of(TOO_MANY_ITEMS_LOST);
-      case "MAX_OUTSTANDING_FEE_FINE_BALANCE" ->
+    return switch (conditionId) {
+      case CONDITION_MAX_ITEMS_CHARGED_OUT -> EnumSet.of(TOO_MANY_ITEMS_CHARGED);
+      case CONDITION_MAX_OVERDUE_ITEMS -> EnumSet.of(TOO_MANY_ITEMS_OVERDUE);
+      case CONDITION_MAX_OVERDUE_RECALLS,
+          CONDITION_RECALL_OVERDUE_BY_MAX_DAYS -> EnumSet.of(RECALL_OVERDUE);
+      case CONDITION_MAX_LOST_ITEMS -> EnumSet.of(TOO_MANY_ITEMS_LOST);
+      case CONDITION_MAX_FEE_FINE_BALANCE ->
           EnumSet.of(EXCESSIVE_OUTSTANDING_FINES, EXCESSIVE_OUTSTANDING_FEES);
-      case "MAX_NUMBER_OF_ITEMS_BILLED" -> EnumSet.of(TOO_MANY_ITEMS_BILLED);
       default -> EnumSet.noneOf(PatronStatus.class);
     };
   }

--- a/src/test/java/org/folio/edge/sip2/api/PatronInformationIT.java
+++ b/src/test/java/org/folio/edge/sip2/api/PatronInformationIT.java
@@ -1,6 +1,8 @@
 package org.folio.edge.sip2.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.CHARGE_PRIVILEGES_DENIED;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.TOO_MANY_ITEMS_CHARGED;
 import static org.folio.edge.sip2.support.Sip2TestCommand.sip2Exchange;
 import static org.folio.edge.sip2.support.model.PatronInformationCommand.PatronInfoSummaryType.HOLD_ITEMS;
 
@@ -214,7 +216,7 @@ class PatronInformationIT extends AbstractErrorDetectionEnabledTest {
               var patronInfo = parseResponse(respMsg);
               assertThat(patronInfo.getValidPatron()).isTrue();
               assertThat(patronInfo.getPatronStatus())
-                  .isEqualTo(EnumSet.allOf(PatronStatus.class));
+                  .isEqualTo(EnumSet.of(CHARGE_PRIVILEGES_DENIED, TOO_MANY_ITEMS_CHARGED));
               assertThat(patronInfo.getScreenMessage())
                   .isEqualTo(List.of("Patron has too many items checked out"));
             }

--- a/src/test/java/org/folio/edge/sip2/api/PatronInformationIT.java
+++ b/src/test/java/org/folio/edge/sip2/api/PatronInformationIT.java
@@ -201,7 +201,7 @@ class PatronInformationIT extends AbstractErrorDetectionEnabledTest {
       "/wiremock/stubs/mod-fee-fines/200-get-feefines-empty.json",
       "/wiremock/stubs/mod-fee-fines/200-get-automated-patron-blocks-with-borrowing-block.json",
   })
-  void getPatronInformation_withAutomatedBorrowingBlock_allStatusFlagsSetAndMessageReturned()
+  void getPatronInformation_withAutomatedBorrowingBlock_chargePrivilegesAndItemsChargedFlagsSet()
       throws Throwable {
     executeInSession(
         successLoginExchange(),

--- a/src/test/java/org/folio/edge/sip2/api/PatronStatusIT.java
+++ b/src/test/java/org/folio/edge/sip2/api/PatronStatusIT.java
@@ -11,7 +11,6 @@ import static org.folio.edge.sip2.support.Sip2TestCommand.sip2Exchange;
 import java.util.EnumSet;
 import java.util.List;
 import org.folio.edge.sip2.api.support.AbstractErrorDetectionEnabledTest;
-import org.folio.edge.sip2.domain.messages.enumerations.PatronStatus;
 import org.folio.edge.sip2.domain.messages.responses.PatronStatusResponse;
 import org.folio.edge.sip2.support.Sip2Commands;
 import org.folio.edge.sip2.support.response.PatronStatusResponseParser;
@@ -100,7 +99,7 @@ class PatronStatusIT extends AbstractErrorDetectionEnabledTest {
       "/wiremock/stubs/mod-fee-fines/200-get-manualblocks.json",
       "/wiremock/stubs/mod-fee-fines/200-get-automated-patron-blocks-with-borrowing-block.json",
   })
-  void getPatronStatus_withAutomatedBorrowingBlock_allStatusFlagsSetAndMessageReturned()
+  void getPatronStatus_withAutomatedBorrowingBlock_chargePrivilegesAndItemsChargedFlagsSet()
       throws Throwable {
     executeInSession(
         successLoginExchange(),

--- a/src/test/java/org/folio/edge/sip2/api/PatronStatusIT.java
+++ b/src/test/java/org/folio/edge/sip2/api/PatronStatusIT.java
@@ -1,6 +1,11 @@
 package org.folio.edge.sip2.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.CHARGE_PRIVILEGES_DENIED;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.HOLD_PRIVILEGES_DENIED;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.RECALL_PRIVILEGES_DENIED;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.RENEWAL_PRIVILEGES_DENIED;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.TOO_MANY_ITEMS_CHARGED;
 import static org.folio.edge.sip2.support.Sip2TestCommand.sip2Exchange;
 
 import java.util.EnumSet;
@@ -75,7 +80,8 @@ class PatronStatusIT extends AbstractErrorDetectionEnabledTest {
               var response = parseResponse(respMsg);
               assertThat(response.getValidPatron()).isTrue();
               assertThat(response.getPatronStatus())
-                  .isEqualTo(EnumSet.allOf(PatronStatus.class));
+                  .isEqualTo(EnumSet.of(CHARGE_PRIVILEGES_DENIED, RENEWAL_PRIVILEGES_DENIED,
+                      RECALL_PRIVILEGES_DENIED, HOLD_PRIVILEGES_DENIED));
               assertThat(response.getScreenMessage())
                   .isEqualTo(List.of(
                       "Your account is blocked. Please contact the library."));
@@ -109,7 +115,7 @@ class PatronStatusIT extends AbstractErrorDetectionEnabledTest {
               var response = parseResponse(respMsg);
               assertThat(response.getValidPatron()).isTrue();
               assertThat(response.getPatronStatus())
-                  .isEqualTo(EnumSet.allOf(PatronStatus.class));
+                  .isEqualTo(EnumSet.of(CHARGE_PRIVILEGES_DENIED, TOO_MANY_ITEMS_CHARGED));
               assertThat(response.getScreenMessage())
                   .isEqualTo(List.of("Patron has too many items checked out"));
             }

--- a/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
@@ -6,9 +6,12 @@ import static org.folio.edge.sip2.api.support.TestUtils.getJsonFromFile;
 import static org.folio.edge.sip2.domain.messages.enumerations.Language.ENGLISH;
 import static org.folio.edge.sip2.domain.messages.enumerations.Language.UNKNOWN;
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.CHARGE_PRIVILEGES_DENIED;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.EXCESSIVE_OUTSTANDING_FEES;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.EXCESSIVE_OUTSTANDING_FINES;
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.HOLD_PRIVILEGES_DENIED;
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.RECALL_PRIVILEGES_DENIED;
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.RENEWAL_PRIVILEGES_DENIED;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.TOO_MANY_ITEMS_CHARGED;
 import static org.folio.edge.sip2.domain.messages.enumerations.Summary.RECALL_ITEMS;
 import static org.folio.edge.sip2.repositories.PatronRepository.MESSAGE_INVALID_PATRON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -2752,11 +2755,11 @@ public class PatronRepositoryTests {
     final JsonObject automatedBlocksResponse = new JsonObject()
         .put("automatedPatronBlocks", new JsonArray()
             .add(new JsonObject()
+                .put("patronBlockConditionId", "3d7c52dc-c732-4223-8bf8-e5917801386f")
                 .put("blockBorrowing", true)
                 .put("blockRenewals", true)
                 .put("blockRequests", true)
-                .put("message", "Patron has too many items checked out")))
-        .put("totalRecords", 1);
+                .put("message", "Patron has too many items checked out")));
 
     when(mockPasswordVerifier.verifyPatronPassword(anyString(), anyString(), any()))
         .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder()
@@ -2780,10 +2783,75 @@ public class PatronRepositoryTests {
           assertEquals(feeAmount.toString(), patronStatusResponse.getFeeAmount());
           assertEquals("Joe Zee Blow", patronStatusResponse.getPersonalName());
           assertEquals(EnumSet.of(CHARGE_PRIVILEGES_DENIED, RENEWAL_PRIVILEGES_DENIED,
-              RECALL_PRIVILEGES_DENIED, HOLD_PRIVILEGES_DENIED),
+              RECALL_PRIVILEGES_DENIED, HOLD_PRIVILEGES_DENIED, TOO_MANY_ITEMS_CHARGED),
               patronStatusResponse.getPatronStatus());
           assertEquals(Collections.singletonList("Patron has too many items checked out"),
               patronStatusResponse.getScreenMessage());
+          testContext.completeNow();
+        }))
+    );
+  }
+
+  @Test
+  void canPerformPatronStatusWithAutomatedBlockConditionFeeFineBalance(Vertx vertx,
+      VertxTestContext testContext,
+      @Mock PasswordVerifier mockPasswordVerifier,
+      @Mock FeeFinesRepository mockFeeFinesRepository,
+      @Mock CirculationRepository mockCirculationRepository,
+      @Mock UsersRepository mockUsersRepository) {
+    final String patronIdentifier = "1029384756";
+    final String patronPassword = "1234";
+    final String institutionId = "diku";
+    final String userId = "99a81cee-d439-42c8-9860-2bd1de881c4a";
+    final Clock clock = TestUtils.getUtcFixedClock();
+    final User user = new User.Builder()
+        .id(userId)
+        .barcode("2349871212")
+        .personal(new Personal.Builder().firstName("Joe").lastName("Blow").build())
+        .build();
+
+    final ExtendedUser extendedUser = new ExtendedUser();
+    extendedUser.setUser(user);
+    extendedUser.setPatronGroup("patrons", "The Library Patrons", "12335");
+
+    final PatronStatusRequest patronStatus = PatronStatusRequest.builder()
+        .patronIdentifier(patronIdentifier)
+        .patronPassword(patronPassword)
+        .institutionId(institutionId)
+        .transactionDate(OffsetDateTime.now())
+        .build();
+
+    // "Maximum outstanding fee/fine balance" seed condition maps to two SIP2 positions.
+    final JsonObject automatedBlocksResponse = new JsonObject()
+        .put("automatedPatronBlocks", new JsonArray()
+            .add(new JsonObject()
+                .put("patronBlockConditionId", "cf7a0d5f-a327-4ca1-aa9e-dc55ec006b8a")
+                .put("blockBorrowing", true)
+                .put("blockRenewals", false)
+                .put("blockRequests", false)
+                .put("message", "Patron owes too much")));
+
+    when(mockPasswordVerifier.verifyPatronPassword(anyString(), anyString(), any()))
+        .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder()
+            .extendedUser(extendedUser).build()));
+    when(mockFeeFinesRepository.getFeeAmountByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(new JsonObject().put("accounts", new JsonArray())));
+    when(mockFeeFinesRepository.getManualBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(new JsonObject()
+            .put("manualblocks", new JsonArray()).put("totalRecords", 0)));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(automatedBlocksResponse));
+
+    final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
+        mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
+    final SessionData sessionData = TestUtils.getMockedSessionData();
+
+    patronRepository.performPatronStatusCommand(patronStatus, sessionData).onComplete(
+        testContext.succeeding(patronStatusResponse -> testContext.verify(() -> {
+          assertNotNull(patronStatusResponse);
+          assertEquals(EnumSet.of(CHARGE_PRIVILEGES_DENIED,
+              EXCESSIVE_OUTSTANDING_FINES, EXCESSIVE_OUTSTANDING_FEES),
+              patronStatusResponse.getPatronStatus());
           testContext.completeNow();
         }))
     );
@@ -2949,7 +3017,6 @@ public class PatronRepositoryTests {
             .put("manualblocks", new JsonArray()).put("totalRecords", 0)));
     when(mockFeeFinesRepository.getAutomatedBlocksByUserId(eq(userId), any()))
         .thenReturn(Future.succeededFuture(new JsonObject()
-            .put("totalRecords", 1)
             .put("automatedPatronBlocks", new JsonArray().add(new JsonObject()
                 .put("blockBorrowing", false)
                 .put("blockRenewals", false)
@@ -2995,7 +3062,6 @@ public class PatronRepositoryTests {
         .thenReturn(Future.succeededFuture(getManualBlockJsonObject(false, true, false)));
     when(mockFeeFinesRepository.getAutomatedBlocksByUserId(eq(userId), any()))
         .thenReturn(Future.succeededFuture(new JsonObject()
-            .put("totalRecords", 1)
             .put("automatedPatronBlocks", new JsonArray().add(new JsonObject()
                 .put("blockBorrowing", false)
                 .put("blockRenewals", false)
@@ -3052,7 +3118,6 @@ public class PatronRepositoryTests {
     extendedUser.setPatronGroup("patrons", "The Library Patrons", "12335");
 
     final JsonObject automatedBlocksResponse = new JsonObject()
-        .put("totalRecords", 1)
         .put("automatedPatronBlocks", new JsonArray().add(new JsonObject()
             .put("blockBorrowing", true)
             .put("blockRenewals", true)

--- a/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
@@ -9,9 +9,12 @@ import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.CHAR
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.EXCESSIVE_OUTSTANDING_FEES;
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.EXCESSIVE_OUTSTANDING_FINES;
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.HOLD_PRIVILEGES_DENIED;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.RECALL_OVERDUE;
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.RECALL_PRIVILEGES_DENIED;
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.RENEWAL_PRIVILEGES_DENIED;
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.TOO_MANY_ITEMS_CHARGED;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.TOO_MANY_ITEMS_LOST;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.TOO_MANY_ITEMS_OVERDUE;
 import static org.folio.edge.sip2.domain.messages.enumerations.Summary.RECALL_ITEMS;
 import static org.folio.edge.sip2.repositories.PatronRepository.MESSAGE_INVALID_PATRON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -2711,7 +2714,7 @@ public class PatronRepositoryTests {
   }
 
   @Test
-  void canPerformPatronStatusWithAutomatedBlocks(Vertx vertx,
+  void canPerformPatronStatusWithAutomatedBlockAllChannelsAndConditionIdMapped(Vertx vertx,
       VertxTestContext testContext,
       @Mock PasswordVerifier mockPasswordVerifier,
       @Mock FeeFinesRepository mockFeeFinesRepository,
@@ -2948,6 +2951,84 @@ public class PatronRepositoryTests {
         PatronRepository.extractAutomatedBlockMessages(blocks));
   }
 
+  private static Stream<Arguments> provideAutomatedBlockConditions() {
+    return Stream.of(
+        // unknown condition id -> no informational flags
+        Arguments.of("00000000-0000-0000-0000-000000000000", EnumSet.noneOf(PatronStatus.class)),
+        // the six FOLIO mod-patron-blocks seed conditions
+        Arguments.of("3d7c52dc-c732-4223-8bf8-e5917801386f",
+            EnumSet.of(TOO_MANY_ITEMS_CHARGED)),
+        Arguments.of("584fbd4f-6a34-4730-a6ca-73a6a6a9d845",
+            EnumSet.of(TOO_MANY_ITEMS_OVERDUE)),
+        Arguments.of("e5b45031-a202-4abb-917b-e1df9346fe2c",
+            EnumSet.of(RECALL_OVERDUE)),
+        Arguments.of("08530ac4-07f2-48e6-9dda-a97bc2bf7053",
+            EnumSet.of(RECALL_OVERDUE)),
+        Arguments.of("72b67965-5b73-4840-bc0b-be8f3f6e047e",
+            EnumSet.of(TOO_MANY_ITEMS_LOST)),
+        Arguments.of("cf7a0d5f-a327-4ca1-aa9e-dc55ec006b8a",
+            EnumSet.of(EXCESSIVE_OUTSTANDING_FINES, EXCESSIVE_OUTSTANDING_FEES)));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideAutomatedBlockConditions")
+  void patronStatusMapsAutomatedBlockConditionToStatusFlags(String conditionId,
+      Set<PatronStatus> expectedPatronStatus, Vertx vertx, VertxTestContext testContext,
+      @Mock PasswordVerifier mockPasswordVerifier,
+      @Mock FeeFinesRepository mockFeeFinesRepository,
+      @Mock CirculationRepository mockCirculationRepository,
+      @Mock UsersRepository mockUsersRepository) {
+    final String patronIdentifier = "1029384756";
+    final String userId = "99a81cee-d439-42c8-9860-2bd1de881c4a";
+    final Clock clock = TestUtils.getUtcFixedClock();
+    final User user = new User.Builder()
+        .id(userId)
+        .barcode("2349871212")
+        .personal(new Personal.Builder().firstName("Joe").lastName("Blow").build())
+        .build();
+    final ExtendedUser extendedUser = new ExtendedUser();
+    extendedUser.setUser(user);
+    extendedUser.setPatronGroup("patrons", "The Library Patrons", "12335");
+
+    final PatronStatusRequest patronStatus = PatronStatusRequest.builder()
+        .patronIdentifier(patronIdentifier)
+        .patronPassword("1234")
+        .institutionId("diku")
+        .transactionDate(OffsetDateTime.now())
+        .build();
+
+    final JsonObject automatedBlocksResponse = new JsonObject()
+        .put("automatedPatronBlocks", new JsonArray().add(new JsonObject()
+            .put("patronBlockConditionId", conditionId)
+            .put("blockBorrowing", false)
+            .put("blockRenewals", false)
+            .put("blockRequests", false)
+            .put("message", "blocked")));
+
+    when(mockPasswordVerifier.verifyPatronPassword(anyString(), anyString(), any()))
+        .thenReturn(Future.succeededFuture(PatronPasswordVerificationRecords.builder()
+            .extendedUser(extendedUser).build()));
+    when(mockFeeFinesRepository.getFeeAmountByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(new JsonObject().put("accounts", new JsonArray())));
+    when(mockFeeFinesRepository.getManualBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(new JsonObject()
+            .put("manualblocks", new JsonArray()).put("totalRecords", 0)));
+    when(mockFeeFinesRepository.getAutomatedBlocksByUserId(eq(userId), any()))
+        .thenReturn(Future.succeededFuture(automatedBlocksResponse));
+
+    final PatronRepository patronRepository = new PatronRepository(mockUsersRepository,
+        mockCirculationRepository, mockFeeFinesRepository, mockPasswordVerifier, clock);
+    final SessionData sessionData = TestUtils.getMockedSessionData();
+
+    patronRepository.performPatronStatusCommand(patronStatus, sessionData).onComplete(
+        testContext.succeeding(patronStatusResponse -> testContext.verify(() -> {
+          assertNotNull(patronStatusResponse);
+          assertEquals(expectedPatronStatus, patronStatusResponse.getPatronStatus());
+          testContext.completeNow();
+        }))
+    );
+  }
+
   @Test
   void canPerformPatronStatusWithOnlyAutomatedRenewalBlock(Vertx vertx,
       VertxTestContext testContext,
@@ -3119,6 +3200,7 @@ public class PatronRepositoryTests {
 
     final JsonObject automatedBlocksResponse = new JsonObject()
         .put("automatedPatronBlocks", new JsonArray().add(new JsonObject()
+            .put("patronBlockConditionId", "3d7c52dc-c732-4223-8bf8-e5917801386f")
             .put("blockBorrowing", true)
             .put("blockRenewals", true)
             .put("blockRequests", true)
@@ -3160,7 +3242,7 @@ public class PatronRepositoryTests {
           assertNotNull(patronInformationResponse);
           assertTrue(patronInformationResponse.getValidPatron());
           assertEquals(EnumSet.of(CHARGE_PRIVILEGES_DENIED, RENEWAL_PRIVILEGES_DENIED,
-              RECALL_PRIVILEGES_DENIED, HOLD_PRIVILEGES_DENIED),
+              RECALL_PRIVILEGES_DENIED, HOLD_PRIVILEGES_DENIED, TOO_MANY_ITEMS_CHARGED),
               patronInformationResponse.getPatronStatus());
           assertEquals(Collections.singletonList("Patron has too many items checked out"),
               patronInformationResponse.getScreenMessage());

--- a/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
+++ b/src/test/java/org/folio/edge/sip2/repositories/PatronRepositoryTests.java
@@ -5,6 +5,7 @@ import static java.lang.Boolean.TRUE;
 import static org.folio.edge.sip2.api.support.TestUtils.getJsonFromFile;
 import static org.folio.edge.sip2.domain.messages.enumerations.Language.ENGLISH;
 import static org.folio.edge.sip2.domain.messages.enumerations.Language.UNKNOWN;
+import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.CHARGE_PRIVILEGES_DENIED;
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.HOLD_PRIVILEGES_DENIED;
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.RECALL_PRIVILEGES_DENIED;
 import static org.folio.edge.sip2.domain.messages.enumerations.PatronStatus.RENEWAL_PRIVILEGES_DENIED;
@@ -1275,7 +1276,9 @@ public class PatronRepositoryTests {
           assertEquals(true, patronStatusResponse.getValidPatron());
           assertEquals(feeAmount.toString(), patronStatusResponse.getFeeAmount());
           assertEquals("Joe Zee Blow", patronStatusResponse.getPersonalName());
-          assertEquals(EnumSet.allOf(PatronStatus.class), patronStatusResponse.getPatronStatus());
+          assertEquals(EnumSet.of(CHARGE_PRIVILEGES_DENIED, RENEWAL_PRIVILEGES_DENIED,
+              RECALL_PRIVILEGES_DENIED, HOLD_PRIVILEGES_DENIED),
+              patronStatusResponse.getPatronStatus());
           assertEquals(Collections.singletonList("Pay your fines!"),
               patronStatusResponse.getScreenMessage());
           testContext.completeNow();
@@ -2557,10 +2560,11 @@ public class PatronRepositoryTests {
   private static Stream<Arguments> provideManualBlocks() {
     return Stream.of(
         Arguments.of(getManualBlockJsonObject(true, true, true),
-            EnumSet.allOf(PatronStatus.class),
+            EnumSet.of(CHARGE_PRIVILEGES_DENIED, RENEWAL_PRIVILEGES_DENIED,
+                RECALL_PRIVILEGES_DENIED, HOLD_PRIVILEGES_DENIED),
             Collections.singletonList("Pay your fines!")),
         Arguments.of(getManualBlockJsonObject(true, true, false),
-            EnumSet.allOf(PatronStatus.class),
+            EnumSet.of(CHARGE_PRIVILEGES_DENIED, RENEWAL_PRIVILEGES_DENIED),
             Collections.singletonList("Pay your fines!")),
         Arguments.of(getManualBlockJsonObject(false, true, true),
             EnumSet.of(RENEWAL_PRIVILEGES_DENIED,
@@ -2568,10 +2572,11 @@ public class PatronRepositoryTests {
                 RECALL_PRIVILEGES_DENIED),
             Collections.singletonList("Pay your fines!")),
         Arguments.of(getManualBlockJsonObject(true, false, true),
-            EnumSet.allOf(PatronStatus.class),
+            EnumSet.of(CHARGE_PRIVILEGES_DENIED, RECALL_PRIVILEGES_DENIED,
+                HOLD_PRIVILEGES_DENIED),
             Collections.singletonList("Pay your fines!")),
         Arguments.of(getManualBlockJsonObject(true, false, false),
-            EnumSet.allOf(PatronStatus.class),
+            EnumSet.of(CHARGE_PRIVILEGES_DENIED),
             Collections.singletonList("Pay your fines!")),
         Arguments.of(getManualBlockJsonObject(false, true, false),
             EnumSet.of(RENEWAL_PRIVILEGES_DENIED),
@@ -2774,7 +2779,9 @@ public class PatronRepositoryTests {
           assertEquals(true, patronStatusResponse.getValidPatron());
           assertEquals(feeAmount.toString(), patronStatusResponse.getFeeAmount());
           assertEquals("Joe Zee Blow", patronStatusResponse.getPersonalName());
-          assertEquals(EnumSet.allOf(PatronStatus.class), patronStatusResponse.getPatronStatus());
+          assertEquals(EnumSet.of(CHARGE_PRIVILEGES_DENIED, RENEWAL_PRIVILEGES_DENIED,
+              RECALL_PRIVILEGES_DENIED, HOLD_PRIVILEGES_DENIED),
+              patronStatusResponse.getPatronStatus());
           assertEquals(Collections.singletonList("Patron has too many items checked out"),
               patronStatusResponse.getScreenMessage());
           testContext.completeNow();
@@ -3087,7 +3094,8 @@ public class PatronRepositoryTests {
         testContext.succeeding(patronInformationResponse -> testContext.verify(() -> {
           assertNotNull(patronInformationResponse);
           assertTrue(patronInformationResponse.getValidPatron());
-          assertEquals(EnumSet.allOf(PatronStatus.class),
+          assertEquals(EnumSet.of(CHARGE_PRIVILEGES_DENIED, RENEWAL_PRIVILEGES_DENIED,
+              RECALL_PRIVILEGES_DENIED, HOLD_PRIVILEGES_DENIED),
               patronInformationResponse.getPatronStatus());
           assertEquals(Collections.singletonList("Patron has too many items checked out"),
               patronInformationResponse.getScreenMessage());

--- a/src/test/resources/json/automated_patron_blocks_response.json
+++ b/src/test/resources/json/automated_patron_blocks_response.json
@@ -1,11 +1,9 @@
 {
   "automatedPatronBlocks" : [ {
-    "patronBlockConditionId" : "1a72f2de-5dd4-4543-a880-e0df97f9e9ad",
+    "patronBlockConditionId" : "3d7c52dc-c732-4223-8bf8-e5917801386f",
     "blockBorrowing" : true,
     "blockRenewals" : true,
     "blockRequests" : true,
-    "message" : "Patron has too many items checked out",
-    "code" : "MAX_NUMBER_OF_ITEMS_CHARGED_OUT",
-    "userId" : "a23eac4b-955e-451c-b4ff-6ec2f5e63e23"
+    "message" : "Patron has too many items checked out"
   } ]
 }

--- a/src/test/resources/wiremock/stubs/mod-fee-fines/200-get-automated-patron-blocks-with-borrowing-block.json
+++ b/src/test/resources/wiremock/stubs/mod-fee-fines/200-get-automated-patron-blocks-with-borrowing-block.json
@@ -17,13 +17,11 @@
     "jsonBody": {
       "automatedPatronBlocks": [
         {
-          "patronBlockConditionId": "1a72f2de-5dd4-4543-a880-e0df97f9e9ad",
+          "patronBlockConditionId": "3d7c52dc-c732-4223-8bf8-e5917801386f",
           "blockBorrowing": true,
           "blockRenewals": false,
           "blockRequests": false,
-          "message": "Patron has too many items checked out",
-          "code": "MAX_NUMBER_OF_ITEMS_CHARGED_OUT",
-          "userId": "bec20636-fb68-41fd-84ea-2cf910673599"
+          "message": "Patron has too many items checked out"
         }
       ]
     },


### PR DESCRIPTION
### Purpose
This is a follow-up PR on top of the existing SIP2-313 changes (PR #258 — automated patron blocks in the SIP2 patron status response). Those changes introduced the mapping and fixed the earlier EnumSet.allOf bug; this PR corrects a remaining production defect in that mapping.                                                                              
                                                                                                                                                                                    
The automated-block → SIP2 patron status mapping was keyed on a code field that does not exist in the FOLIO mod-patron-blocks contract. Verified against source (ramls/automated-patron-block.json has additionalProperties: false with only patronBlockConditionId, blockBorrowing, blockRenewals, blockRequests, message; runtime PatronBlocksService.createBlockForLimit sets exactly those 5 fields, never code). In production the informational positions (5, 6, 9, 10, 11, 12) were therefore never set — the existing tests passed only because fixtures carried a fabricated code.

### Approach
  - Re-key the mapping from the non-existent code to patronBlockConditionId, using the 6 stable seed-condition UUIDs from mod-patron-blocks (held as named constants; it's the only identifier the API returns, so no extra call needed).                                                                                                                             
  - Mapping (positions verified against the 14-char SIP2 field):                                                                                                                    
    - max items charged out → TOO_MANY_ITEMS_CHARGED                                                                                                                                
    - max overdue items → TOO_MANY_ITEMS_OVERDUE                                                                                                                                    
    - max overdue recalls / recall overdue by max days → RECALL_OVERDUE                                                                                                             
    - max lost items → TOO_MANY_ITEMS_LOST                                                                                                                                          
    - max fee/fine balance → EXCESSIVE_OUTSTANDING_FINES + EXCESSIVE_OUTSTANDING_FEES (FOLIO combines both)                                                                         
  - Removed two unreachable branches (claims returned, items billed) — FOLIO has no matching condition; documented that SIP2 positions 7/8/13 have no automated-block source.       
  - Aligned fixtures with the earlier PR to the real schema: dropped code/userId/spurious totalRecords, used real seed UUIDs.                                                       
  - Tests: parameterized coverage of every mapping branch (including unknown-id → empty), driven through the public performPatronStatusCommand — no production visibility relaxed.  


### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[SIP2-313](https://folio-org.atlassian.net/browse/SIP2-313)
_List any Jira issues related to this pull request._

### Learning and Resources (if applicable)
_Discuss any research conducted during the development of this pull request. Include links to relevant blog posts, patterns, libraries, or addons that were used to solve the problem._

### Screenshots (if applicable)
_If this pull request involves any visual changes or new features, consider including screenshots or GIFs to illustrate the changes._
